### PR TITLE
feat(kg): add resumable concept generation and fix language bug

### DIFF
--- a/scripts/slurm/kg/kg_common.sh
+++ b/scripts/slurm/kg/kg_common.sh
@@ -110,7 +110,12 @@ docker image prune -af 2>/dev/null || true
 docker volume prune -f 2>/dev/null || true
 
 echo ""
-echo "Cleaning up unused Ollama models to free disk space..."
+echo "Cleaning up partial Ollama downloads and unused models..."
+# Remove partial/interrupted model downloads (blobs/sha256-*-partial)
+find "$OLLAMA_MODELS_DIR" -name "*-partial" -delete 2>/dev/null || true
+# Remove orphaned temp files left by interrupted pulls
+find "$OLLAMA_MODELS_DIR" -name "*.tmp" -delete 2>/dev/null || true
+
 docker compose -f "$COMPOSE_FILE" --profile "$DOCKER_PROFILE" up -d "$OLLAMA_SERVICE" 2>/dev/null || true
 OLLAMA_UP=false
 for i in {1..30}; do
@@ -134,6 +139,18 @@ if [ "$OLLAMA_UP" = true ]; then
             docker compose -f "$COMPOSE_FILE" exec -T "$OLLAMA_SERVICE" ollama rm "$model" 2>/dev/null || true
         fi
     done
+    docker compose -f "$COMPOSE_FILE" --profile "$DOCKER_PROFILE" down 2>/dev/null || true
+fi
+
+# Fail fast if disk space is critically low (need ~15 GB for build + model)
+MIN_DISK_GB=${MIN_DISK_GB:-15}
+AVAIL_KB=$(df --output=avail "$PROJECT_DIR" 2>/dev/null | tail -1 | tr -d ' ')
+AVAIL_GB=$((AVAIL_KB / 1024 / 1024))
+echo "Available disk space: ${AVAIL_GB} GB (minimum: ${MIN_DISK_GB} GB)"
+if [ "$AVAIL_GB" -lt "$MIN_DISK_GB" ]; then
+    echo "ERROR: Not enough disk space (${AVAIL_GB} GB < ${MIN_DISK_GB} GB). Aborting."
+    echo "Tip: manually run 'docker system prune -af --volumes' on the node."
+    exit 1
 fi
 
 echo ""

--- a/scripts/slurm/kg/kg_common.sh
+++ b/scripts/slurm/kg/kg_common.sh
@@ -104,10 +104,9 @@ echo "Cleaning up any orphan containers from previous runs..."
 docker compose -f "$COMPOSE_FILE" --profile "$DOCKER_PROFILE" down --remove-orphans 2>/dev/null || true
 
 echo ""
-echo "Pruning Docker build cache, unused images, and volumes to free disk space..."
+echo "Pruning all unused Docker data (images, containers, volumes, build cache)..."
+docker system prune -af --volumes 2>/dev/null || true
 docker builder prune -af 2>/dev/null || true
-docker image prune -af 2>/dev/null || true
-docker volume prune -f 2>/dev/null || true
 
 echo ""
 echo "Cleaning up partial Ollama downloads and unused models..."
@@ -143,12 +142,15 @@ if [ "$OLLAMA_UP" = true ]; then
 fi
 
 # Fail fast if disk space is critically low (need ~15 GB for build + model)
+# Check Docker's storage partition, not the project directory
 MIN_DISK_GB=${MIN_DISK_GB:-15}
-AVAIL_KB=$(df --output=avail "$PROJECT_DIR" 2>/dev/null | tail -1 | tr -d ' ')
+DOCKER_ROOT=$(docker info --format '{{.DockerRootDir}}' 2>/dev/null || echo "/var/lib/docker")
+AVAIL_KB=$(df --output=avail "$DOCKER_ROOT" 2>/dev/null | tail -1 | tr -d ' ')
 AVAIL_GB=$((AVAIL_KB / 1024 / 1024))
+echo "Docker storage: $DOCKER_ROOT"
 echo "Available disk space: ${AVAIL_GB} GB (minimum: ${MIN_DISK_GB} GB)"
 if [ "$AVAIL_GB" -lt "$MIN_DISK_GB" ]; then
-    echo "ERROR: Not enough disk space (${AVAIL_GB} GB < ${MIN_DISK_GB} GB). Aborting."
+    echo "ERROR: Not enough disk space on Docker partition (${AVAIL_GB} GB < ${MIN_DISK_GB} GB). Aborting."
     echo "Tip: manually run 'docker system prune -af --volumes' on the node."
     exit 1
 fi

--- a/src/arandu/kg/atlas_backend.py
+++ b/src/arandu/kg/atlas_backend.py
@@ -208,10 +208,11 @@ class AtlasRagConstructor:
         # Step 3: Create LLM generator using unified LLMClient
         if self._llm_client is None:
             self._llm_client = self._build_llm_client()
+        generation_config = self._build_generation_config()
         model = LLMGenerator(
             self._llm_client.client,
             self._config.model_id,
-            temperature=self._config.temperature,
+            default_config=generation_config,
         )
 
         # Step 4: Detect resume offset and build ProcessingConfig
