### PR TITLE
chore(env): document all pipeline env vars in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,75 +1,291 @@
 # =============================================================================
 # Arandu Environment Configuration
-# Copy this file to .env and customize as needed
+# Copy this file to .env and customize as needed.
+#
+# All Arandu settings use the ARANDU_ prefix. Each pipeline domain has its
+# own sub-prefix (ARANDU_QA_, ARANDU_CEP_, ARANDU_KG_, etc.). Third-party
+# credentials (OpenAI, Gemini, Hugging Face, Google Drive) use their
+# provider-native names.
+# =============================================================================
+
+
+# =============================================================================
+# Third-Party Credentials
 # =============================================================================
 
 # -----------------------------------------------------------------------------
-# Transcription Settings
+# OpenAI / OpenAI-compatible providers
 # -----------------------------------------------------------------------------
+# Used by the shared LLMClient (arandu.shared.llm_client) for:
+#   - OpenAI models (gpt-4o, gpt-4o-mini, ...)
+#   - Any OpenAI-compatible endpoint when you set a custom base_url. This
+#     includes Gemini's OpenAI-compat layer, Mistral/Anthropic OpenAI shims,
+#     self-hosted vLLM, etc.
+# For Gemini: put your Gemini API key here and set ARANDU_LLM_BASE_URL below.
+# OPENAI_API_KEY=
 
-# Whisper model to use (default: openai/whisper-large-v3-turbo)
-# Options:
-#   - openai/whisper-large-v3        (highest accuracy, slower)
-#   - openai/whisper-large-v3-turbo  (good balance of speed/accuracy)
-#   - distil-whisper/distil-large-v3 (fastest, good for CPU)
+# Custom base URL for OpenAI-compatible endpoints. Leave blank for OpenAI.
+# Examples:
+#   Gemini:  https://generativelanguage.googleapis.com/v1beta/openai/
+#   vLLM:    http://localhost:8000/v1
+#   Ollama:  http://localhost:11434/v1   (Ollama is autodetected, rarely needed)
+# ARANDU_LLM_BASE_URL=
+
+# -----------------------------------------------------------------------------
+# Hugging Face (Whisper model downloads)
+# -----------------------------------------------------------------------------
+# Only needed for gated/private HF repos. Public Whisper checkpoints work
+# without a token.
+# HF_TOKEN=
+# HUGGING_FACE_HUB_TOKEN=
+
+# -----------------------------------------------------------------------------
+# Google Drive (credentials live as files, not env vars)
+# -----------------------------------------------------------------------------
+# Google Drive auth uses credentials.json + token.json on disk. Point Arandu
+# at the directory containing them via ARANDU_CREDENTIALS_DIR below.
+
+
+# =============================================================================
+# Transcription Settings (ARANDU_*)
+# Pydantic: src/arandu/transcription/config.py TranscriberConfig
+# =============================================================================
+
+# Whisper model. Options:
+#   openai/whisper-large-v3         highest accuracy, slowest
+#   openai/whisper-large-v3-turbo   good speed/accuracy balance (default)
+#   distil-whisper/distil-large-v3  fastest, good on CPU
 ARANDU_MODEL_ID=openai/whisper-large-v3-turbo
 
-# Number of parallel workers (adjust based on GPU VRAM)
-# GPU recommendations: 4 workers for 24GB, 2 workers for 16GB
-# CPU recommendations: 2-4 workers depending on RAM
+# Expected input language (ISO 639-1). Leave unset for auto-detection.
+# ARANDU_LANGUAGE=pt
+
+# Emit segment-level timestamps alongside the full text.
+# ARANDU_RETURN_TIMESTAMPS=true
+
+# Audio windowing (seconds). Rarely needs changing.
+# ARANDU_CHUNK_LENGTH_S=30
+# ARANDU_STRIDE_LENGTH_S=5
+
+# Parallel worker count (GPU: 4 @ 24GB, 2 @ 16GB; CPU: 2-4 depending on RAM).
 ARANDU_WORKERS=4
 
