### PR TITLE
docs: update links in index.mdx for getting started guide

### DIFF
--- a/docs-site/src/content/docs/index.mdx
+++ b/docs-site/src/content/docs/index.mdx
@@ -6,7 +6,7 @@ hero:
   tagline: Composable pipelines for transcription, QA generation, and knowledge graph construction — designed for ethnographic media collections and climate-impact research.
   actions:
     - text: Get Started
-      link: /getting-started/
+      link: /arandu/getting-started/
       icon: right-arrow
       variant: primary
     - text: View on GitHub
@@ -44,4 +44,4 @@ arandu transcribe audio.mp3
 arandu generate-cep-qa results/
 ```
 
-See the [Getting Started guide](/getting-started/) for full setup instructions.
+See the [Getting Started guide](/arandu/getting-started/) for full setup instructions.


### PR DESCRIPTION
This pull request updates links in the documentation to ensure they point to the correct "Getting Started" guide location. The main change is updating the path from `/getting-started/` to `/arandu/getting-started/` in both the hero section and within the documentation content.

**Documentation updates:**

* Updated the "Get Started" button link in the hero section to `/arandu/getting-started/` to reflect the correct documentation path.
* Updated the inline reference to the Getting Started guide in the documentation content to `/arandu/getting-started/` for consistency and accuracy.