### PR TITLE
fix(report): remove redundant Pipeline filter from filter bar

### DIFF
--- a/src/gtranscriber/core/report/templates/_filter_engine.js
+++ b/src/gtranscriber/core/report/templates/_filter_engine.js
@@ -124,8 +124,6 @@
     sel.onchange = function () {
       setActiveRun(sel.value);
     };
-    // Also populate pipeline filter
-    populateSelect("filter-pipeline", runs.map(function (r) { return r.pipeline_id; }));
   }
 
   async function setActiveRun(pipelineId) {
@@ -226,7 +224,7 @@
     if (search) search.addEventListener("input", applyAndUpdate);
 
     // Select change handlers
-    ["filter-pipeline", "filter-location", "filter-participant"].forEach(
+    ["filter-location", "filter-participant"].forEach(
       function (id) {
         var el = document.getElementById(id);
         if (el) el.addEventListener("change", applyAndUpdate);
@@ -237,7 +235,7 @@
     var resetBtn = document.getElementById("btn-reset-filters");
     if (resetBtn) {
       resetBtn.onclick = function () {
-        ["filter-pipeline", "filter-location", "filter-participant"].forEach(
+        ["filter-location", "filter-participant"].forEach(
           function (id) {
             var el = document.getElementById(id);
             if (el) {
@@ -284,7 +282,6 @@
   function getActiveFilters() {
     var filters = {};
 
-    filters.pipelines = getSelectedValues("filter-pipeline");
     filters.locations = getSelectedValues("filter-location");
     filters.participants = getSelectedValues("filter-participant");
 
@@ -321,11 +318,6 @@
   function applyFilters(data, filters) {
     var qa = data.qa_pairs.filter(function (q) {
       if (
-        filters.pipelines.length &&
-        filters.pipelines.indexOf(q.pipeline_id) === -1
-      )
-        return false;
-      if (
         filters.locations.length &&
         (!q.location || filters.locations.indexOf(q.location) === -1)
       )
@@ -357,11 +349,6 @@
 
     var trans = data.transcriptions.filter(function (t) {
       if (
-        filters.pipelines.length &&
-        filters.pipelines.indexOf(t.pipeline_id) === -1
-      )
-        return false;
-      if (
         filters.locations.length &&
         (!t.location || filters.locations.indexOf(t.location) === -1)
       )
@@ -381,14 +368,7 @@
       return true;
     });
 
-    var runs = data.runs.filter(function (r) {
-      if (
-        filters.pipelines.length &&
-        filters.pipelines.indexOf(r.pipeline_id) === -1
-      )
-        return false;
-      return true;
-    });
+    var runs = data.runs;
 
     return { qa_pairs: qa, transcriptions: trans, runs: runs };
   }

--- a/src/gtranscriber/core/report/templates/report.html.j2
+++ b/src/gtranscriber/core/report/templates/report.html.j2
@@ -31,10 +31,6 @@
     <!-- Global Filter Bar -->
     <div id="filter-bar">
         <div class="filter-group">
-            <label for="filter-pipeline">Pipeline</label>
-            <select id="filter-pipeline" multiple></select>
-        </div>
-        <div class="filter-group">
             <label for="filter-location">Location</label>
             <select id="filter-location" multiple></select>
         </div>


### PR DESCRIPTION
## Summary

- Remove the `#filter-pipeline` multi-select from the report filter bar, its populate logic, event listeners, reset handler, and `applyFilters()` conditions
- The Pipeline filter was redundant with the Experiment run selector (`#run-selector`), which already scopes all loaded data to a single pipeline run via `setActiveRun()`

Closes #58

## Files Changed

- `src/gtranscriber/core/report/templates/report.html.j2` — removed the filter-group div
- `src/gtranscriber/core/report/templates/_filter_engine.js` — removed populate call, event wiring, reset logic, filter state, and filter conditions

## Test Plan

- [x] Open the report dashboard and verify the filter bar no longer shows a "Pipeline" dropdown
- [x] Verify Location, Participant, and other filters still work correctly
- [x] Verify the Reset button clears all remaining filters
- [x] Verify switching experiments via the run selector still loads data correctly