-# Enable 8-bit quantization (reduces VRAM usage by ~50%)
-ARANDU_QUANTIZE=false
-
-# Force CPU execution (set to true for CPU-only partitions)
+# Force CPU execution (set true on CPU-only partitions).
 ARANDU_FORCE_CPU=false
 
+# Quantization: halves VRAM; small quality drop.
+ARANDU_QUANTIZE=false
+# ARANDU_QUANTIZE_BITS=8
+
+# Retry behavior for transient failures.
+# ARANDU_MAX_RETRIES=3
+# ARANDU_RETRY_DELAY=2.0
+
 # -----------------------------------------------------------------------------
-# Input/Output Paths
+# Paths
 # -----------------------------------------------------------------------------
 
-# Input catalog file name (relative to input directory)
+# Input catalog file name (relative to ARANDU_INPUT_DIR).
 ARANDU_CATALOG_FILE=catalog.csv
 
-# Directory containing input catalog (mounted as /app/input)
+# Catalog input directory (mounted as /app/input in Docker).
 ARANDU_INPUT_DIR=./input
 
-# Directory for transcription results (mounted as /app/results)
+# Results directory (mounted as /app/results).
 ARANDU_RESULTS_DIR=./results
 
-# Directory containing credentials.json and token.json
+# Directory containing credentials.json + token.json for Google Drive.
 ARANDU_CREDENTIALS_DIR=./
 
-# Hugging Face cache directory (for persistent model storage)
+# Override for individual credential file names (defaults are fine).
+# ARANDU_CREDENTIALS=credentials.json
+# ARANDU_TOKEN=token.json
+# ARANDU_SCOPES=["https://www.googleapis.com/auth/drive.readonly"]
+
+# Hugging Face cache directory (persisted across runs).
 ARANDU_HF_CACHE_DIR=./cache/huggingface
 
-# -----------------------------------------------------------------------------
-# SLURM Settings (used by SLURM job scripts)
-# -----------------------------------------------------------------------------
+# Scratch directory for intermediate files.
+# ARANDU_TEMP_DIR=/tmp
 
