### PR TITLE
feat(cep): persist generation prompt alongside QA pairs

### DIFF
--- a/src/gtranscriber/core/cep/bloom_scaffolding.py
+++ b/src/gtranscriber/core/cep/bloom_scaffolding.py
@@ -219,7 +219,7 @@ class BloomScaffoldingGenerator:
                 max_tokens=self.qa_config.max_tokens,
             )
 
-            pairs = self._parse_response(response, context, bloom_level)
+            pairs = self._parse_response(response, context, bloom_level, generation_prompt=prompt)
             return pairs
 
         except Exception as e:
@@ -295,6 +295,8 @@ class BloomScaffoldingGenerator:
         response: str,
         context: str,
         bloom_level: str,
+        *,
+        generation_prompt: str | None = None,
     ) -> list[QAPairCEP]:
         """Parse LLM response into QAPairCEP objects.
 
@@ -302,6 +304,7 @@ class BloomScaffoldingGenerator:
             response: Raw LLM response text.
             context: Source context for validation.
             bloom_level: Bloom level used for generation.
+            generation_prompt: LLM prompt used to generate the response.
 
         Returns:
             List of QAPairCEP objects.
@@ -374,6 +377,7 @@ class BloomScaffoldingGenerator:
                     is_multi_hop=is_multi_hop,
                     hop_count=hop_count,
                     tacit_inference=tacit_inference,
+                    generation_prompt=generation_prompt,
                 )
                 pairs.append(pair)
             except Exception as e:

--- a/src/gtranscriber/core/cep/reasoning.py
+++ b/src/gtranscriber/core/cep/reasoning.py
@@ -142,6 +142,7 @@ class ReasoningEnricher:
                 is_multi_hop=enriched_data.get("is_multi_hop", qa_pair.is_multi_hop),
                 hop_count=enriched_data.get("hop_count") or qa_pair.hop_count,
                 tacit_inference=enriched_data.get("tacit_inference") or qa_pair.tacit_inference,
+                generation_prompt=qa_pair.generation_prompt,
             )
 
         except Exception as e:

--- a/src/gtranscriber/core/cep/validator.py
+++ b/src/gtranscriber/core/cep/validator.py
@@ -123,6 +123,7 @@ class QAValidator:
                 is_multi_hop=qa_pair.is_multi_hop,
                 hop_count=qa_pair.hop_count,
                 tacit_inference=qa_pair.tacit_inference,
+                generation_prompt=qa_pair.generation_prompt,
                 validation=scores,
                 is_valid=is_valid,
             )
@@ -143,6 +144,7 @@ class QAValidator:
                 is_multi_hop=qa_pair.is_multi_hop,
                 hop_count=qa_pair.hop_count,
                 tacit_inference=qa_pair.tacit_inference,
+                generation_prompt=qa_pair.generation_prompt,
                 validation=None,
                 is_valid=True,  # Default to valid if validation fails
             )

--- a/src/gtranscriber/schemas.py
+++ b/src/gtranscriber/schemas.py
@@ -203,6 +203,9 @@ class QAPairCEP(QAPair):
     tacit_inference: str | None = Field(
         None, description="Explanation of implicit/tacit knowledge used in the answer"
     )
+    generation_prompt: str | None = Field(
+        None, description="LLM prompt used to generate this QA pair"
+    )
 
     @model_validator(mode="after")
     def validate_multi_hop(self) -> Self:

--- a/tests/core/cep/test_bloom_scaffolding.py
+++ b/tests/core/cep/test_bloom_scaffolding.py
@@ -792,6 +792,77 @@ class TestBloomScaffoldingGenerator:
         assert "Riverine communities." in result
         assert result.startswith("1.")
 
+    def test_parse_response_threads_generation_prompt(
+        self,
+        mock_llm_client: Any,
+        qa_config: QAConfig,
+        cep_config: CEPConfig,
+    ) -> None:
+        """Test that _parse_response threads generation_prompt to pairs."""
+        generator = BloomScaffoldingGenerator(
+            llm_client=mock_llm_client,
+            qa_config=qa_config,
+            cep_config=cep_config,
+        )
+
+        response = json.dumps([{"question": "Q?", "answer": "A", "confidence": 0.9}])
+
+        pairs = generator._parse_response(
+            response, "Context.", "remember", generation_prompt="The prompt"
+        )
+
+        assert len(pairs) == 1
+        assert pairs[0].generation_prompt == "The prompt"
+
+    def test_parse_response_defaults_generation_prompt_to_none(
+        self,
+        mock_llm_client: Any,
+        qa_config: QAConfig,
+        cep_config: CEPConfig,
+    ) -> None:
+        """Test that _parse_response defaults generation_prompt to None."""
+        generator = BloomScaffoldingGenerator(
+            llm_client=mock_llm_client,
+            qa_config=qa_config,
+            cep_config=cep_config,
+        )
+
+        response = json.dumps([{"question": "Q?", "answer": "A", "confidence": 0.9}])
+
+        pairs = generator._parse_response(response, "Context.", "remember")
+
+        assert len(pairs) == 1
+        assert pairs[0].generation_prompt is None
+
+    def test_generate_sets_generation_prompt(
+        self,
+        mock_llm_client: Any,
+        qa_config: QAConfig,
+    ) -> None:
+        """Test that generate() produces pairs with non-None generation_prompt."""
+        cep_config = CEPConfig(
+            bloom_levels=["remember"],
+            bloom_distribution={"remember": 1.0},
+            language="pt",
+        )
+
+        mock_llm_client.generate.return_value = json.dumps(
+            [{"question": "Q?", "answer": "A.", "confidence": 0.9}]
+        )
+
+        generator = BloomScaffoldingGenerator(
+            llm_client=mock_llm_client,
+            qa_config=qa_config,
+            cep_config=cep_config,
+        )
+
+        pairs = generator.generate("Context text.", num_questions=1)
+
+        assert len(pairs) >= 1
+        for pair in pairs:
+            assert pair.generation_prompt is not None
+            assert len(pair.generation_prompt) > 0
+
     def test_format_prior_pairs_respects_max_limit(
         self,
         mock_llm_client: Any,

--- a/tests/core/cep/test_cep_generator.py
+++ b/tests/core/cep/test_cep_generator.py
@@ -420,6 +420,54 @@ class TestCEPQAGenerator:
             assert "context" in data
 
 
+class TestCEPGenerationPromptIntegration:
+    """Tests for generation_prompt propagation through the full CEP pipeline."""
+
+    def test_pipeline_produces_non_none_generation_prompt(
+        self,
+        mock_llm_client: Any,
+        qa_config: QAConfig,
+        cep_config: CEPConfig,
+        sample_transcription: EnrichedRecord,
+    ) -> None:
+        """Test that full pipeline produces pairs with non-None generation_prompt."""
+        generator = CEPQAGenerator(
+            llm_client=mock_llm_client,
+            qa_config=qa_config,
+            cep_config=cep_config,
+        )
+
+        result = generator.generate_qa_pairs(sample_transcription)
+
+        assert len(result.qa_pairs) > 0
+        for pair in result.qa_pairs:
+            assert pair.generation_prompt is not None
+            assert len(pair.generation_prompt) > 0
+
+    def test_jsonl_export_includes_generation_prompt(
+        self,
+        mock_llm_client: Any,
+        qa_config: QAConfig,
+        cep_config: CEPConfig,
+        sample_transcription: EnrichedRecord,
+    ) -> None:
+        """Test that JSONL export includes generation_prompt field."""
+        generator = CEPQAGenerator(
+            llm_client=mock_llm_client,
+            qa_config=qa_config,
+            cep_config=cep_config,
+        )
+
+        result = generator.generate_qa_pairs(sample_transcription)
+        jsonl = result.to_jsonl()
+
+        lines = [line for line in jsonl.strip().split("\n") if line]
+        for line in lines:
+            data = json.loads(line)
+            assert "generation_prompt" in data
+            assert data["generation_prompt"] is not None
+
+
 class TestQARecordCEP:
     """Tests for QARecordCEP schema."""
 

--- a/tests/core/cep/test_reasoning.py
+++ b/tests/core/cep/test_reasoning.py
@@ -360,6 +360,40 @@ class TestReasoningEnricher:
         assert results[0].reasoning_trace == "Trace"
         assert results[1].reasoning_trace is None
 
+    def test_enrich_preserves_generation_prompt(
+        self,
+        mock_llm_client: Any,
+        cep_config: CEPConfig,
+    ) -> None:
+        """Test that generation_prompt is preserved through enrich()."""
+        pair = QAPairCEP(
+            question="Por que?",
+            answer="Porque sim.",
+            context="Contexto.",
+            question_type="conceptual",
+            confidence=0.9,
+            bloom_level="analyze",
+            generation_prompt="Original prompt",
+        )
+
+        mock_llm_client.generate.return_value = json.dumps(
+            {
+                "reasoning_trace": "A → B",
+                "is_multi_hop": False,
+                "hop_count": None,
+                "tacit_inference": None,
+            }
+        )
+
+        enricher = ReasoningEnricher(
+            llm_client=mock_llm_client,
+            cep_config=cep_config,
+        )
+
+        result = enricher.enrich(pair, "context")
+
+        assert result.generation_prompt == "Original prompt"
+
     def test_enrich_handles_llm_error(
         self,
         mock_llm_client: Any,

--- a/tests/core/cep/test_validator.py
+++ b/tests/core/cep/test_validator.py
@@ -243,6 +243,66 @@ class TestQAValidator:
         assert result.validation is None
         assert result.is_valid is True  # Default to valid when validation fails
 
+    def test_validate_preserves_generation_prompt_success(
+        self,
+        mock_llm_client: Any,
+        cep_config: CEPConfig,
+    ) -> None:
+        """Test that generation_prompt is preserved through validate() success path."""
+        pair = QAPairCEP(
+            question="Q?",
+            answer="A.",
+            context="Context.",
+            question_type="conceptual",
+            confidence=0.9,
+            bloom_level="analyze",
+            generation_prompt="The original prompt",
+        )
+
+        mock_llm_client.generate.return_value = json.dumps(
+            {
+                "faithfulness": 0.9,
+                "bloom_calibration": 0.8,
+                "informativeness": 0.7,
+            }
+        )
+
+        validator = QAValidator(
+            validator_client=mock_llm_client,
+            cep_config=cep_config,
+        )
+
+        result = validator.validate(pair, "context")
+
+        assert result.generation_prompt == "The original prompt"
+
+    def test_validate_preserves_generation_prompt_error(
+        self,
+        mock_llm_client: Any,
+        cep_config: CEPConfig,
+    ) -> None:
+        """Test that generation_prompt is preserved through validate() error path."""
+        pair = QAPairCEP(
+            question="Q?",
+            answer="A.",
+            context="Context.",
+            question_type="conceptual",
+            confidence=0.9,
+            bloom_level="analyze",
+            generation_prompt="The original prompt",
+        )
+
+        mock_llm_client.generate.side_effect = Exception("LLM error")
+
+        validator = QAValidator(
+            validator_client=mock_llm_client,
+            cep_config=cep_config,
+        )
+
+        result = validator.validate(pair, "context")
+
+        assert result.generation_prompt == "The original prompt"
+
     def test_validate_clamps_scores(
         self,
         mock_llm_client: Any,

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -17,6 +17,8 @@ from gtranscriber.schemas import (
     InputRecord,
     KGMetadata,
     QAPair,
+    QAPairCEP,
+    QAPairValidated,
     RelationMetricsResult,
     SemanticQualityResult,
     TranscriptionSegment,
@@ -280,6 +282,79 @@ class TestQAPair:
                 end_time=5.0,
             )
         assert "start_time must be less than end_time" in str(exc_info.value)
+
+
+class TestQAPairCEPGenerationPrompt:
+    """Tests for QAPairCEP.generation_prompt field."""
+
+    def test_defaults_to_none(self) -> None:
+        """Test that generation_prompt defaults to None."""
+        pair = QAPairCEP(
+            question="Q?",
+            answer="A",
+            context="C",
+            question_type="factual",
+            confidence=0.9,
+            bloom_level="remember",
+        )
+        assert pair.generation_prompt is None
+
+    def test_accepts_string(self) -> None:
+        """Test that generation_prompt accepts a string value."""
+        pair = QAPairCEP(
+            question="Q?",
+            answer="A",
+            context="C",
+            question_type="factual",
+            confidence=0.9,
+            bloom_level="remember",
+            generation_prompt="Generate a question about...",
+        )
+        assert pair.generation_prompt == "Generate a question about..."
+
+    def test_inherited_by_qa_pair_validated(self) -> None:
+        """Test that QAPairValidated inherits generation_prompt."""
+        pair = QAPairValidated(
+            question="Q?",
+            answer="A",
+            context="C",
+            question_type="factual",
+            confidence=0.9,
+            bloom_level="remember",
+            generation_prompt="The prompt",
+            validation=None,
+            is_valid=True,
+        )
+        assert pair.generation_prompt == "The prompt"
+
+    def test_included_in_serialization(self) -> None:
+        """Test that generation_prompt is included in JSON serialization."""
+        pair = QAPairCEP(
+            question="Q?",
+            answer="A",
+            context="C",
+            question_type="factual",
+            confidence=0.9,
+            bloom_level="remember",
+            generation_prompt="My prompt",
+        )
+        data = pair.model_dump()
+        assert "generation_prompt" in data
+        assert data["generation_prompt"] == "My prompt"
+
+    def test_none_included_in_serialization(self) -> None:
+        """Test that None generation_prompt is included in JSON serialization."""
+        pair = QAPairCEP(
+            question="Q?",
+            answer="A",
+            context="C",
+            question_type="factual",
+            confidence=0.9,
+            bloom_level="remember",
+        )
+        data = pair.model_dump()
+        assert "generation_prompt" in data
+        assert data["generation_prompt"] is None
 
 
 class TestKGMetadata:


### PR DESCRIPTION
Save the LLM prompt used to generate each QA pair for research reproducibility.

- Add `generation_prompt` field to `QAPairCEP` (defaults to None for backward compatibility)
- Thread prompt from `_build_prompt()` through `_parse_response()` to each pair in bloom_scaffolding
- Preserve field through reasoning enrichment and validator pipelines
- Add tests for schema, bloom scaffolding, reasoning, validator, and full pipeline integration