### PR TITLE
fix(kg): keep orphan-nodes patch installed through concept generation

### DIFF
--- a/src/arandu/kg/atlas_backend.py
+++ b/src/arandu/kg/atlas_backend.py
@@ -596,23 +596,32 @@ class AtlasRagConstructor:
         finally:
             triple_extraction.DatasetProcessor = original_cls
 
-        logger.info("Converting JSON to CSV...")
+        # Install the orphan-nodes patch for the rest of the pipeline.
+        # atlas-rag's ``generate_concept_csv_temp`` also calls
+        # ``csvs_to_temp_graphml`` internally to rebuild a fresh temp graph
+        # before concept generation, so the patch must stay active through
+        # both ``convert_json_to_csv()`` and
+        # ``_run_concept_generation_with_resume()``. Previously the patch
+        # was only active during convert_json_to_csv — concept generation
+        # then hit the unpatched function and crashed with KeyError: 'id'
+        # after ~20h of work (job 779284).
         from atlas_rag.kg_construction.utils.csv_processing import csv_to_graphml
 
         original_csvs_to_temp = csv_to_graphml.csvs_to_temp_graphml
         csv_to_graphml.csvs_to_temp_graphml = _patched_csvs_to_temp_graphml
         try:
+            logger.info("Converting JSON to CSV...")
             extractor.convert_json_to_csv()
+
+            if self._opts["include_concept"]:
+                self._run_concept_generation_with_resume(extractor, output_dir)
+                extractor.create_concept_csv()
+
+            logger.info("Converting to GraphML...")
+            extractor.convert_to_graphml()
+            logger.info("Atlas-rag pipeline completed")
         finally:
             csv_to_graphml.csvs_to_temp_graphml = original_csvs_to_temp
-
-        if self._opts["include_concept"]:
-            self._run_concept_generation_with_resume(extractor, output_dir)
-            extractor.create_concept_csv()
-
-        logger.info("Converting to GraphML...")
-        extractor.convert_to_graphml()
-        logger.info("Atlas-rag pipeline completed")
 
     # ------------------------------------------------------------------
     # Resumable concept generation

--- a/tests/kg/test_atlas_backend.py
+++ b/tests/kg/test_atlas_backend.py
@@ -894,6 +894,53 @@ class TestRunPipeline:
         mock_extractor.create_concept_csv.assert_not_called()
         mock_extractor.convert_to_graphml.assert_called_once()
 
+    def test_orphan_patch_active_during_concept_generation(
+        self, tmp_path: Path, _mock_atlas_rag: dict
+    ) -> None:
+        """Regression: the orphan-nodes patch must stay installed through
+        concept generation.
+
+        atlas-rag's ``generate_concept_csv_temp`` rebuilds a fresh temp
+        graph internally by calling ``csvs_to_temp_graphml``. If the patch
+        is reverted before concept generation runs (the original
+        narrow-scope wiring), that call hits the unpatched function,
+        creates orphan nodes, and ``generate_concept`` crashes with
+        ``KeyError: 'id'`` after hours of work (see job 779284,
+        2026-04-24).
+
+        This test asserts the patch is still installed when
+        ``generate_concept_csv_temp`` is invoked.
+        """
+        import arandu.kg.atlas_backend as backend
+        from arandu.kg.atlas_backend import AtlasRagConstructor
+
+        config = KGConfig(backend_options={"include_concept": True})
+        constructor = AtlasRagConstructor(config)
+
+        self._setup_missing_csv(tmp_path)
+        mock_extractor = MagicMock()
+
+        observed: dict[str, object] = {}
+
+        def _capture_patch_state(*_args: object, **_kwargs: object) -> None:
+            # Re-import from the same module path `_run_pipeline` uses so we
+            # see the attribute value on the exact object the production
+            # code is touching.
+            from atlas_rag.kg_construction.utils.csv_processing import (
+                csv_to_graphml as live_csv_to_graphml,
+            )
+
+            observed["csvs_to_temp_at_concept_gen"] = live_csv_to_graphml.csvs_to_temp_graphml
+
+        mock_extractor.generate_concept_csv_temp.side_effect = _capture_patch_state
+
+        constructor._run_pipeline(mock_extractor, tmp_path)
+
+        assert observed["csvs_to_temp_at_concept_gen"] is backend._patched_csvs_to_temp_graphml, (
+            "Orphan-nodes patch was reverted before concept generation — "
+            "this is the regression that caused 779284 to crash."
+        )
+
 
 class TestResumableConceptGeneration:
     """Tests for _run_concept_generation_with_resume."""


### PR DESCRIPTION
## Summary

- Widens the atlas-rag orphan-nodes monkey-patch (PR #85) so it stays installed for the whole KG pipeline, not just ``convert_json_to_csv()``.
- Adds a regression test that fails under the old narrow-scope wiring.
- Unblocks the test-kg-04 concept-gen run that crashed after ~20 h.

## Why

Job 779284 (qwen3:14b concept generation on test-kg-04) failed at 20 h 10 m with ``KeyError: 'id'`` at ``atlas_rag/kg_construction/concept_generation.py:212``. Same bug PR #85 was supposed to fix.

atlas-rag's ``generate_concept_csv_temp`` re-calls ``csvs_to_temp_graphml`` internally to build a fresh temp graph before concept generation. The patch wiring in ``_run_pipeline`` looked like this:

```python
original_csvs_to_temp = csv_to_graphml.csvs_to_temp_graphml
csv_to_graphml.csvs_to_temp_graphml = _patched_csvs_to_temp_graphml
try:
    extractor.convert_json_to_csv()
finally:
    csv_to_graphml.csvs_to_temp_graphml = original_csvs_to_temp  # <- patch gone

if self._opts["include_concept"]:
    self._run_concept_generation_with_resume(extractor, output_dir)  # <- unpatched
```

The patch was reverted *before* concept generation ran. When ``generate_concept_csv_temp`` rebuilt the temp graph, it hit the original (unpatched) function, orphan nodes got created without ``id`` attributes, and ``generate_concept`` crashed.

Fix: widen the ``try/finally`` so the patch stays installed until the whole pipeline finishes (convert_json_to_csv → concept_generation → convert_to_graphml).

## Regression test

``TestRunPipeline::test_orphan_patch_active_during_concept_generation`` captures the live ``csvs_to_temp_graphml`` attribute at the exact moment ``generate_concept_csv_temp`` is called and asserts it is the patched function. Verified to fail under the old wiring.

## Test plan

- [x] ``uv run pytest tests/kg/test_atlas_backend.py`` — 53/53 pass (was 52/52; one new test).
- [ ] Resubmit the KG SLURM job on tupi against test-kg-04 and confirm concept generation progresses past the earlier crash point (batch 262 / 837) — will update this PR with the result.