-# Project directory on PCAD (default: $HOME/etno-kgc-preprocessing)
+
+# =============================================================================
+# QA Generation (ARANDU_QA_*)
+# Pydantic: src/arandu/qa/config.py QAConfig
+# =============================================================================
+
+# LLM provider: "openai", "ollama", or "custom".
+ARANDU_QA_PROVIDER=ollama
+
+# Model ID (provider-specific: "gpt-4o-mini", "qwen3:14b", ...).
+ARANDU_QA_MODEL_ID=qwen3:14b
+
+# Ollama endpoint (only used when provider=ollama).
+ARANDU_QA_OLLAMA_URL=http://localhost:11434/v1
+
+# Base URL override (only used when provider=custom).
+# ARANDU_QA_BASE_URL=
+
+# Sampling parameters.
+ARANDU_QA_TEMPERATURE=0.7
+ARANDU_QA_MAX_TOKENS=4096
+
+# QA generation volume + output.
+ARANDU_QA_QUESTIONS_PER_DOCUMENT=5
+ARANDU_QA_OUTPUT_DIR=./qa_dataset
+ARANDU_QA_LANGUAGE=pt
+ARANDU_QA_WORKERS=4
+
+
+# =============================================================================
+# CEP (Critical-Event Protocol) QA Generation (ARANDU_CEP_*)
+# Pydantic: src/arandu/qa/config.py CEPConfig
+# =============================================================================
+
+# Bloom-level coverage.
+# ARANDU_CEP_BLOOM_LEVELS=["remember","understand","apply","analyze","evaluate","create"]
+# ARANDU_CEP_BLOOM_DISTRIBUTION={"remember":0.2,"understand":0.2,"apply":0.15,"analyze":0.15,"evaluate":0.15,"create":0.15}
+
+# Reasoning traces + multi-hop settings.
+ARANDU_CEP_ENABLE_REASONING_TRACES=true
+ARANDU_CEP_MAX_HOP_COUNT=3
+ARANDU_CEP_REASONING_MAX_TOKENS=2048
+
+# Scaffolding context (prior QA pairs injected as context).
+ARANDU_CEP_ENABLE_SCAFFOLDING_CONTEXT=true
+ARANDU_CEP_MAX_SCAFFOLDING_PAIRS=10
+
+# Source metadata context (include speaker/source info in prompts).
+ARANDU_CEP_ENABLE_SOURCE_METADATA_CONTEXT=true
+
+# Validation (legacy weighted-score path — deprecated by the judge pipeline
+# but still read by the CEP generator for backwards compatibility).
+ARANDU_CEP_VALIDATION_THRESHOLD=0.6
+# ARANDU_CEP_FAITHFULNESS_WEIGHT=0.4
+# ARANDU_CEP_BLOOM_CALIBRATION_WEIGHT=0.3
+# ARANDU_CEP_INFORMATIVENESS_WEIGHT=0.3
+# ARANDU_CEP_SELF_CONTAINEDNESS_WEIGHT=0.0
+
+ARANDU_CEP_LANGUAGE=pt
+
+
+# =============================================================================
+# Judge Pipeline (ARANDU_JUDGE_*)
+# Pydantic: src/arandu/qa/config.py JudgeConfig
+# =============================================================================
+
+# Language for judge prompts (picks the right prompts/judge/criteria/<name>/<lang>/prompt.md).
+ARANDU_JUDGE_LANGUAGE=pt
+
+# Sampling parameters for LLM criteria. Lower temperature = more deterministic.
+ARANDU_JUDGE_TEMPERATURE=0.3
+ARANDU_JUDGE_MAX_TOKENS=2048
+
+
+# =============================================================================
+# Knowledge Graph Construction (ARANDU_KG_*)
+# Pydantic: src/arandu/kg/config.py KGConfig
+# =============================================================================
+
+# Backend: "atlas" (AutoSchemaKG) is the only implemented backend today.
+ARANDU_KG_BACKEND=atlas
+
+# Backend-specific options (JSON object; keys depend on backend).
+# ARANDU_KG_BACKEND_OPTIONS={}
+
+# LLM provider + model.
+ARANDU_KG_PROVIDER=ollama
+ARANDU_KG_MODEL_ID=qwen3:14b
+
+# Ollama endpoint (used when provider=ollama).
+ARANDU_KG_OLLAMA_URL=http://localhost:11434/v1
+
+# Base URL override (used when provider=custom).
+# ARANDU_KG_BASE_URL=
+
+# Extraction temperature.
+ARANDU_KG_TEMPERATURE=0.5
+
+ARANDU_KG_LANGUAGE=pt
+ARANDU_KG_OUTPUT_DIR=./knowledge_graphs
+
+
+# =============================================================================
+# Evaluation (ARANDU_EVAL_*)
+# Pydantic: src/arandu/shared/config.py EvaluationConfig
+# =============================================================================
+
+# Metrics to compute. Valid: "qa", "entity", "relation", "semantic".
+# ARANDU_EVAL_METRICS=["qa","entity","relation","semantic"]
+
+# Sentence-transformer model for semantic similarity metrics.
+ARANDU_EVAL_EMBEDDING_MODEL=sentence-transformers/all-MiniLM-L6-v2
+
+# Directories read/written by the evaluation step.
+ARANDU_EVAL_OUTPUT_DIR=./evaluation
+ARANDU_EVAL_QA_DIR=./qa_dataset
+ARANDU_EVAL_KG_DIR=./knowledge_graphs
+ARANDU_EVAL_RESULTS_DIR=./results
+
+
+# =============================================================================
+# Results Versioning (ARANDU_RESULTS_*)
+# Pydantic: src/arandu/shared/config.py ResultsConfig
+# =============================================================================
+
+ARANDU_RESULTS_BASE_DIR=./results
+ARANDU_RESULTS_ENABLE_VERSIONING=true
+
+
+# =============================================================================
+# Transcription Quality (heuristic) (ARANDU_QUALITY_*)
+# Pydantic: src/arandu/shared/config.py TranscriptionQualityConfig
+# =============================================================================
+
+# Enable the heuristic quality stage that runs inline after transcription.
+ARANDU_QUALITY_ENABLED=true
+
+# Minimum overall score to mark a record is_valid=true.
+ARANDU_QUALITY_QUALITY_THRESHOLD=0.5
+
+# Expected language for script-match checks.
+ARANDU_QUALITY_EXPECTED_LANGUAGE=pt
+
+# Dimension weights (must sum to 1.0; enforced by validator).
+# ARANDU_QUALITY_SCRIPT_MATCH_WEIGHT=0.35
+# ARANDU_QUALITY_REPETITION_WEIGHT=0.30
+# ARANDU_QUALITY_SEGMENT_QUALITY_WEIGHT=0.20
+# ARANDU_QUALITY_CONTENT_DENSITY_WEIGHT=0.15
+
+# Per-dimension tuning knobs (defaults are calibrated for Portuguese Whisper runs).
+# ARANDU_QUALITY_MAX_NON_LATIN_RATIO=0.1
+# ARANDU_QUALITY_MAX_WORD_REPETITION_RATIO=0.15
+# ARANDU_QUALITY_MAX_PHRASE_REPETITION_COUNT=4
+# ARANDU_QUALITY_SUSPICIOUS_UNIFORM_INTERVALS=5
+# ARANDU_QUALITY_MIN_WORDS_PER_MINUTE=30.0
+# ARANDU_QUALITY_MAX_WORDS_PER_MINUTE=300.0
+# ARANDU_QUALITY_MAX_EMPTY_SEGMENT_RATIO=0.2
+# ARANDU_QUALITY_UNIFORM_INTERVAL_TOLERANCE=0.1
+
+
+# =============================================================================
+# SLURM / GPU / ROCm (set by job scripts, override only when needed)
+# =============================================================================
+
+# Project directory on PCAD (default: $HOME/etno-kgc-preprocessing).
 # PROJECT_DIR=/home/username/etno-kgc-preprocessing
 