@@ -443,6 +444,19 @@ class AtlasRagConstructor:
             model_id=self._config.model_id,
             base_url=self._config.base_url
             or (self._config.ollama_url if self._config.provider == "ollama" else None),
+        )
+
+    def _build_generation_config(self) -> Any:
+        """Build an atlas-rag ``GenerationConfig`` from KGConfig settings.
+
+        Returns:
+            A ``GenerationConfig`` instance with temperature from KGConfig.
+        """
+        from atlas_rag.llm_generator.generation_config import GenerationConfig
+
+        return GenerationConfig(
+            temperature=self._config.temperature,
+            max_tokens=self._opts["max_new_tokens"],
         )
 
     def _build_processing_config(

--- a/src/arandu/kg/atlas_backend.py
+++ b/src/arandu/kg/atlas_backend.py
@@ -390,10 +390,14 @@ class AtlasRagConstructor:
                 last_lines = [ln for ln in last_file.read_text().strip().split("\n") if ln.strip()]
                 records_in_previous = total_records - len(last_lines)
                 keep = expected_records - records_in_previous
-                last_file.write_text("\n".join(last_lines[:keep]) + "\n")
 
-                trimmed = len(last_lines) - keep
-                logger.info("Trimmed %d partial records from %s", trimmed, last_file)
+                if keep <= 0:
+                    logger.info("Removing fully-partial extraction file %s", last_file)
+                    last_file.unlink()
+                else:
+                    last_file.write_text("\n".join(last_lines[:keep]) + "\n")
+                    trimmed = len(last_lines) - keep
+                    logger.info("Trimmed %d partial records from %s", trimmed, last_file)
 
         if completed_batches > 0:
             logger.info(

--- a/src/arandu/kg/atlas_backend.py
+++ b/src/arandu/kg/atlas_backend.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import csv
 import json
 import logging
+import shutil
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -599,8 +600,7 @@ class AtlasRagConstructor:
 
         # Step 5: Backup input CSV
         logger.info("Backing up input CSV: %s -> %s", missing_csv, backup_file)
-        missing_csv_content = missing_csv.read_text()
-        backup_file.write_text(missing_csv_content)
+        shutil.copy2(missing_csv, backup_file)
 
         # Step 6: Trim input CSV to exclude completed nodes
         remaining = self._trim_input_csv(missing_csv, completed_nodes)
@@ -611,6 +611,10 @@ class AtlasRagConstructor:
             self._restore_and_finalize(
                 missing_csv, backup_file, accumulator, shard_file, concepts_dir
             )
+            # Ensure concept_shard_0.csv exists so downstream create_concept_csv()
+            # has a valid input even when there were zero remaining nodes.
+            if not shard_file.exists():
+                shard_file.write_text("")
             return
 
         # Step 8: Run concept generation
@@ -654,7 +658,9 @@ class AtlasRagConstructor:
                 for row in reader:
                     if len(row) == 3 and all(cell.strip() for cell in row):
                         if row[2].strip().lower() in self._VALID_NODE_TYPES:
-                            valid.append([cell.strip() for cell in row])
+                            stripped = [cell.strip() for cell in row]
+                            stripped[2] = stripped[2].lower()
+                            valid.append(stripped)
                         else:
                             logger.debug("Dropping row with invalid node_type: %s", row)
                     else:

--- a/src/arandu/kg/atlas_backend.py
+++ b/src/arandu/kg/atlas_backend.py
@@ -7,6 +7,7 @@ is only required when the ``atlas`` backend is actually selected.
 
 from __future__ import annotations
 
+import csv
 import json
 import logging
 from pathlib import Path
@@ -223,7 +224,7 @@ class AtlasRagConstructor:
 
         # Step 5: Run atlas-rag extraction pipeline
         extractor = KnowledgeGraphExtractor(model, processing_config)
-        self._run_pipeline(extractor)
+        self._run_pipeline(extractor, output_dir)
 
         # Step 6: Load graph and build result
         return self._build_result(records, output_dir)
@@ -482,7 +483,7 @@ class AtlasRagConstructor:
             resume_from=resume_from,
         )
 
-    def _run_pipeline(self, extractor: Any) -> None:
+    def _run_pipeline(self, extractor: Any, output_dir: Path) -> None:
         """Run the atlas-rag extraction pipeline steps.
 
         Temporarily replaces atlas-rag's ``DatasetProcessor`` with a subclass
@@ -491,6 +492,7 @@ class AtlasRagConstructor:
 
         Args:
             extractor: A ``KnowledgeGraphExtractor`` instance.
+            output_dir: Pipeline output directory (parent of ``atlas_output``).
         """
         from atlas_rag.kg_construction import triple_extraction
 
@@ -508,16 +510,258 @@ class AtlasRagConstructor:
         extractor.convert_json_to_csv()
 
         if self._opts["include_concept"]:
-            logger.info("Generating concept CSV (temporary)...")
-            extractor.generate_concept_csv_temp(
-                batch_size=self._opts["batch_size_concept"],
-            )
-            logger.info("Creating final concept CSV...")
+            self._run_concept_generation_with_resume(extractor, output_dir)
             extractor.create_concept_csv()
 
         logger.info("Converting to GraphML...")
         extractor.convert_to_graphml()
         logger.info("Atlas-rag pipeline completed")
+
+    # ------------------------------------------------------------------
+    # Resumable concept generation
+    # ------------------------------------------------------------------
+
+    _VALID_NODE_TYPES = frozenset({"event", "entity", "relation"})
+
+    def _run_concept_generation_with_resume(
+        self,
+        extractor: Any,
+        output_dir: Path,
+    ) -> None:
+        """Run concept generation with resume support.
+
+        Wraps ``extractor.generate_concept_csv_temp()`` so that progress
+        survives interruptions (e.g. SLURM timeouts).  A cumulative
+        ``concept_completed.csv`` file grows across failures.  On each
+        resume, already-conceptualized nodes are excluded from the input.
+
+        Args:
+            extractor: A ``KnowledgeGraphExtractor`` instance.
+            output_dir: Pipeline output directory (parent of ``atlas_output``).
+
+        Raises:
+            FileNotFoundError: If the missing_concepts CSV does not exist.
+        """
+        atlas_output = output_dir / "atlas_output"
+        concepts_dir = atlas_output / "concepts"
+        triples_dir = atlas_output / "triples_csv"
+
+        # Step 0: Locate missing_concepts CSV (input)
+        missing_csvs = sorted(triples_dir.glob("missing_concepts*_from_json.csv"))
+        if not missing_csvs:
+            raise FileNotFoundError(
+                f"No missing_concepts CSV found in {triples_dir}. "
+                "Triple extraction + convert_json_to_csv must run first."
+            )
+        missing_csv = missing_csvs[0]
+
+        concepts_dir.mkdir(parents=True, exist_ok=True)
+        shard_file = concepts_dir / "concept_shard_0.csv"
+        accumulator = concepts_dir / "concept_completed.csv"
+        backup_file = missing_csv.with_suffix(missing_csv.suffix + ".bak")
+
+        # Step 2: Restore backup if dirty state from previous crash
+        if backup_file.exists():
+            logger.info("Restoring input CSV from backup: %s", backup_file)
+            backup_file.replace(missing_csv)
+
+        # Step 3: Absorb leftover shard from interrupted run
+        if shard_file.exists():
+            valid_rows = self._read_valid_concept_rows(shard_file)
+            if valid_rows:
+                self._append_to_accumulator(accumulator, valid_rows)
+                logger.info(
+                    "Absorbed %d rows from interrupted shard into accumulator",
+                    len(valid_rows),
+                )
+            shard_file.unlink()
+
+        # Step 4: Read completed node names
+        completed_nodes = self._read_completed_nodes(accumulator)
+
+        # Step 5: Backup input CSV
+        logger.info("Backing up input CSV: %s -> %s", missing_csv, backup_file)
+        missing_csv_content = missing_csv.read_text()
+        backup_file.write_text(missing_csv_content)
+
+        # Step 6: Trim input CSV to exclude completed nodes
+        remaining = self._trim_input_csv(missing_csv, completed_nodes)
+
+        # Step 7: If all nodes are done, skip generation
+        if remaining == 0:
+            logger.info("All concept nodes already completed, skipping generation")
+            self._restore_and_finalize(
+                missing_csv, backup_file, accumulator, shard_file, concepts_dir
+            )
+            return
+
+        # Step 8: Run concept generation
+        logger.info(
+            "Generating concepts for %d remaining nodes (%d already completed)",
+            remaining,
+            len(completed_nodes),
+        )
+        extractor.generate_concept_csv_temp(
+            batch_size=self._opts["batch_size_concept"],
+            language=self._config.language,
+        )
+
+        # Step 9: Absorb new shard output
+        if shard_file.exists():
+            valid_rows = self._read_valid_concept_rows(shard_file)
+            if valid_rows:
+                self._append_to_accumulator(accumulator, valid_rows)
+                logger.info("Absorbed %d new concept rows", len(valid_rows))
+            shard_file.unlink()
+
+        # Steps 11-13: Restore input, finalize accumulator
+        self._restore_and_finalize(missing_csv, backup_file, accumulator, shard_file, concepts_dir)
+
+    def _read_valid_concept_rows(self, csv_path: Path) -> list[list[str]]:
+        """Read and validate rows from a concept CSV file.
+
+        Each valid row has exactly 3 non-empty columns with column 2
+        being one of ``event``, ``entity``, ``relation`` (lowercase).
+
+        Args:
+            csv_path: Path to a concept CSV file.
+
+        Returns:
+            List of valid [node, description, node_type] rows.
+        """
+        valid: list[list[str]] = []
+        try:
+            with csv_path.open(newline="") as f:
+                reader = csv.reader(f)
+                for row in reader:
+                    if len(row) == 3 and all(cell.strip() for cell in row):
+                        if row[2].strip().lower() in self._VALID_NODE_TYPES:
+                            valid.append([cell.strip() for cell in row])
+                        else:
+                            logger.debug("Dropping row with invalid node_type: %s", row)
+                    else:
+                        logger.debug("Dropping malformed concept row: %s", row)
+        except (OSError, csv.Error) as exc:
+            logger.warning("Failed to read concept CSV %s: %s", csv_path, exc)
+        return valid
+
+    def _append_to_accumulator(
+        self,
+        accumulator: Path,
+        rows: list[list[str]],
+    ) -> None:
+        """Append rows to the accumulator CSV, deduplicating by node name.
+
+        Deduplication is case-sensitive on column 0 (node name). On
+        conflict, the latest entry wins.
+
+        Args:
+            accumulator: Path to ``concept_completed.csv``.
+            rows: Validated concept rows to append.
+        """
+        existing: dict[str, list[str]] = {}
+        if accumulator.exists():
+            with accumulator.open(newline="") as f:
+                for row in csv.reader(f):
+                    if len(row) == 3:
+                        existing[row[0]] = row
+
+        for row in rows:
+            existing[row[0]] = row
+
+        with accumulator.open("w", newline="") as f:
+            writer = csv.writer(f)
+            writer.writerows(existing.values())
+
+    def _read_completed_nodes(self, accumulator: Path) -> set[str]:
+        """Read completed node names from the accumulator.
+
+        Args:
+            accumulator: Path to ``concept_completed.csv``.
+
+        Returns:
+            Set of completed node names (column 0, case-sensitive).
+        """
+        if not accumulator.exists():
+            return set()
+
+        nodes: set[str] = set()
+        with accumulator.open(newline="") as f:
+            for row in csv.reader(f):
+                if len(row) >= 1 and row[0].strip():
+                    nodes.add(row[0].strip())
+        return nodes
+
+    def _trim_input_csv(self, csv_path: Path, completed: set[str]) -> int:
+        """Rewrite input CSV excluding already-completed nodes.
+
+        Reads all rows, filters out nodes in ``completed``, and rewrites
+        the file.  The first row is treated as a header if present.
+
+        Args:
+            csv_path: Path to the missing_concepts CSV.
+            completed: Node names to exclude.
+
+        Returns:
+            Number of remaining data rows (excluding header).
+        """
+        with csv_path.open(newline="") as f:
+            all_rows = list(csv.reader(f))
+
+        if not all_rows:
+            return 0
+
+        header = all_rows[0]
+        data_rows = [row for row in all_rows[1:] if row and row[0] not in completed]
+
+        with csv_path.open("w", newline="") as f:
+            writer = csv.writer(f)
+            writer.writerow(header)
+            writer.writerows(data_rows)
+
+        if completed:
+            logger.info(
+                "Trimmed input CSV: %d -> %d rows (%d already completed)",
+                len(all_rows) - 1,
+                len(data_rows),
+                len(all_rows) - 1 - len(data_rows),
+            )
+        return len(data_rows)
+
+    def _restore_and_finalize(
+        self,
+        missing_csv: Path,
+        backup_file: Path,
+        accumulator: Path,
+        shard_file: Path,
+        concepts_dir: Path,
+    ) -> None:
+        """Restore input CSV and rename accumulator to final shard.
+
+        Args:
+            missing_csv: Original input CSV path.
+            backup_file: Backup of original input.
+            accumulator: Cumulative concept CSV.
+            shard_file: Expected final shard path.
+            concepts_dir: Concepts output directory.
+        """
+        # Step 11: Restore original input from backup
+        if backup_file.exists():
+            backup_file.replace(missing_csv)
+            logger.info("Restored original input CSV from backup")
+
+        # Step 12: Rename accumulator to concept_shard_0.csv
+        if accumulator.exists():
+            accumulator.replace(shard_file)
+            logger.info("Finalized concept output: %s", shard_file)
+
+        # Step 13: Guard — only concept_shard_0.csv should exist
+        csv_files = [f for f in concepts_dir.glob("*.csv") if f.name != "concept_shard_0.csv"]
+        if csv_files:
+            logger.warning(
+                "Unexpected CSV files in concepts/: %s",
+                [f.name for f in csv_files],
+            )
 
     def _build_result(
         self,

--- a/tests/kg/test_atlas_backend.py
+++ b/tests/kg/test_atlas_backend.py
@@ -845,15 +845,25 @@ class TestBuildProcessingConfig:
 class TestRunPipeline:
     """Tests for _run_pipeline."""
 
-    def test_all_five_steps_called(self, _mock_atlas_rag: dict) -> None:
+    @staticmethod
+    def _setup_missing_csv(output_dir: Path) -> Path:
+        """Create a minimal missing_concepts CSV so resume wrapper works."""
+        triples_dir = output_dir / "atlas_output" / "triples_csv"
+        triples_dir.mkdir(parents=True, exist_ok=True)
+        csv_file = triples_dir / "missing_concepts_test_from_json.csv"
+        csv_file.write_text("node,description,node_type\nfoo,bar,entity\n")
+        return csv_file
+
+    def test_all_five_steps_called(self, tmp_path: Path, _mock_atlas_rag: dict) -> None:
         """Test all 5 atlas-rag pipeline steps are called."""
         from arandu.kg.atlas_backend import AtlasRagConstructor
 
         config = KGConfig(backend_options={"include_concept": True})
         constructor = AtlasRagConstructor(config)
 
+        self._setup_missing_csv(tmp_path)
         mock_extractor = MagicMock()
-        constructor._run_pipeline(mock_extractor)
+        constructor._run_pipeline(mock_extractor, tmp_path)
 
         mock_extractor.run_extraction.assert_called_once()
         mock_extractor.convert_json_to_csv.assert_called_once()
@@ -861,7 +871,7 @@ class TestRunPipeline:
         mock_extractor.create_concept_csv.assert_called_once()
         mock_extractor.convert_to_graphml.assert_called_once()
 
-    def test_skip_concept_steps(self, _mock_atlas_rag: dict) -> None:
+    def test_skip_concept_steps(self, tmp_path: Path, _mock_atlas_rag: dict) -> None:
         """Test concept steps are skipped when include_concept=False."""
         from arandu.kg.atlas_backend import AtlasRagConstructor
 
@@ -869,13 +879,378 @@ class TestRunPipeline:
         constructor = AtlasRagConstructor(config)
 
         mock_extractor = MagicMock()
-        constructor._run_pipeline(mock_extractor)
+        constructor._run_pipeline(mock_extractor, tmp_path)
 
         mock_extractor.run_extraction.assert_called_once()
         mock_extractor.convert_json_to_csv.assert_called_once()
         mock_extractor.generate_concept_csv_temp.assert_not_called()
         mock_extractor.create_concept_csv.assert_not_called()
         mock_extractor.convert_to_graphml.assert_called_once()
+
+
+class TestResumableConceptGeneration:
+    """Tests for _run_concept_generation_with_resume."""
+
+    @staticmethod
+    def _setup_dirs(output_dir: Path) -> tuple[Path, Path, Path]:
+        """Create atlas_output directory structure and a missing_concepts CSV.
+
+        Returns:
+            Tuple of (missing_csv, concepts_dir, triples_dir).
+        """
+        triples_dir = output_dir / "atlas_output" / "triples_csv"
+        concepts_dir = output_dir / "atlas_output" / "concepts"
+        triples_dir.mkdir(parents=True, exist_ok=True)
+        concepts_dir.mkdir(parents=True, exist_ok=True)
+
+        missing_csv = triples_dir / "missing_concepts_test_from_json.csv"
+        missing_csv.write_text(
+            "node,description,node_type\n"
+            "Rio Guaíba,grande rio do sul,entity\n"
+            "enchente,evento climático,event\n"
+            "afeta,relação causal,relation\n"
+        )
+        return missing_csv, concepts_dir, triples_dir
+
+    def test_fresh_run(self, tmp_path: Path, _mock_atlas_rag: dict) -> None:
+        """Fresh run with no prior data — generation runs normally."""
+        from arandu.kg.atlas_backend import AtlasRagConstructor
+
+        missing_csv, concepts_dir, _ = self._setup_dirs(tmp_path)
+        config = KGConfig(language="pt")
+        constructor = AtlasRagConstructor(config)
+
+        mock_extractor = MagicMock()
+        # Simulate atlas-rag writing a shard
+        shard = concepts_dir / "concept_shard_0.csv"
+
+        def write_shard(**kwargs: Any) -> None:
+            shard.write_text(
+                "Rio Guaíba,large river in southern Brazil,entity\n"
+                "enchente,climatic event,event\n"
+                "afeta,causal relation,relation\n"
+            )
+
+        mock_extractor.generate_concept_csv_temp.side_effect = write_shard
+
+        constructor._run_concept_generation_with_resume(mock_extractor, tmp_path)
+
+        mock_extractor.generate_concept_csv_temp.assert_called_once_with(
+            batch_size=16,
+            language="pt",
+        )
+        # Final output should be concept_shard_0.csv
+        assert shard.exists()
+        # Backup should be cleaned up
+        assert not missing_csv.with_suffix(".csv.bak").exists()
+
+    def test_full_resume_all_completed(self, tmp_path: Path, _mock_atlas_rag: dict) -> None:
+        """All nodes already in accumulator — generation is skipped."""
+        from arandu.kg.atlas_backend import AtlasRagConstructor
+
+        _missing_csv, concepts_dir, _ = self._setup_dirs(tmp_path)
+
+        # Pre-populate accumulator with all nodes
+        accumulator = concepts_dir / "concept_completed.csv"
+        accumulator.write_text(
+            "Rio Guaíba,large river in southern Brazil,entity\n"
+            "enchente,climatic event,event\n"
+            "afeta,causal relation,relation\n"
+        )
+
+        config = KGConfig(language="pt")
+        constructor = AtlasRagConstructor(config)
+        mock_extractor = MagicMock()
+
+        constructor._run_concept_generation_with_resume(mock_extractor, tmp_path)
+
+        mock_extractor.generate_concept_csv_temp.assert_not_called()
+        # Accumulator should be renamed to shard
+        shard = concepts_dir / "concept_shard_0.csv"
+        assert shard.exists()
+        assert not accumulator.exists()
+
+    def test_partial_resume(self, tmp_path: Path, _mock_atlas_rag: dict) -> None:
+        """Leftover shard absorbed, generation runs with trimmed input."""
+        from arandu.kg.atlas_backend import AtlasRagConstructor
+
+        _missing_csv, concepts_dir, _ = self._setup_dirs(tmp_path)
+
+        # Simulate interrupted shard with 1 completed node
+        leftover_shard = concepts_dir / "concept_shard_0.csv"
+        leftover_shard.write_text("Rio Guaíba,large river in southern Brazil,entity\n")
+
+        config = KGConfig(language="pt")
+        constructor = AtlasRagConstructor(config)
+        mock_extractor = MagicMock()
+
+        shard = concepts_dir / "concept_shard_0.csv"
+
+        def write_shard(**kwargs: Any) -> None:
+            shard.write_text("enchente,climatic event,event\nafeta,causal relation,relation\n")
+
+        mock_extractor.generate_concept_csv_temp.side_effect = write_shard
+
+        constructor._run_concept_generation_with_resume(mock_extractor, tmp_path)
+
+        mock_extractor.generate_concept_csv_temp.assert_called_once()
+        assert shard.exists()
+        # Should contain all 3 nodes (1 from leftover + 2 from new run)
+        import csv
+
+        with shard.open(newline="") as f:
+            rows = list(csv.reader(f))
+        assert len(rows) == 3
+
+    def test_corrupted_rows_dropped(self, tmp_path: Path, _mock_atlas_rag: dict) -> None:
+        """Malformed rows in leftover shard are dropped, valid ones kept."""
+        from arandu.kg.atlas_backend import AtlasRagConstructor
+
+        _missing_csv, concepts_dir, _ = self._setup_dirs(tmp_path)
+
+        # Leftover shard with corrupted rows
+        leftover_shard = concepts_dir / "concept_shard_0.csv"
+        leftover_shard.write_text(
+            "Rio Guaíba,large river in southern Brazil,entity\n"
+            "bad_row_only_two_cols,missing\n"
+            ",,\n"
+            "enchente,climatic event,INVALID_TYPE\n"
+            "afeta,causal relation,relation\n"
+        )
+
+        config = KGConfig(language="pt")
+        constructor = AtlasRagConstructor(config)
+        mock_extractor = MagicMock()
+
+        shard = concepts_dir / "concept_shard_0.csv"
+
+        def write_shard(**kwargs: Any) -> None:
+            shard.write_text("enchente,climatic event,event\n")
+
+        mock_extractor.generate_concept_csv_temp.side_effect = write_shard
+
+        constructor._run_concept_generation_with_resume(mock_extractor, tmp_path)
+
+        assert shard.exists()
+        import csv
+
+        with shard.open(newline="") as f:
+            rows = list(csv.reader(f))
+        node_names = {row[0] for row in rows}
+        # Valid rows: Rio Guaíba (entity) and afeta (relation) from leftover
+        # Plus enchente (event) from new run
+        assert "Rio Guaíba" in node_names
+        assert "afeta" in node_names
+        assert "enchente" in node_names
+
+    def test_backup_restore_on_dirty_state(self, tmp_path: Path, _mock_atlas_rag: dict) -> None:
+        """Backup file from previous crash is restored before proceeding."""
+        from arandu.kg.atlas_backend import AtlasRagConstructor
+
+        missing_csv, concepts_dir, _ = self._setup_dirs(tmp_path)
+
+        # Simulate dirty state: input was trimmed, backup exists
+        original_content = missing_csv.read_text()
+        backup = missing_csv.with_suffix(".csv.bak")
+        backup.write_text(original_content)
+        # Overwrite input with trimmed version
+        missing_csv.write_text("node,description,node_type\nenchente,evento climático,event\n")
+
+        config = KGConfig(language="pt")
+        constructor = AtlasRagConstructor(config)
+        mock_extractor = MagicMock()
+
+        shard = concepts_dir / "concept_shard_0.csv"
+
+        def write_shard(**kwargs: Any) -> None:
+            shard.write_text(
+                "Rio Guaíba,large river,entity\n"
+                "enchente,climatic event,event\n"
+                "afeta,causal relation,relation\n"
+            )
+
+        mock_extractor.generate_concept_csv_temp.side_effect = write_shard
+
+        constructor._run_concept_generation_with_resume(mock_extractor, tmp_path)
+
+        # Input should be restored to original (all 3 nodes)
+        restored = missing_csv.read_text()
+        assert "Rio Guaíba" in restored
+        assert "enchente" in restored
+        assert "afeta" in restored
+
+    def test_multiple_successive_failures(self, tmp_path: Path, _mock_atlas_rag: dict) -> None:
+        """Accumulator grows correctly across 2 interruptions."""
+        from arandu.kg.atlas_backend import AtlasRagConstructor
+
+        _missing_csv, concepts_dir, _ = self._setup_dirs(tmp_path)
+
+        config = KGConfig(language="pt")
+        constructor = AtlasRagConstructor(config)
+
+        shard = concepts_dir / "concept_shard_0.csv"
+        accumulator = concepts_dir / "concept_completed.csv"
+
+        # --- Failure 1: only 1 node completed, then "crash" ---
+        mock_ext1 = MagicMock()
+
+        def write_shard_1(**kwargs: Any) -> None:
+            shard.write_text("Rio Guaíba,large river,entity\n")
+
+        mock_ext1.generate_concept_csv_temp.side_effect = write_shard_1
+        constructor._run_concept_generation_with_resume(mock_ext1, tmp_path)
+
+        # After first run, shard should have 1 node
+        assert shard.exists()
+
+        # Simulate crash: rename shard back to look like interrupted state
+        # (In real life, the shard would be a leftover from atlas-rag being killed)
+        # For the next resume, we need a leftover shard_0 and an accumulator
+        # The finalize step already renamed accumulator -> shard_0
+        # So simulate the atlas-rag crash by putting a new partial shard
+        # while the previous result is now in concept_shard_0.csv
+        # We need to set up for a second resume: put shard content into accumulator
+        # and create a new leftover shard
+        import csv
+
+        with shard.open(newline="") as f:
+            rows_after_first = list(csv.reader(f))
+        accumulator.write_text("")
+        with accumulator.open("w", newline="") as f:
+            writer = csv.writer(f)
+            writer.writerows(rows_after_first)
+        shard.unlink()
+
+        # Simulate a second partial shard from interrupted run
+        shard.write_text("enchente,climatic event,event\n")
+
+        # --- Failure 2: second node completed ---
+        mock_ext2 = MagicMock()
+
+        def write_shard_2(**kwargs: Any) -> None:
+            shard.write_text("afeta,causal relation,relation\n")
+
+        mock_ext2.generate_concept_csv_temp.side_effect = write_shard_2
+        constructor._run_concept_generation_with_resume(mock_ext2, tmp_path)
+
+        # Final shard should have all 3 nodes
+        assert shard.exists()
+        with shard.open(newline="") as f:
+            final_rows = list(csv.reader(f))
+        assert len(final_rows) == 3
+        node_names = {row[0] for row in final_rows}
+        assert node_names == {"Rio Guaíba", "enchente", "afeta"}
+
+    def test_empty_input_csv(self, tmp_path: Path, _mock_atlas_rag: dict) -> None:
+        """Header-only input CSV — no nodes to process, completes immediately."""
+        from arandu.kg.atlas_backend import AtlasRagConstructor
+
+        _, _concepts_dir, triples_dir = self._setup_dirs(tmp_path)
+        # Overwrite with header-only
+        missing_csv = sorted(triples_dir.glob("missing_concepts*_from_json.csv"))[0]
+        missing_csv.write_text("node,description,node_type\n")
+
+        config = KGConfig(language="pt")
+        constructor = AtlasRagConstructor(config)
+        mock_extractor = MagicMock()
+
+        constructor._run_concept_generation_with_resume(mock_extractor, tmp_path)
+
+        mock_extractor.generate_concept_csv_temp.assert_not_called()
+
+    def test_merge_guard(self, tmp_path: Path, _mock_atlas_rag: dict) -> None:
+        """After resume completes, only concept_shard_0.csv exists in concepts/."""
+        from arandu.kg.atlas_backend import AtlasRagConstructor
+
+        _missing_csv, concepts_dir, _ = self._setup_dirs(tmp_path)
+
+        config = KGConfig(language="pt")
+        constructor = AtlasRagConstructor(config)
+        mock_extractor = MagicMock()
+
+        shard = concepts_dir / "concept_shard_0.csv"
+
+        def write_shard(**kwargs: Any) -> None:
+            shard.write_text(
+                "Rio Guaíba,large river,entity\n"
+                "enchente,climatic event,event\n"
+                "afeta,causal relation,relation\n"
+            )
+
+        mock_extractor.generate_concept_csv_temp.side_effect = write_shard
+
+        constructor._run_concept_generation_with_resume(mock_extractor, tmp_path)
+
+        csv_files = list(concepts_dir.glob("*.csv"))
+        assert len(csv_files) == 1
+        assert csv_files[0].name == "concept_shard_0.csv"
+
+    def test_empty_shard_leftover(self, tmp_path: Path, _mock_atlas_rag: dict) -> None:
+        """Empty/header-only shard leftover — no rows absorbed, generation proceeds."""
+        from arandu.kg.atlas_backend import AtlasRagConstructor
+
+        _missing_csv, concepts_dir, _ = self._setup_dirs(tmp_path)
+
+        # Empty shard from crash right after atlas-rag opened the file
+        leftover_shard = concepts_dir / "concept_shard_0.csv"
+        leftover_shard.write_text("")
+
+        config = KGConfig(language="pt")
+        constructor = AtlasRagConstructor(config)
+        mock_extractor = MagicMock()
+
+        shard = concepts_dir / "concept_shard_0.csv"
+
+        def write_shard(**kwargs: Any) -> None:
+            shard.write_text(
+                "Rio Guaíba,large river,entity\n"
+                "enchente,climatic event,event\n"
+                "afeta,causal relation,relation\n"
+            )
+
+        mock_extractor.generate_concept_csv_temp.side_effect = write_shard
+
+        constructor._run_concept_generation_with_resume(mock_extractor, tmp_path)
+
+        mock_extractor.generate_concept_csv_temp.assert_called_once()
+        assert shard.exists()
+
+    def test_missing_input_csv(self, tmp_path: Path, _mock_atlas_rag: dict) -> None:
+        """Missing missing_concepts CSV raises FileNotFoundError."""
+        from arandu.kg.atlas_backend import AtlasRagConstructor
+
+        # Create output structure but no missing_concepts CSV
+        triples_dir = tmp_path / "atlas_output" / "triples_csv"
+        triples_dir.mkdir(parents=True, exist_ok=True)
+
+        config = KGConfig(language="pt")
+        constructor = AtlasRagConstructor(config)
+        mock_extractor = MagicMock()
+
+        with pytest.raises(FileNotFoundError, match="No missing_concepts CSV found"):
+            constructor._run_concept_generation_with_resume(mock_extractor, tmp_path)
+
+    def test_language_kwarg_passed(self, tmp_path: Path, _mock_atlas_rag: dict) -> None:
+        """Verify language=self._config.language is passed to generate_concept_csv_temp."""
+        from arandu.kg.atlas_backend import AtlasRagConstructor
+
+        _missing_csv, concepts_dir, _ = self._setup_dirs(tmp_path)
+
+        config = KGConfig(language="pt")
+        constructor = AtlasRagConstructor(config)
+        mock_extractor = MagicMock()
+
+        shard = concepts_dir / "concept_shard_0.csv"
+
+        def write_shard(**kwargs: Any) -> None:
+            shard.write_text("Rio Guaíba,large river,entity\n")
+
+        mock_extractor.generate_concept_csv_temp.side_effect = write_shard
+
+        constructor._run_concept_generation_with_resume(mock_extractor, tmp_path)
+
+        call_kwargs = mock_extractor.generate_concept_csv_temp.call_args[1]
+        assert call_kwargs["language"] == "pt"
 
 
 class TestBuildResult:

--- a/tests/kg/test_atlas_backend.py
+++ b/tests/kg/test_atlas_backend.py
@@ -1145,7 +1145,7 @@ class TestResumableConceptGeneration:
         """Header-only input CSV — no nodes to process, completes immediately."""
         from arandu.kg.atlas_backend import AtlasRagConstructor
 
-        _, _concepts_dir, triples_dir = self._setup_dirs(tmp_path)
+        _, concepts_dir, triples_dir = self._setup_dirs(tmp_path)
         # Overwrite with header-only
         missing_csv = sorted(triples_dir.glob("missing_concepts*_from_json.csv"))[0]
         missing_csv.write_text("node,description,node_type\n")
@@ -1157,6 +1157,8 @@ class TestResumableConceptGeneration:
         constructor._run_concept_generation_with_resume(mock_extractor, tmp_path)
 
         mock_extractor.generate_concept_csv_temp.assert_not_called()
+        # concept_shard_0.csv must exist so downstream create_concept_csv() has valid input
+        assert (concepts_dir / "concept_shard_0.csv").exists()
 
     def test_merge_guard(self, tmp_path: Path, _mock_atlas_rag: dict) -> None:
         """After resume completes, only concept_shard_0.csv exists in concepts/."""


### PR DESCRIPTION
## Summary
- Add `_run_concept_generation_with_resume()` wrapper around atlas-rag's `generate_concept_csv_temp()` so concept generation progress survives SLURM timeouts via a cumulative `concept_completed.csv` accumulator
- Fix `language` kwarg not being passed to `generate_concept_csv_temp()`, which caused English concept prompts to be used on Portuguese text
- Update `_run_pipeline()` signature to accept `output_dir` parameter for resume support
- Add 11 new tests covering all resume scenarios: fresh run, full/partial resume, corrupted rows, backup restore, multiple successive failures, empty input, merge guard, empty shard leftover, missing input CSV, and language kwarg verification

## Test plan
- [ ] Run `uv run pytest tests/kg/test_atlas_backend.py -v` — all 50 tests pass (11 new resume tests + 39 existing)
- [ ] Run `uv run pytest` — full suite passes (1 pre-existing failure in `test_batch.py` is unrelated)
- [ ] Run `uv run ruff check src/arandu/kg/atlas_backend.py` — no lint violations
- [ ] Verify fresh run: `test_fresh_run` confirms generation executes normally with `language="pt"` kwarg
- [ ] Verify resume after SLURM kill: `test_partial_resume` and `test_multiple_successive_failures` confirm accumulator grows across interruptions
- [ ] Verify corrupted output handling: `test_corrupted_rows_dropped` confirms malformed CSV rows are discarded
- [ ] Verify dirty state recovery: `test_backup_restore_on_dirty_state` confirms `.bak` file is restored after mid-trim crash
- [ ] End-to-end: resume `test-kg-02` or run fresh KG pipeline on cluster to produce `corpus_graph.graphml`

Closes #77