### PR TITLE
fix(kg): monkey-patch atlas-rag orphan nodes

### DIFF
--- a/src/arandu/kg/atlas_backend.py
+++ b/src/arandu/kg/atlas_backend.py
@@ -164,7 +164,7 @@ def _get_enriched_processor_cls() -> type:
 def _patched_csvs_to_temp_graphml(
     triple_node_file: str,
     triple_edge_file: str,
-    config: Any = None,
+    config: Any,
 ) -> None:
     """Patched ``csvs_to_temp_graphml`` that guards against orphan nodes.
 
@@ -174,9 +174,12 @@ def _patched_csvs_to_temp_graphml(
 
     This patch ensures both edge endpoints exist as fully-attributed
     nodes before adding edges. Can be removed once atlas-rag upstream
-    fixes the issue.
+    fixes the issue (HKUST-KnowComp/AutoSchemaKG).
 
-    See: ``atlas-rag-keyerror-issue.md``
+    Args:
+        triple_node_file: Path to the triple nodes CSV.
+        triple_edge_file: Path to the triple edges CSV.
+        config: atlas-rag ``ProcessingConfig`` instance.
     """
     import os
     import pickle
@@ -212,17 +215,20 @@ def _patched_csvs_to_temp_graphml(
                 g.add_node(end_id, id=row[":END_ID"], type="entity")
                 orphan_count += 1
             if not g.has_edge(start_id, end_id):
-                g.add_edge(start_id, end_id, relation=row["relation"], type=row[":TYPE"])
+                g.add_edge(
+                    start_id, end_id, relation=row["relation"], type=row[":TYPE"]
+                )
 
     if orphan_count:
         logger.warning("Patched %d orphan nodes with default attributes", orphan_count)
 
     output_name = (
-        f"{config.output_directory}/kg_graphml/{config.filename_pattern}_without_concept.pkl"
+        f"{config.output_directory}/kg_graphml"
+        f"/{config.filename_pattern}_without_concept.pkl"
     )
     output_dir = os.path.dirname(output_name)
-    if output_dir and not os.path.exists(output_dir):
-        os.makedirs(output_dir)
+    if output_dir:
+        os.makedirs(output_dir, exist_ok=True)
     with open(output_name, "wb") as output_file:
         pickle.dump(g, output_file)
 

--- a/src/arandu/kg/atlas_backend.py
+++ b/src/arandu/kg/atlas_backend.py
@@ -161,6 +161,72 @@ def _get_enriched_processor_cls() -> type:
     return _MetadataEnrichedProcessorCls
 
 
+def _patched_csvs_to_temp_graphml(
+    triple_node_file: str,
+    triple_edge_file: str,
+    config: Any = None,
+) -> None:
+    """Patched ``csvs_to_temp_graphml`` that guards against orphan nodes.
+
+    atlas-rag's ``add_edge()`` auto-creates nodes without attributes when
+    edge endpoints are missing from the nodes CSV. This causes
+    ``generate_concept()`` to crash with ``KeyError: 'id'``.
+
+    This patch ensures both edge endpoints exist as fully-attributed
+    nodes before adding edges. Can be removed once atlas-rag upstream
+    fixes the issue.
+
+    See: ``atlas-rag-keyerror-issue.md``
+    """
+    import os
+    import pickle
+
+    import networkx as nx
+    from atlas_rag.kg_construction.utils.csv_processing.csv_to_graphml import (
+        get_node_id,
+    )
+
+    g = nx.DiGraph()
+    entity_to_id: dict[str, str] = {}
+
+    # Add triple nodes (same as original)
+    with open(triple_node_file) as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            node_id = row["name:ID"]
+            mapped_id = get_node_id(node_id, entity_to_id)
+            if mapped_id not in g.nodes:
+                g.add_node(mapped_id, id=node_id, type=row["type"])
+
+    # Add triple edges — ensure endpoints exist with attributes
+    orphan_count = 0
+    with open(triple_edge_file) as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            start_id = get_node_id(row[":START_ID"], entity_to_id)
+            end_id = get_node_id(row[":END_ID"], entity_to_id)
+            if start_id not in g.nodes:
+                g.add_node(start_id, id=row[":START_ID"], type="entity")
+                orphan_count += 1
+            if end_id not in g.nodes:
+                g.add_node(end_id, id=row[":END_ID"], type="entity")
+                orphan_count += 1
+            if not g.has_edge(start_id, end_id):
+                g.add_edge(start_id, end_id, relation=row["relation"], type=row[":TYPE"])
+
+    if orphan_count:
+        logger.warning("Patched %d orphan nodes with default attributes", orphan_count)
+
+    output_name = (
+        f"{config.output_directory}/kg_graphml/{config.filename_pattern}_without_concept.pkl"
+    )
+    output_dir = os.path.dirname(output_name)
+    if output_dir and not os.path.exists(output_dir):
+        os.makedirs(output_dir)
+    with open(output_name, "wb") as output_file:
+        pickle.dump(g, output_file)
+
+
 class AtlasRagConstructor:
     """KG constructor using atlas-rag (AutoSchemaKG) as the extraction backend.
 
@@ -528,7 +594,14 @@ class AtlasRagConstructor:
             triple_extraction.DatasetProcessor = original_cls
 
         logger.info("Converting JSON to CSV...")
-        extractor.convert_json_to_csv()
+        from atlas_rag.kg_construction.utils.csv_processing import csv_to_graphml
+
+        original_csvs_to_temp = csv_to_graphml.csvs_to_temp_graphml
+        csv_to_graphml.csvs_to_temp_graphml = _patched_csvs_to_temp_graphml
+        try:
+            extractor.convert_json_to_csv()
+        finally:
+            csv_to_graphml.csvs_to_temp_graphml = original_csvs_to_temp
 
         if self._opts["include_concept"]:
             self._run_concept_generation_with_resume(extractor, output_dir)

--- a/src/arandu/kg/atlas_backend.py
+++ b/src/arandu/kg/atlas_backend.py
@@ -215,16 +215,13 @@ def _patched_csvs_to_temp_graphml(
                 g.add_node(end_id, id=row[":END_ID"], type="entity")
                 orphan_count += 1
             if not g.has_edge(start_id, end_id):
-                g.add_edge(
-                    start_id, end_id, relation=row["relation"], type=row[":TYPE"]
-                )
+                g.add_edge(start_id, end_id, relation=row["relation"], type=row[":TYPE"])
 
     if orphan_count:
         logger.warning("Patched %d orphan nodes with default attributes", orphan_count)
 
     output_name = (
-        f"{config.output_directory}/kg_graphml"
-        f"/{config.filename_pattern}_without_concept.pkl"
+        f"{config.output_directory}/kg_graphml/{config.filename_pattern}_without_concept.pkl"
     )
     output_dir = os.path.dirname(output_name)
     if output_dir:

--- a/tests/kg/test_atlas_backend.py
+++ b/tests/kg/test_atlas_backend.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+import csv
 import json
 from pathlib import Path  # noqa: TC003 — used at runtime for tmp_path fixtures
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ClassVar
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -1259,6 +1260,147 @@ class TestResumableConceptGeneration:
 
         call_kwargs = mock_extractor.generate_concept_csv_temp.call_args[1]
         assert call_kwargs["language"] == "pt"
+
+
+class TestPatchedCsvsToTempGraphml:
+    """Tests for _patched_csvs_to_temp_graphml orphan node handling."""
+
+    _NODE_FIELDS: ClassVar[list[str]] = ["name:ID", "type", "concepts", "synsets", ":LABEL"]
+
+    @staticmethod
+    def _write_nodes_csv(path: Path, rows: list[dict[str, str]]) -> None:
+        """Write a triple nodes CSV file."""
+        with path.open("w", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=TestPatchedCsvsToTempGraphml._NODE_FIELDS)
+            writer.writeheader()
+            writer.writerows(rows)
+
+    @staticmethod
+    def _write_edges_csv(path: Path, rows: list[dict[str, str]]) -> None:
+        """Write a triple edges CSV file."""
+        with path.open("w", newline="") as f:
+            writer = csv.DictWriter(
+                f, fieldnames=[":START_ID", ":END_ID", "relation", "concepts", "synsets", ":TYPE"]
+            )
+            writer.writeheader()
+            writer.writerows(rows)
+
+    def test_orphan_nodes_get_default_attributes(
+        self, tmp_path: Path, _mock_atlas_rag: dict
+    ) -> None:
+        """Edge endpoints missing from nodes CSV get id and type attributes."""
+        import pickle
+
+        # Make get_node_id return input as-is (no hashing)
+        csv_mod = _mock_atlas_rag["atlas_rag.kg_construction.utils.csv_processing.csv_to_graphml"]
+        csv_mod.get_node_id = lambda name, cache=None: name
+
+        from arandu.kg.atlas_backend import _patched_csvs_to_temp_graphml
+
+        nodes_file = tmp_path / "nodes.csv"
+        edges_file = tmp_path / "edges.csv"
+        self._write_nodes_csv(
+            nodes_file,
+            [
+                {
+                    "name:ID": "rio",
+                    "type": "entity",
+                    "concepts": "",
+                    "synsets": "",
+                    ":LABEL": "Node",
+                },
+            ],
+        )
+        self._write_edges_csv(
+            edges_file,
+            [
+                {
+                    ":START_ID": "rio",
+                    ":END_ID": "enchente",
+                    "relation": "causou",
+                    "concepts": "",
+                    "synsets": "",
+                    ":TYPE": "Relation",
+                },
+            ],
+        )
+
+        config = MagicMock()
+        config.output_directory = str(tmp_path / "output")
+        config.filename_pattern = "test"
+
+        _patched_csvs_to_temp_graphml(str(nodes_file), str(edges_file), config)
+
+        pkl_path = tmp_path / "output" / "kg_graphml" / "test_without_concept.pkl"
+        assert pkl_path.exists()
+
+        with open(pkl_path, "rb") as f:
+            g = pickle.load(f)
+
+        # "enchente" was only in edges, should have been created with attributes
+        orphan_nodes = [n for n in g.nodes if g.nodes[n].get("id") == "enchente"]
+        assert len(orphan_nodes) == 1
+        assert g.nodes[orphan_nodes[0]]["type"] == "entity"
+        assert g.nodes[orphan_nodes[0]]["id"] == "enchente"
+
+    def test_no_orphans_when_all_nodes_present(self, tmp_path: Path, _mock_atlas_rag: dict) -> None:
+        """No orphan warning when all edge endpoints exist in nodes CSV."""
+        csv_mod = _mock_atlas_rag["atlas_rag.kg_construction.utils.csv_processing.csv_to_graphml"]
+        csv_mod.get_node_id = lambda name, cache=None: name
+
+        from arandu.kg.atlas_backend import _patched_csvs_to_temp_graphml
+
+        nodes_file = tmp_path / "nodes.csv"
+        edges_file = tmp_path / "edges.csv"
+        self._write_nodes_csv(
+            nodes_file,
+            [
+                {
+                    "name:ID": "rio",
+                    "type": "entity",
+                    "concepts": "",
+                    "synsets": "",
+                    ":LABEL": "Node",
+                },
+                {
+                    "name:ID": "enchente",
+                    "type": "event",
+                    "concepts": "",
+                    "synsets": "",
+                    ":LABEL": "Node",
+                },
+            ],
+        )
+        self._write_edges_csv(
+            edges_file,
+            [
+                {
+                    ":START_ID": "rio",
+                    ":END_ID": "enchente",
+                    "relation": "causou",
+                    "concepts": "",
+                    "synsets": "",
+                    ":TYPE": "Relation",
+                },
+            ],
+        )
+
+        config = MagicMock()
+        config.output_directory = str(tmp_path / "output")
+        config.filename_pattern = "test"
+
+        _patched_csvs_to_temp_graphml(str(nodes_file), str(edges_file), config)
+
+        import pickle
+
+        pkl_path = tmp_path / "output" / "kg_graphml" / "test_without_concept.pkl"
+        with open(pkl_path, "rb") as f:
+            g = pickle.load(f)
+
+        # "enchente" should keep its original type from nodes CSV
+        enchente_nodes = [n for n in g.nodes if g.nodes[n].get("id") == "enchente"]
+        assert len(enchente_nodes) == 1
+        assert g.nodes[enchente_nodes[0]]["type"] == "event"  # original, not "entity"
 
 
 class TestBuildResult:

--- a/tests/kg/test_atlas_backend.py
+++ b/tests/kg/test_atlas_backend.py
@@ -88,6 +88,12 @@ def _mock_atlas_rag() -> dict[str, MagicMock]:
     mocks["atlas_rag.llm_generator.prompt"] = MagicMock()
     mocks["atlas_rag.llm_generator.prompt.triple_extraction_prompt"] = prompt_module
 
+    # Mock csv_processing for the orphan-node patch
+    csv_to_graphml_module = MagicMock()
+    mocks["atlas_rag.kg_construction.utils"] = MagicMock()
+    mocks["atlas_rag.kg_construction.utils.csv_processing"] = MagicMock()
+    mocks["atlas_rag.kg_construction.utils.csv_processing.csv_to_graphml"] = csv_to_graphml_module
+
     with patch.dict("sys.modules", mocks):
         yield mocks
 


### PR DESCRIPTION
## Summary

- Monkey-patch `csvs_to_temp_graphml` in atlas-rag to guard against orphan nodes created by `add_edge()` without attributes
- atlas-rag's `generate_concept()` crashes with `KeyError: 'id'` when accessing neighbor node attributes on these orphan nodes (~1,700 out of 13,376 nodes affected in test-kg-04)
- The patch ensures both edge endpoints exist as fully-attributed nodes before adding edges, defaulting to `type="entity"`
- Same monkey-patch pattern already used for concept prompts and DatasetProcessor

## Test plan

- [x] `uv run pytest tests/kg/test_atlas_backend.py -v` — 50 tests pass
- [ ] Rerun KG pipeline on cluster to verify concept generation completes past batch ~598
- [ ] File upstream issue on HKUST-KnowComp/AutoSchemaKG (draft in `atlas-rag-keyerror-issue.md`)

Part of #78