-# Force CPU mode even if GPU is available
+# Force CPU mode from SLURM launcher.
 # USE_CPU=false
 
-# -----------------------------------------------------------------------------
-# GPU Settings (automatically detected, override if needed)
-# -----------------------------------------------------------------------------
-
-# Limit visible NVIDIA GPUs (comma-separated indices, e.g., "0,1")
+# Limit visible NVIDIA GPUs (comma-separated indices, e.g. "0,1").
 # NVIDIA_VISIBLE_DEVICES=all
 
-# CUDA device selection (usually set automatically by SLURM)
+# CUDA device selection (usually set automatically by SLURM).
 # CUDA_VISIBLE_DEVICES=
 
-# -----------------------------------------------------------------------------
-# AMD ROCm Settings (for sirius partition)
-# -----------------------------------------------------------------------------
-
-# Enable ROCm mode for AMD GPUs (set automatically by sirius.slurm)
+# AMD ROCm mode (set automatically by sirius.slurm).
 # USE_ROCM=false
 
-# Override GFX version for RDNA3 GPUs (RX 7900 series)
+# GFX override for RDNA3 GPUs (RX 7900 series).
 # HSA_OVERRIDE_GFX_VERSION=11.0.0

--- a/.env.example
+++ b/.env.example
@@ -52,8 +52,8 @@
 # =============================================================================
 
 # Whisper model. Options:
-#   openai/whisper-large-v3         highest accuracy, slowest
-#   openai/whisper-large-v3-turbo   good speed/accuracy balance (default)
+#   openai/whisper-large-v3         highest accuracy, slowest (code default in TranscriberConfig)
+#   openai/whisper-large-v3-turbo   good speed/accuracy balance (set explicitly below)
 #   distil-whisper/distil-large-v3  fastest, good on CPU
 ARANDU_MODEL_ID=openai/whisper-large-v3-turbo
 
@@ -97,9 +97,11 @@ ARANDU_RESULTS_DIR=./results
 # Directory containing credentials.json + token.json for Google Drive.
 ARANDU_CREDENTIALS_DIR=./
 
-# Override for individual credential file names (defaults are fine).
+# Override individual credential file names if needed (defaults are fine).
 # ARANDU_CREDENTIALS=credentials.json
 # ARANDU_TOKEN=token.json
+# Drive access defaults to the broader read/write scope
+# (https://www.googleapis.com/auth/drive). Override here for readonly access.
 # ARANDU_SCOPES=["https://www.googleapis.com/auth/drive.readonly"]
 
 # Hugging Face cache directory (persisted across runs).
@@ -158,8 +160,11 @@ ARANDU_CEP_MAX_SCAFFOLDING_PAIRS=10
 # Source metadata context (include speaker/source info in prompts).
 ARANDU_CEP_ENABLE_SOURCE_METADATA_CONTEXT=true
 
-# Validation (legacy weighted-score path — deprecated by the judge pipeline
-# but still read by the CEP generator for backwards compatibility).
+# Validation (legacy weighted-score path — superseded by the judge pipeline).
+# These fields are still defined on CEPConfig but are no longer consumed by
+# the CEP generator or judge; only the report layer
+# (src/arandu/report/{exporter,service}.py) reads them, for legacy datasets
+# that recorded a weighted-score threshold. Safe to leave at the defaults.
 ARANDU_CEP_VALIDATION_THRESHOLD=0.6
 # ARANDU_CEP_FAITHFULNESS_WEIGHT=0.4
 # ARANDU_CEP_BLOOM_CALIBRATION_WEIGHT=0.3


### PR DESCRIPTION
## Summary

Rewrites `.env.example` to cover every Pydantic settings class in the project (9 total), not just the original transcription-focused subset. Each domain has its own section with a pointer to the corresponding `BaseSettings` class in `src/`.

- All third-party credentials front-loaded: `OPENAI_API_KEY`, `ARANDU_LLM_BASE_URL`, HF tokens, GDrive auth bits.
- Includes a Gemini-via-OpenAI-compat recipe (`ARANDU_LLM_BASE_URL=https://generativelanguage.googleapis.com/v1beta/openai/`) — surfaced while wiring the LLM-criteria test path.
- Safe defaults uncommented; tuning knobs commented out so `cp .env.example .env` produces a working baseline without clutter.

Caught while preparing the LLM-criteria branch: only `TranscriberConfig` plus SLURM/GPU toggles were documented; everything under `ARANDU_QA_*`, `ARANDU_CEP_*`, `ARANDU_JUDGE_*`, `ARANDU_KG_*`, `ARANDU_EVAL_*`, `ARANDU_RESULTS_*`, `ARANDU_QUALITY_*` was missing.

Diff: +252 / −36 in `.env.example`.

## Test plan

- [ ] `cp .env.example .env` and run `arandu --help` — pipeline boots without `MissingEnvVar` errors on a clean checkout
- [ ] Spot-check a transcription pipeline run with the default `.env`: only required third-party credentials need to be filled in
- [ ] Verify the Gemini recipe (`OPENAI_API_KEY=<gemini-key>` + `ARANDU_LLM_BASE_URL=https://generativelanguage.googleapis.com/v1beta/openai/`) reaches the LLM judge

## Out of scope

`docs-site/src/content/docs/configuration.md` still references PR-#87-removed weighted-validation fields. That cleanup is tracked separately as `docs-site-update` and is intentionally not folded into this PR.