### PR TITLE
fix(kg): atlas-rag attribute-leak shims + Portuguese predicate relabel + KG analytics

### DIFF
--- a/docs/planning/ROADMAP.md
+++ b/docs/planning/ROADMAP.md
@@ -6,14 +6,26 @@
 
 ---
 
+## Status snapshot (2026-04-29)
+
+- **Phase A — Unblock KG**: substantially **done**. First Portuguese KG built (`test-kg-04`, 14,617 nodes / 60,318 edges, 95.7% in the largest weakly-connected component). Five distinct atlas-rag bug families surfaced and patched as on-disk shims; upstream issue [HKUST-KnowComp/AutoSchemaKG#45](https://github.com/HKUST-KnowComp/AutoSchemaKG/issues/45) **was answered the same day** with a three-layer fix on `release/v0.0.6` — most of our local shims become removable on the version bump (tracked in the dedicated `atlas-rag-v006-cleanup` session).
+- **Phase B — Judge Refactor**: structural work merged via PRs [#84](https://github.com/FredDsR/arandu/pull/84), [#87](https://github.com/FredDsR/arandu/pull/87); LLM criteria open in PR [#88](https://github.com/FredDsR/arandu/pull/88). Remaining: **manual QA-judge calibration audit** (43 rejected + 31 admitted pairs from 2,410 valid; ~6–8 h of work) → returns the remediation decision that closes Phase B.
+- **Phase C — RAG Evaluation**: not started; unblocks when Phase B closes.
+- **New gate added — C′: Fresh-Corpus Rerun**. New interviews were uploaded to the Drive corpus since `test-kg-04`; the thesis Results chapter must use a clean run on the updated corpus, so a single end-to-end run (transcription → CEP → QA → judge → KG → metrics → RAG eval) sits between Phase C and the Results chapter. Should run on atlas-rag 0.0.6 (post-shim-cleanup).
+- **Architectural pivot**: shard-and-merge KG migration was the only durable answer when leak-per-interruption was the failure mode. With upstream's three-layer fix in 0.0.6, monolithic runs become much safer — sharding is now a *nice-to-have* refactor rather than a forcing function.
+- **Timeline reality**: ~5 weeks were spent on the atlas-rag bug-hunt that the original Phase A plan didn't anticipate. The upstream fix bought back ~2 weeks of pressure. June 2026 (A–C done) is **tight but reachable** if Phase C scopes to BM25 vs GraphRAG only. December 2026 hard deadline remains comfortable.
+
+---
+
 ## Timeline Overview
 
-| Phase | Issue | When | Goal | Blocked By |
-|-------|-------|------|------|------------|
-| **A: Unblock KG** | [#78](https://github.com/FredDsR/etno-kgc-preprocessing/issues/78) | April (~2 weeks) | Get a complete GraphML from 309 transcriptions | Nothing |
-| **B: Judge Refactor** | [#79](https://github.com/FredDsR/etno-kgc-preprocessing/issues/79) | April–May (~3 weeks) | Composable multi-stage judge as shared module | Nothing (parallel with A) |
-| **C: RAG Evaluation** | [#80](https://github.com/FredDsR/etno-kgc-preprocessing/issues/80) | May–June (~4 weeks) | BM25 vs GraphRAG comparison using QA pairs | A + B |
-| **D: Writing & Human Eval** | — | Parallel, intensifies June–Aug | Dissertation chapters, specialist evaluation, articles | B for human eval protocol, C for results chapter |
+| Phase | Issue | When | Goal | Status / Blocked By |
+|-------|-------|------|------|---------------------|
+| **A: Unblock KG** | [#78](https://github.com/FredDsR/etno-kgc-preprocessing/issues/78) | April (actual: ~4 weeks) | Get a complete GraphML from the corpus | **Done** — `test-kg-04` graphml built; 5 atlas-rag bugs shimmed; upstream #45 acknowledged |
+| **B: Judge Refactor** | [#79](https://github.com/FredDsR/etno-kgc-preprocessing/issues/79) | April–May (actual: ~5 weeks) | Composable multi-stage judge as shared module | **Closing** — structural work merged; PR #88 (LLM criteria) open; QA calibration audit pending |
+| **C: RAG Evaluation** | [#80](https://github.com/FredDsR/etno-kgc-preprocessing/issues/80) | May–June (~4 weeks) | BM25 vs GraphRAG comparison using QA pairs | Blocked on B |
+| **C′: Fresh-Corpus Rerun** | — | After C (~1 week wall-time) | Clean end-to-end run on updated Drive corpus; produces canonical thesis dataset | Blocked on B + C |
+| **D: Writing & Human Eval** | — | Parallel, intensifies June–Aug | Dissertation chapters, specialist evaluation, articles | B for human eval protocol; C′ for results chapter |
 | **E: Polish** | — | July–Dec if needed | Bloom article, KG framework comparison, conferences | D for human eval data |
 
 ### Chronogram
@@ -25,20 +37,21 @@ gantt
     axisFormat %b %Y
 
     section Implementation
-    A · Unblock KG                        :task_a, 2026-04-01, 14d
-    B · Judge refactor                    :task_b, 2026-04-01, 23d
-    C · RAG evaluation + experiments      :task_c, after task_a task_b, 33d
+    A · Unblock KG                        :done, task_a, 2026-04-01, 28d
+    B · Judge refactor                    :active, task_b, 2026-04-01, 35d
+    C · RAG evaluation + experiments      :task_c, after task_b, 33d
+    C' · Fresh-corpus rerun               :task_cr, after task_c, 7d
 
     section Research
     Human evaluation with specialists     :task_h, after task_b, 55d
     Chapters 1-3                          :active, task_w, 2026-04-01, 75d
-    Results chapter                       :task_r, after task_c task_h, 30d
+    Results chapter                       :task_r, after task_cr task_h, 30d
 
     section Publication
     Articles + conferences                :task_p, after task_r, 60d
 
     section Milestones
-    June target (A-C done)                :milestone, 2026-06-30, 0d
+    June target (A–C done)                :milestone, 2026-06-30, 0d
     December hard deadline                :milestone, 2026-12-15, 0d
 ```
 
@@ -50,8 +63,10 @@ flowchart TD
         A["A: Unblock KG · #78"]
         B["B: Judge Refactor · #79"]
         C["C: RAG Evaluation · #80"]
+        CR["C′: Fresh-Corpus Rerun"]
         A --> C
         B --> C
+        C --> CR
     end
 
     subgraph human ["Human Evaluation"]
@@ -64,7 +79,7 @@ flowchart TD
     subgraph writing ["Writing"]
         D1["Chapters 1-3 (start immediately)"]
         D5["Evaluation results chapter"]
-        C --> D5
+        CR --> D5
         D4 --> D5
     end
 
@@ -74,7 +89,7 @@ flowchart TD
         E3["Conference submissions"]
         D4 --> E1
         D5 --> E1
-        C --> E2
+        CR --> E2
         E1 --> E3
     end
 ```
@@ -83,25 +98,33 @@ flowchart TD
 
 ## Phase A: Unblock KG
 
-**Goal**: Produce a complete Knowledge Graph from the 309 transcriptions.
+**Goal**: Produce a complete Knowledge Graph from the corpus.
 
-**Context**: `test-kg-02` got halfway through concept generation (6,256/13,383 nodes) before SLURM killed it. A language bug means concepts were generated with English prompts. No GraphML output exists.
+**Context (original)**: `test-kg-02` got halfway through concept generation (6,256/13,383 nodes) before SLURM killed it. A language bug meant concepts were generated with English prompts. No GraphML output existed.
+
+**Outcome (2026-04-29)**: `test-kg-04` produced a valid Portuguese GraphML — **14,617 nodes / 60,318 edges**, 95.7% in the largest weakly-connected component. The bug-hunt that paid for this took ~4 weeks (vs. 2 planned) and surfaced five distinct atlas-rag failure modes, all interruption-derived. Upstream answered our report the same day with a three-layer fix on `release/v0.0.6`, which retroactively obsoletes most of the local shims.
 
 ### Tasks
 
 1. ~~**Implement #77** — resumable concept generation wrapper + `language='pt'` bug fix~~ Done
-2. ~~**Patch atlas-rag `KeyError: 'id'`** — monkey-patch `csvs_to_temp_graphml()` in `atlas_backend.py` so edge endpoints get `id`/`type` attributes.~~ Done in PR [#85](https://github.com/FredDsR/arandu/pull/85).
-3. **File upstream issue** on [HKUST-KnowComp/AutoSchemaKG](https://github.com/HKUST-KnowComp/AutoSchemaKG) so the local patch can eventually be removed.
-4. **Run KG pipeline to completion** — resume from `test-kg-04` checkpoint with patch applied
-5. **Inspect output quality** — are Portuguese entities/relations sensible? Knowledge islands?
-6. **Analyze predicate explosion** — check for semantic duplicates in predicates (e.g., "lutar"/"combater"/"brigar" as separate predicates). AutoSchemaKG's conceptualization step should canonicalize these, but the language bug may have broken it. (Feedback: Joel, midway seminar)
+2. ~~**Patch atlas-rag `KeyError: 'id'`** — monkey-patch `csvs_to_temp_graphml()` in `atlas_backend.py` so edge endpoints get `id`/`type` attributes.~~ Done in PR [#85](https://github.com/FredDsR/arandu/pull/85). *(Note: this monkey-patch turned out to be dead code due to a Python `from … import` capture issue; the real fix is the disk-rewrite shims in PR #92, and now upstream 0.0.6.)*
+3. ~~**File upstream issue** on [HKUST-KnowComp/AutoSchemaKG](https://github.com/HKUST-KnowComp/AutoSchemaKG) so the local patch can eventually be removed.~~ Done — [issue #45](https://github.com/HKUST-KnowComp/AutoSchemaKG/issues/45). **Maintainer responded 2026-04-29 with a three-layer fix on `release/v0.0.6`.**
+4. ~~**Run KG pipeline to completion**~~ Done — `test-kg-04` graphml built locally on the partial cluster state after concept generation finished (job 780114, 21h 44m on tupi).
+5. **Inspect output quality** — Portuguese entities and relations look sensible at a structural level (95.7% giant component, moderate clustering 0.23, max degree 6,949 — power-law shape). Manual semantic inspection still pending; will land alongside the QA-judge calibration audit.
+6. **Analyze predicate explosion** — surfaced empirically: 1,957 unique predicates in `test-kg-04`. atlas-rag's hardcoded English `is participated by` accounted for 37.3% of `Relation`-typed edges; now relabeled to Portuguese `envolve` for `lang=pt` runs. Semantic canonicalization (e.g. `lutar`/`combater`/`brigar`) deferred to RAG-time normalization in Phase C. (Feedback: Joel, midway seminar)
 7. ~~**Close #75** — superseded by #77~~ Done
+8. **Land PR #92 (KG fixes bundle)** — three on-disk shims + predicate relabel + new analytics scripts. Decision (2026-04-29): merge as-is; cleanup of redundant shims happens in the dedicated `atlas-rag-v006-cleanup` workstream after upstream 0.0.6 releases.
 
 ### Success Criteria
 
-- A `corpus_graph.graphml` file exists with meaningful Portuguese entities and relations
-- Concept generation can survive SLURM timeouts and resume
-- Predicate space is reasonable (no massive explosion of semantically equivalent predicates)
+- ~~A `*.graphml` file exists with meaningful Portuguese entities and relations~~ ✓ `test-kg-04` graphml in hand (14,617 nodes / 60,318 edges).
+- ~~Concept generation can survive SLURM timeouts and resume~~ ✓ Resume helper landed; survived two crashes on `test-kg-04`.
+- ~~Predicate space is reasonable (no massive explosion of semantically equivalent predicates)~~ Partially — 1,957 unique predicates is large but the synthesized participation predicate dominates (37.3% of relations); semantic canonicalization deferred to Phase C.
+- **(new)** Analytics scripts (`kg_report.py`, `kg_structural_metrics.py`, `kg_relabel_predicate.py`) produce reproducible structural summaries.
+
+### Long-term architectural plan (shard-and-merge)
+
+Originally proposed as the only durable answer to atlas-rag's leak-per-interruption pattern: split the corpus into N partitions, run extraction independently on each, merge the GraphMLs offline. **Status (2026-04-29):** downgraded to *nice-to-have* now that upstream 0.0.6 ships three layers of orphan-node defense. Will be revisited if Phase C reveals partitioning advantages for retrieval, or if scaling to a much larger corpus.
 
 ---
 
@@ -150,15 +173,26 @@ Stage 3: Human-comparable evaluation (single LLM criterion)
 
 ### Tasks
 
-1. **Individual thresholds** — replace weighted avg with per-criterion minimums
-2. **Rename**: `JudgePipeline` → `JudgeStep`, create new `JudgePipeline` (multi-stage)
-3. **Move judge to `shared/judge/`** — cross-domain service like `llm_client`
-4. **#35: `generate_structured()` on LLMClient** — DRY across all LLM criteria
-5. **Extract heuristic validators as criteria** — transcription heuristics implement `JudgeCriterion`
-6. **New transcription criteria** — language drift, hallucination loop detection
-7. **Human-comparable QA criterion** — designed backwards from annotation protocol
-8. **Remove `--validate` flag** from `generate-cep-qa` (clean break, no backwards compat)
-9. **Standalone CLI**: `arandu judge <domain> <input>`
+1. ~~**Individual thresholds** — replace weighted avg with per-criterion minimums~~ Done (PR [#84](https://github.com/FredDsR/arandu/pull/84))
+2. ~~**Rename**: `JudgePipeline` → `JudgeStep`, create new `JudgePipeline` (multi-stage)~~ Done (PR [#84](https://github.com/FredDsR/arandu/pull/84))
+3. ~~**Move judge to `shared/judge/`**~~ Done (PR [#84](https://github.com/FredDsR/arandu/pull/84))
+4. ~~**#35: `generate_structured()` on LLMClient**~~ Done — `JudgeResultMixin` extracts the pattern (commit `6b142c2`)
+5. ~~**Extract heuristic validators as criteria**~~ Done (PR [#87](https://github.com/FredDsR/arandu/pull/87))
+6. **New transcription criteria** — `language_drift` and `hallucination_loop` open in PR [#88](https://github.com/FredDsR/arandu/pull/88)
+7. **Human-comparable QA criterion** — **deferred to Phase D** (depends on the annotation protocol design)
+8. ~~**Remove `--validate` flag** from `generate-cep-qa`~~ Done (PR [#87](https://github.com/FredDsR/arandu/pull/87))
+9. ~~**Standalone CLI**: `arandu judge-transcription` / `arandu judge-qa`~~ Done (PR [#87](https://github.com/FredDsR/arandu/pull/87))
+
+### Calibration evidence (added since the original roadmap)
+
+A judge isn't usable until we know how often its decisions agree with a human reading. Phase B now includes a calibration evidence framework that didn't exist when the roadmap was written:
+
+- **Dual notebooks** (transcription + QA) covering per-criterion distributions, inter-criterion correlation, stage attribution, failure co-occurrence, and threshold proximity.
+- **Audit protocol**: dual-class proportional sampling at 30% of rejected + 15% of admitted, sample sizes set so Clopper-Pearson 95% CIs land inside ±10pp of the observed rate.
+- **QA-side sample drawn 2026-04-28**: 43 rejected + 31 admitted pairs from 2,410 valid (population pulled from `test-judge-01`, seed=42). Manual audit pending (~6–8 h of work) — its remediation decision is the gate that closes Phase B.
+- **Transcription-side audit complete**; silence-filler gap closed in `e1a091c`.
+
+Tracked in the dedicated `judge-calibration-notebooks` work session.
 
 ### Key Decisions
 
@@ -207,6 +241,33 @@ Generate a subset of questions whose answers are **not** present in the KG, to t
 6. Implement `arandu judge answers` CLI command (reuses Phase B judge)
 7. Run experiments, collect results
 8. Analyze: separate graph quality limitations from retrieval tool limitations (Feedback: Joel, midway seminar)
+
+---
+
+## Phase C′: Fresh-Corpus Rerun (gate before Results chapter)
+
+**Goal**: Single end-to-end run on the updated Drive corpus, producing the canonical thesis dataset.
+
+**Why this exists (added 2026-04-29)**: New interviews were uploaded to the Drive source corpus since `test-kg-04`. The thesis Results chapter must reflect the *current* dataset, not a mid-2026 snapshot. A fresh run also eliminates artifact contamination (stale CEPs, partial concept-gen state, pre-relabel graphmls, pre-LLM-criteria judge verdicts). The numbers from `test-kg-04` are valid for *describing* the pipeline (bug-hunt narrative, structural metrics, calibration evidence) but **must not** appear in the Results chapter.
+
+### Tasks
+
+1. **Audit new interviews** — survey the Drive: count, languages, durations, communities, recording-setup differences vs. `test-kg-04` corpus. Informs partition strategy and run-time estimate.
+2. **Pin the dataset via manifest-in-repo** — commit `data/manifest_<run-id>.json` with file_id + md5 + modifiedTime per input. Drive remains the byte source; the repo is the canonical record of "what was in the dataset". Decision rationale: avoids storing interview audio in the repo (size + GDPR), lets us prove the dataset retroactively without depending on Drive folder organization.
+3. **Bump atlas-rag to 0.0.6** — strip the redundant local shims; keep only the predicate relabel and the analytics scripts. Tracked in the `atlas-rag-v006-cleanup` work session.
+4. **Run end-to-end on the updated corpus**: transcription → CEP → QA → judge (post-PR-#88) → KG (atlas-rag 0.0.6) → structural metrics → RAG evaluation.
+5. **Produce the run's metrics package** — graphml, judge verdicts, RAG eval scores, structural metrics output — ready to drop into the Results chapter.
+
+### Pre-requisites
+
+- Phase B closed (calibration audit verdict applied to judge config).
+- Phase C closed (RAG evaluation pipeline operational).
+- atlas-rag 0.0.6 released (or pinned via the `release/v0.0.6` branch).
+- Drive manifest committed.
+
+### Estimate
+
+~1 week wall-time on atlas-rag 0.0.6 monolithic. Transcription is the largest single block; concept generation is much faster on 0.0.6 than the test-kg-04 baseline because the resume path no longer re-introduces leaks.
 
 ---
 
@@ -368,14 +429,17 @@ Feedback from Luciana and Joel incorporated into the roadmap:
 
 ---
 
-## Open Issues
+## Open Issues / PRs
 
-| # | Title | Phase | Priority |
-|---|-------|-------|----------|
-| [#77](https://github.com/FredDsR/etno-kgc-preprocessing/issues/77) | Resumable concept generation + language bug | A | Critical |
-| [#35](https://github.com/FredDsR/etno-kgc-preprocessing/issues/35) | Extract `generate_structured()` to LLMClient | B | High |
+| Ref | Title | Phase | Status |
+|---|---|---|---|
+| ~~[#77](https://github.com/FredDsR/etno-kgc-preprocessing/issues/77)~~ | ~~Resumable concept generation + language bug~~ | A | Closed (PR #81) |
+| ~~[#35](https://github.com/FredDsR/etno-kgc-preprocessing/issues/35)~~ | ~~Extract `generate_structured()` to LLMClient~~ | B | Closed (folded into `JudgeResultMixin`) |
 | ~~[#75](https://github.com/FredDsR/etno-kgc-preprocessing/issues/75)~~ | ~~Concept gen resume~~ | — | Closed (superseded by #77) |
+| [PR #88](https://github.com/FredDsR/arandu/pull/88) | Judge LLM criteria (`language_drift`, `hallucination_loop`) | B | Open — ready for merge |
+| [PR #92](https://github.com/FredDsR/arandu/pull/92) | KG fixes bundle (3 shims + predicate relabel + analytics) | A | Open — to merge as-is, then strip in `atlas-rag-v006-cleanup` |
+| [HKUST-KnowComp/AutoSchemaKG#45](https://github.com/HKUST-KnowComp/AutoSchemaKG/issues/45) | Upstream attribute-leak fix | A | **Answered + fixed on `release/v0.0.6`** (2026-04-29) |
 
 ---
 
-**Last Updated**: 2026-03-23
+**Last Updated**: 2026-04-29

--- a/scripts/kg_relabel_predicate.py
+++ b/scripts/kg_relabel_predicate.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Relabel atlas-rag's hardcoded event-participation predicate in a GraphML.
+
+Equivalent to the in-pipeline sweep
+``AtlasRagConstructor._relabel_synthesized_event_participation`` but
+applied directly to an already-built GraphML file. Use this on graphs
+produced before the in-pipeline relabel landed.
+
+Usage:
+    uv run python scripts/kg_relabel_predicate.py <graphml> [--lang pt] [--dry-run]
+
+The original file is moved to ``<graphml>.bak`` before the rewrite. Pass
+``--dry-run`` to count occurrences without modifying anything.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import sys
+from pathlib import Path
+
+import networkx as nx
+from rich.console import Console
+
+from arandu.kg.atlas_backend import (
+    SYNTHESIZED_EVENT_PARTICIPATION_PREDICATE_BY_LANG,
+    SYNTHESIZED_EVENT_PARTICIPATION_PREDICATE_EN,
+)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("graphml", type=Path, help="Path to the GraphML file")
+    parser.add_argument(
+        "--lang",
+        default="pt",
+        help=(
+            "Target language whose predicate replaces 'is participated by'. "
+            f"Available: {sorted(SYNTHESIZED_EVENT_PARTICIPATION_PREDICATE_BY_LANG)}."
+        ),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Count matches without rewriting the file",
+    )
+    args = parser.parse_args()
+
+    console = Console()
+
+    target = SYNTHESIZED_EVENT_PARTICIPATION_PREDICATE_BY_LANG.get(args.lang)
+    if not target:
+        console.print(
+            f"[red]No predicate mapping for language '{args.lang}'. "
+            f"Available: {sorted(SYNTHESIZED_EVENT_PARTICIPATION_PREDICATE_BY_LANG)}[/red]"
+        )
+        sys.exit(2)
+
+    if not args.graphml.exists():
+        console.print(f"[red]GraphML not found: {args.graphml}[/red]")
+        sys.exit(2)
+
+    console.print(f"Loading [bold]{args.graphml}[/bold] ...")
+    g: nx.DiGraph = nx.read_graphml(str(args.graphml))
+
+    matches = 0
+    for _, _, data in g.edges(data=True):
+        if data.get("relation") == SYNTHESIZED_EVENT_PARTICIPATION_PREDICATE_EN:
+            if not args.dry_run:
+                data["relation"] = target
+            matches += 1
+
+    console.print(
+        f"Found [bold]{matches:,}[/bold] edges with relation "
+        f"'{SYNTHESIZED_EVENT_PARTICIPATION_PREDICATE_EN}' → '{target}'"
+    )
+
+    if args.dry_run:
+        console.print("[yellow]Dry-run: file not modified[/yellow]")
+        return
+
+    if matches == 0:
+        console.print("[green]Nothing to rewrite — file untouched[/green]")
+        return
+
+    backup = args.graphml.with_suffix(args.graphml.suffix + ".bak")
+    console.print(f"Backing up to [bold]{backup}[/bold]")
+    shutil.copy2(args.graphml, backup)
+
+    console.print("Writing rewritten GraphML ...")
+    nx.write_graphml(g, str(args.graphml), infer_numeric_types=True)
+    console.print(f"[green]Done. {matches:,} edges relabeled.[/green]")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/kg_structural_metrics.py
+++ b/scripts/kg_structural_metrics.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Compute structural graph metrics from a knowledge-graph GraphML file.
+
+Loads the GraphML with NetworkX and reports nodes/edges, density,
+degree distribution, weakly/strongly connected components, clustering
+coefficients, and (with --full) shortest-path metrics on the largest
+weakly connected component.
+
+Usage:
+    uv run python scripts/kg_structural_metrics.py <graphml_path> [--full] [--json]
+
+Examples:
+    uv run python scripts/kg_structural_metrics.py \\
+        results/test-kg-04/kg/outputs/atlas_output/kg_graphml/transcriptions.json_graph.graphml
+
+Notes:
+    - The graph is directed. Density / strongly-connected use the
+      directed graph; clustering and shortest-path metrics use the
+      undirected projection.
+    - --full enables avg shortest path + diameter on the largest WCC,
+      which is O(V*E) per node and slow on dense graphs (~minutes for
+      ~10k nodes).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import sys
+import time
+from pathlib import Path
+
+import networkx as nx
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+
+
+def _component_stats(g: nx.DiGraph) -> dict[str, int | float]:
+    wcc = list(nx.weakly_connected_components(g))
+    scc = list(nx.strongly_connected_components(g))
+    largest_wcc = max(wcc, key=len) if wcc else set()
+    largest_scc = max(scc, key=len) if scc else set()
+    return {
+        "weakly_connected_components": len(wcc),
+        "largest_wcc_size": len(largest_wcc),
+        "largest_wcc_fraction": len(largest_wcc) / g.number_of_nodes()
+        if g.number_of_nodes()
+        else 0.0,
+        "strongly_connected_components": len(scc),
+        "largest_scc_size": len(largest_scc),
+    }
+
+
+def _degree_stats(g: nx.DiGraph) -> dict[str, float]:
+    in_degs = [d for _, d in g.in_degree()]
+    out_degs = [d for _, d in g.out_degree()]
+    total_degs = [d for _, d in g.degree()]
+    return {
+        "avg_in_degree": statistics.fmean(in_degs) if in_degs else 0.0,
+        "avg_out_degree": statistics.fmean(out_degs) if out_degs else 0.0,
+        "avg_total_degree": statistics.fmean(total_degs) if total_degs else 0.0,
+        "median_total_degree": float(statistics.median(total_degs)) if total_degs else 0.0,
+        "stdev_total_degree": statistics.pstdev(total_degs) if total_degs else 0.0,
+        "max_total_degree": float(max(total_degs)) if total_degs else 0.0,
+        "min_total_degree": float(min(total_degs)) if total_degs else 0.0,
+    }
+
+
+def _clustering_stats(g_undir: nx.Graph) -> dict[str, float]:
+    return {
+        "transitivity": nx.transitivity(g_undir),
+        "average_clustering": nx.average_clustering(g_undir),
+    }
+
+
+def _shortest_path_stats_largest_wcc(g: nx.DiGraph) -> dict[str, float]:
+    wcc = max(nx.weakly_connected_components(g), key=len)
+    sub = g.subgraph(wcc).to_undirected()
+    eccentricities = nx.eccentricity(sub)
+    diameter = max(eccentricities.values())
+    avg_shortest_path = nx.average_shortest_path_length(sub)
+    return {
+        "largest_wcc_diameter": float(diameter),
+        "largest_wcc_avg_shortest_path": avg_shortest_path,
+    }
+
+
+def compute_metrics(graphml: Path, full: bool) -> dict:
+    t0 = time.perf_counter()
+    g: nx.DiGraph = nx.read_graphml(str(graphml))
+    load_seconds = time.perf_counter() - t0
+
+    n = g.number_of_nodes()
+    e = g.number_of_edges()
+    metrics: dict = {
+        "graphml_path": str(graphml),
+        "graphml_size_mb": round(graphml.stat().st_size / (1024 * 1024), 2),
+        "nodes": n,
+        "edges": e,
+        "is_directed": g.is_directed(),
+        "density": nx.density(g),
+        "load_seconds": round(load_seconds, 2),
+    }
+    metrics.update(_component_stats(g))
+    metrics.update(_degree_stats(g))
+    metrics.update(_clustering_stats(g.to_undirected()))
+
+    if full:
+        t0 = time.perf_counter()
+        metrics.update(_shortest_path_stats_largest_wcc(g))
+        metrics["shortest_path_seconds"] = round(time.perf_counter() - t0, 2)
+
+    return metrics
+
+
+def render_table(metrics: dict, console: Console) -> None:
+    console.print(
+        Panel.fit(
+            f"[bold]{Path(metrics['graphml_path']).name}[/bold]\n"
+            f"{metrics['graphml_size_mb']} MB | "
+            f"loaded in {metrics['load_seconds']}s",
+            title="Structural Metrics",
+        )
+    )
+
+    basic = Table(title="Basic", show_header=False)
+    basic.add_column(style="bold")
+    basic.add_column(justify="right")
+    basic.add_row("Nodes", f"{metrics['nodes']:,}")
+    basic.add_row("Edges", f"{metrics['edges']:,}")
+    basic.add_row("Directed", str(metrics["is_directed"]))
+    basic.add_row("Density", f"{metrics['density']:.6f}")
+    console.print(basic)
+
+    comp = Table(title="Components", show_header=False)
+    comp.add_column(style="bold")
+    comp.add_column(justify="right")
+    comp.add_row("Weakly connected components", f"{metrics['weakly_connected_components']:,}")
+    comp.add_row(
+        "Largest WCC size",
+        f"{metrics['largest_wcc_size']:,} ({metrics['largest_wcc_fraction'] * 100:.1f}%)",
+    )
+    comp.add_row("Strongly connected components", f"{metrics['strongly_connected_components']:,}")
+    comp.add_row("Largest SCC size", f"{metrics['largest_scc_size']:,}")
+    console.print(comp)
+
+    deg = Table(title="Degree distribution", show_header=False)
+    deg.add_column(style="bold")
+    deg.add_column(justify="right")
+    deg.add_row("Avg in-degree", f"{metrics['avg_in_degree']:.2f}")
+    deg.add_row("Avg out-degree", f"{metrics['avg_out_degree']:.2f}")
+    deg.add_row("Avg total degree", f"{metrics['avg_total_degree']:.2f}")
+    deg.add_row("Median total degree", f"{metrics['median_total_degree']:.2f}")
+    deg.add_row("Stdev total degree", f"{metrics['stdev_total_degree']:.2f}")
+    deg.add_row("Max total degree", f"{metrics['max_total_degree']:.0f}")
+    deg.add_row("Min total degree", f"{metrics['min_total_degree']:.0f}")
+    console.print(deg)
+
+    clu = Table(title="Clustering (undirected projection)", show_header=False)
+    clu.add_column(style="bold")
+    clu.add_column(justify="right")
+    clu.add_row("Transitivity (global)", f"{metrics['transitivity']:.4f}")
+    clu.add_row("Average clustering", f"{metrics['average_clustering']:.4f}")
+    console.print(clu)
+
+    if "largest_wcc_diameter" in metrics:
+        sp = Table(title="Shortest paths (largest WCC, undirected)", show_header=False)
+        sp.add_column(style="bold")
+        sp.add_column(justify="right")
+        sp.add_row("Diameter", f"{metrics['largest_wcc_diameter']:.0f}")
+        sp.add_row("Avg shortest path", f"{metrics['largest_wcc_avg_shortest_path']:.2f}")
+        sp.add_row("Compute time", f"{metrics['shortest_path_seconds']}s")
+        console.print(sp)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("graphml", type=Path, help="Path to the GraphML file")
+    parser.add_argument(
+        "--full",
+        action="store_true",
+        help="Also compute diameter + avg shortest path on the largest WCC (slow)",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit JSON instead of Rich tables")
+    args = parser.parse_args()
+
+    console = Console()
+    if not args.graphml.exists():
+        console.print(f"[red]GraphML not found: {args.graphml}[/red]")
+        sys.exit(2)
+
+    metrics = compute_metrics(args.graphml, full=args.full)
+
+    if args.json:
+        console.print_json(json.dumps(metrics))
+    else:
+        render_table(metrics, console)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/kg_structural_metrics.py
+++ b/scripts/kg_structural_metrics.py
@@ -36,6 +36,19 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
 
+from arandu.kg.atlas_backend import (
+    SYNTHESIZED_EVENT_PARTICIPATION_PREDICATE_BY_LANG,
+    SYNTHESIZED_EVENT_PARTICIPATION_PREDICATE_EN,
+)
+
+# All known forms of the synthesized event-participation predicate, across
+# the languages we relabel. Used to split edges into atlas-rag-synthesized
+# vs LLM-extracted relations regardless of which language the run used.
+SYNTHESIZED_PARTICIPATION_PREDICATES: frozenset[str] = frozenset(
+    {SYNTHESIZED_EVENT_PARTICIPATION_PREDICATE_EN}
+    | set(SYNTHESIZED_EVENT_PARTICIPATION_PREDICATE_BY_LANG.values())
+)
+
 
 def _component_stats(g: nx.DiGraph) -> dict[str, int | float]:
     wcc = list(nx.weakly_connected_components(g))
@@ -75,6 +88,49 @@ def _clustering_stats(g_undir: nx.Graph) -> dict[str, float]:
     }
 
 
+def _edge_type_breakdown(g: nx.DiGraph) -> dict[str, int]:
+    """Count edges by atlas-rag's ``type`` attribute.
+
+    Atlas-rag tags edges with one of: ``Relation`` (entity↔entity / event↔
+    entity triples), ``Source`` (text-mention edges), ``Concept`` (concept
+    linking). Unknown types get bucketed under ``other``.
+    """
+    counts = {"Relation": 0, "Source": 0, "Concept": 0, "other": 0}
+    for _, _, data in g.edges(data=True):
+        t = data.get("type")
+        counts[t if t in counts else "other"] += 1
+    return counts
+
+
+def _relation_split_stats(g: nx.DiGraph) -> dict[str, int | float]:
+    """Within ``type=Relation`` edges, split synthesized vs LLM-extracted.
+
+    Atlas-rag synthesizes ``(Event, "is participated by", Entity)`` edges
+    from the LLM's event_entity_relation_dict (no predicate field). Every
+    other Relation-typed edge carries an LLM-chosen predicate. Text and
+    Concept edges are excluded — they're structural, not semantic.
+    """
+    synthesized = 0
+    extracted = 0
+    for _, _, data in g.edges(data=True):
+        if data.get("type") != "Relation":
+            continue
+        rel = data.get("relation")
+        if rel in SYNTHESIZED_PARTICIPATION_PREDICATES:
+            synthesized += 1
+        else:
+            extracted += 1
+
+    total = synthesized + extracted
+    return {
+        "synthesized_participation_edges": synthesized,
+        "extracted_relation_edges": extracted,
+        "relation_edges_total": total,
+        "synthesized_share_of_relations": synthesized / total if total else 0.0,
+        "extracted_share_of_relations": extracted / total if total else 0.0,
+    }
+
+
 def _shortest_path_stats_largest_wcc(g: nx.DiGraph) -> dict[str, float]:
     wcc = max(nx.weakly_connected_components(g), key=len)
     sub = g.subgraph(wcc).to_undirected()
@@ -106,6 +162,8 @@ def compute_metrics(graphml: Path, full: bool) -> dict:
     metrics.update(_component_stats(g))
     metrics.update(_degree_stats(g))
     metrics.update(_clustering_stats(g.to_undirected()))
+    metrics["edges_by_type"] = _edge_type_breakdown(g)
+    metrics.update(_relation_split_stats(g))
 
     if full:
         t0 = time.perf_counter()
@@ -164,6 +222,41 @@ def render_table(metrics: dict, console: Console) -> None:
     clu.add_row("Transitivity (global)", f"{metrics['transitivity']:.4f}")
     clu.add_row("Average clustering", f"{metrics['average_clustering']:.4f}")
     console.print(clu)
+
+    edge_types = metrics["edges_by_type"]
+    total_edges = metrics["edges"]
+    et = Table(title="Edges by type")
+    et.add_column("Type", style="bold")
+    et.add_column("Edges", justify="right")
+    et.add_column("Share", justify="right")
+    for label, key in (
+        ("Relation (triples)", "Relation"),
+        ("Source (text mention)", "Source"),
+        ("Concept (concept link)", "Concept"),
+        ("other", "other"),
+    ):
+        count = edge_types[key]
+        if count or key != "other":
+            share = (count / total_edges * 100) if total_edges else 0.0
+            et.add_row(label, f"{count:,}", f"{share:.1f}%")
+    console.print(et)
+
+    if metrics["relation_edges_total"]:
+        rel = Table(title="Within Relation edges: synthesized vs LLM-extracted")
+        rel.add_column("Source", style="bold")
+        rel.add_column("Edges", justify="right")
+        rel.add_column("Share of Relation", justify="right")
+        rel.add_row(
+            "atlas-rag synthesized",
+            f"{metrics['synthesized_participation_edges']:,}",
+            f"{metrics['synthesized_share_of_relations'] * 100:.1f}%",
+        )
+        rel.add_row(
+            "LLM extracted",
+            f"{metrics['extracted_relation_edges']:,}",
+            f"{metrics['extracted_share_of_relations'] * 100:.1f}%",
+        )
+        console.print(rel)
 
     if "largest_wcc_diameter" in metrics:
         sp = Table(title="Shortest paths (largest WCC, undirected)", show_header=False)

--- a/src/arandu/kg/atlas_backend.py
+++ b/src/arandu/kg/atlas_backend.py
@@ -1030,14 +1030,27 @@ class AtlasRagConstructor:
         Returns:
             Number of orphan endpoints backfilled into the nodes CSV.
         """
-        triples_dir = output_dir / "atlas_output" / "triples_csv"
+        atlas_output = output_dir / "atlas_output"
+        triples_dir = atlas_output / "triples_csv"
+        # When include_concept=True, atlas-rag passes the *_with_concept.csv
+        # from concept_csv/ as triple_edge_file. Otherwise it falls back to
+        # the *_without_emb.csv from triples_csv/. Mirror that selection so
+        # the sweep targets exactly the file csvs_to_graphml will read.
+        if self._opts["include_concept"]:
+            edges_dir = atlas_output / "concept_csv"
+            edges_pattern = "triple_edges_*_from_json_with_concept.csv"
+        else:
+            edges_dir = triples_dir
+            edges_pattern = "triple_edges_*_from_json_without_emb.csv"
+
         nodes_csvs = list(triples_dir.glob("triple_nodes_*_from_json_without_emb.csv"))
-        edges_csvs = list(triples_dir.glob("triple_edges_*_from_json_with_concept.csv"))
+        edges_csvs = list(edges_dir.glob(edges_pattern))
         if not nodes_csvs or not edges_csvs:
             logger.debug(
-                "No triple_nodes/triple_edges _without_emb / _with_concept CSV in %s — "
-                "skipping endpoint coverage sweep",
+                "No triple_nodes (%s) / triple_edges (%s/%s) — skipping endpoint coverage sweep",
                 triples_dir,
+                edges_dir,
+                edges_pattern,
             )
             return 0
 

--- a/src/arandu/kg/atlas_backend.py
+++ b/src/arandu/kg/atlas_backend.py
@@ -610,6 +610,16 @@ class AtlasRagConstructor:
             self._run_concept_generation_with_resume(extractor, output_dir)
             extractor.create_concept_csv()
 
+        # Backfill triple_nodes CSV with any endpoint referenced by
+        # triple_edges but absent from triple_nodes. atlas-rag's
+        # ``csvs_to_graphml`` calls ``g.add_edge`` on every edge endpoint;
+        # missing endpoints become attributeless nodes that crash line 185
+        # of ``csv_to_graphml.py`` (``g.nodes[node_id]['type']``). Filed
+        # upstream as the same family of ID-consistency bugs in
+        # HKUST-KnowComp/AutoSchemaKG#45 — interruption-derived per the
+        # authors, so the local sweep is the maintained fix.
+        self._ensure_triple_node_csv_covers_endpoints(output_dir)
+
         logger.info("Converting to GraphML...")
         extractor.convert_to_graphml()
         logger.info("Atlas-rag pipeline completed")
@@ -996,6 +1006,84 @@ class AtlasRagConstructor:
             )
 
         return patched
+
+    def _ensure_triple_node_csv_covers_endpoints(self, output_dir: Path) -> int:
+        """Backfill triple_nodes CSV with edge endpoints that lack a row.
+
+        atlas-rag's ``csvs_to_graphml`` reads
+        ``triple_nodes_<pat>_from_json_without_emb.csv`` to seed the graph
+        with attributed nodes, then iterates
+        ``triple_edges_<pat>_from_json_with_concept.csv`` and calls
+        ``g.add_edge(start_id, end_id, ...)``. Any endpoint absent from the
+        nodes CSV becomes an attributeless node (NetworkX implicitly
+        creates it) and crashes line 185 of ``csv_to_graphml.py`` —
+        ``if g.nodes[node_id]['type'] in ['triple', 'concept']`` raises
+        ``KeyError: 'type'``.
+
+        This sweep appends a row (``name:ID=<endpoint>``, ``type=entity``,
+        empty other columns) for every endpoint missing from the nodes
+        CSV, so the graph build sees a well-formed input.
+
+        Args:
+            output_dir: Pipeline output directory (parent of ``atlas_output``).
+
+        Returns:
+            Number of orphan endpoints backfilled into the nodes CSV.
+        """
+        triples_dir = output_dir / "atlas_output" / "triples_csv"
+        nodes_csvs = list(triples_dir.glob("triple_nodes_*_from_json_without_emb.csv"))
+        edges_csvs = list(triples_dir.glob("triple_edges_*_from_json_with_concept.csv"))
+        if not nodes_csvs or not edges_csvs:
+            logger.debug(
+                "No triple_nodes/triple_edges _without_emb / _with_concept CSV in %s — "
+                "skipping endpoint coverage sweep",
+                triples_dir,
+            )
+            return 0
+
+        nodes_csv = nodes_csvs[0]
+        edges_csv = edges_csvs[0]
+
+        try:
+            with nodes_csv.open(newline="") as f:
+                reader = csv.DictReader(f)
+                node_header = reader.fieldnames or []
+                existing_names = {row["name:ID"] for row in reader if row.get("name:ID")}
+
+            endpoint_names: set[str] = set()
+            with edges_csv.open(newline="") as f:
+                reader = csv.DictReader(f)
+                for row in reader:
+                    if row.get(":START_ID"):
+                        endpoint_names.add(row[":START_ID"])
+                    if row.get(":END_ID"):
+                        endpoint_names.add(row[":END_ID"])
+        except (OSError, csv.Error, KeyError) as exc:
+            logger.warning(
+                "Failed to read triple_*.csv for endpoint coverage sweep (%s); skipping",
+                exc,
+            )
+            return 0
+
+        orphans = endpoint_names - existing_names
+        if not orphans:
+            return 0
+
+        with nodes_csv.open("a", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=node_header)
+            for name in sorted(orphans):
+                row = dict.fromkeys(node_header, "")
+                row["name:ID"] = name
+                if "type" in node_header:
+                    row["type"] = "entity"
+                writer.writerow(row)
+
+        logger.warning(
+            "Backfilled %d orphan endpoint(s) into %s with type=entity",
+            len(orphans),
+            nodes_csv.name,
+        )
+        return len(orphans)
 
     def _restore_and_finalize(
         self,

--- a/src/arandu/kg/atlas_backend.py
+++ b/src/arandu/kg/atlas_backend.py
@@ -683,6 +683,14 @@ class AtlasRagConstructor:
         # Step 6: Trim input CSV to exclude completed nodes
         remaining = self._trim_input_csv(missing_csv, completed_nodes)
 
+        # Step 6b: Drop phantom rows whose node ID isn't anywhere in the
+        # triple_nodes / triple_edges sources. atlas-rag's
+        # ``generate_concept`` would crash with NetworkXError on these rows
+        # because the temp KG is built from those CSVs and the phantom node
+        # never enters the graph. Filed upstream as the second of the
+        # ID-consistency bugs in HKUST-KnowComp/AutoSchemaKG.
+        remaining = self._drop_phantom_missing_concepts(missing_csv, triples_dir)
+
         # Step 7: If all nodes are done, skip generation
         if remaining == 0:
             logger.info("All concept nodes already completed, skipping generation")
@@ -829,6 +837,90 @@ class AtlasRagConstructor:
                 len(all_rows) - 1 - len(data_rows),
             )
         return len(data_rows)
+
+    def _drop_phantom_missing_concepts(self, csv_path: Path, triples_dir: Path) -> int:
+        """Drop missing-concepts rows whose node ID isn't in the temp-KG sources.
+
+        atlas-rag writes node IDs to ``missing_concepts*_from_json.csv`` that
+        sometimes don't appear in either ``triple_nodes*.csv`` or
+        ``triple_edges*.csv``. When ``generate_concept`` later calls
+        ``temp_kg.predecessors(node_id)`` on such a phantom, NetworkX raises
+        ``NetworkXError: The node ... is not in the digraph``. This helper
+        prefilters the CSV to drop rows whose column-0 value is absent from
+        the union of ``name:ID`` (triple_nodes) and ``:START_ID`` /
+        ``:END_ID`` (triple_edges).
+
+        If the source CSVs cannot be read, returns the unfiltered row count
+        and lets the downstream pipeline surface any actual issue.
+
+        Args:
+            csv_path: Path to the missing_concepts CSV (will be rewritten in
+                place when phantom rows are detected).
+            triples_dir: Directory containing ``triple_nodes*.csv`` and
+                ``triple_edges*.csv`` produced by atlas-rag's
+                ``convert_json_to_csv``.
+
+        Returns:
+            Number of remaining data rows after the prefilter.
+        """
+        valid_names: set[str] = set()
+        nodes_csvs = list(triples_dir.glob("triple_nodes*.csv"))
+        edges_csvs = list(triples_dir.glob("triple_edges*.csv"))
+        if not nodes_csvs and not edges_csvs:
+            logger.debug(
+                "No triple_nodes/triple_edges CSVs in %s — skipping phantom prefilter",
+                triples_dir,
+            )
+            with csv_path.open(newline="") as f:
+                rows = list(csv.reader(f))
+            return max(0, len(rows) - 1)
+
+        try:
+            for nodes_file in nodes_csvs:
+                with nodes_file.open(newline="") as f:
+                    reader = csv.DictReader(f)
+                    for row in reader:
+                        if row.get("name:ID"):
+                            valid_names.add(row["name:ID"])
+            for edges_file in edges_csvs:
+                with edges_file.open(newline="") as f:
+                    reader = csv.DictReader(f)
+                    for row in reader:
+                        if row.get(":START_ID"):
+                            valid_names.add(row[":START_ID"])
+                        if row.get(":END_ID"):
+                            valid_names.add(row[":END_ID"])
+        except (OSError, csv.Error, KeyError) as exc:
+            logger.warning(
+                "Failed to read triple_*.csv for phantom prefilter (%s); skipping",
+                exc,
+            )
+            with csv_path.open(newline="") as f:
+                rows = list(csv.reader(f))
+            return max(0, len(rows) - 1)
+
+        with csv_path.open(newline="") as f:
+            all_rows = list(csv.reader(f))
+
+        if not all_rows:
+            return 0
+
+        header = all_rows[0]
+        kept = [row for row in all_rows[1:] if row and row[0] in valid_names]
+        dropped = len(all_rows) - 1 - len(kept)
+
+        if dropped:
+            with csv_path.open("w", newline="") as f:
+                writer = csv.writer(f)
+                writer.writerow(header)
+                writer.writerows(kept)
+            logger.warning(
+                "Dropped %d phantom row(s) from %s (node IDs absent from triple_*.csv)",
+                dropped,
+                csv_path.name,
+            )
+
+        return len(kept)
 
     def _restore_and_finalize(
         self,

--- a/src/arandu/kg/atlas_backend.py
+++ b/src/arandu/kg/atlas_backend.py
@@ -703,6 +703,15 @@ class AtlasRagConstructor:
                 shard_file.write_text("")
             return
 
+        # Step 7b: Backfill missing id/type attributes on temp_kg nodes.
+        # atlas-rag's ``generate_concept`` walks the graph via ``predecessors``
+        # / ``successors`` and reads ``temp_kg.nodes[neighbor]['id']`` (line
+        # 212 of concept_generation.py). Some atlas-rag code path adds nodes
+        # without attributes (distinct from the orphan-attribute path covered
+        # by ``_patched_csvs_to_temp_graphml``); without this sweep that
+        # neighbor lookup raises ``KeyError: 'id'``.
+        self._ensure_temp_kg_node_attributes(output_dir)
+
         # Step 8: Run concept generation
         logger.info(
             "Generating concepts for %d remaining nodes (%d already completed)",
@@ -921,6 +930,72 @@ class AtlasRagConstructor:
             )
 
         return len(kept)
+
+    def _ensure_temp_kg_node_attributes(self, output_dir: Path) -> int:
+        """Backfill missing ``id`` / ``type`` attributes on every temp_kg node.
+
+        atlas-rag's ``generate_concept`` reads
+        ``temp_kg.nodes[neighbor]['id']`` while building the context string
+        for each missing concept. If any node lacks the ``id`` attribute the
+        lookup raises ``KeyError: 'id'`` and the whole job fails. The
+        ``_patched_csvs_to_temp_graphml`` helper sets ``id`` on every node it
+        creates, but a separate atlas-rag code path (not covered by that
+        patch) can add attributeless nodes to the temp KG; this sweep is a
+        defensive shim that runs immediately before concept generation,
+        loads the pickle, sets ``id = node_id`` and ``type = "entity"`` on
+        any node missing those attributes, and writes the pickle back.
+
+        Args:
+            output_dir: Pipeline output directory (parent of ``atlas_output``).
+
+        Returns:
+            Number of nodes that needed at least one attribute backfilled.
+        """
+        import pickle
+
+        kg_dir = output_dir / "atlas_output" / "kg_graphml"
+        pkl_paths = list(kg_dir.glob("*_without_concept.pkl"))
+        if not pkl_paths:
+            logger.debug(
+                "No *_without_concept.pkl in %s — skipping temp_kg attribute sweep",
+                kg_dir,
+            )
+            return 0
+
+        pkl_path = pkl_paths[0]
+        try:
+            with pkl_path.open("rb") as f:
+                g = pickle.load(f)
+        except (OSError, pickle.UnpicklingError) as exc:
+            logger.warning(
+                "Failed to load temp_kg pickle %s for attribute sweep (%s); skipping",
+                pkl_path,
+                exc,
+            )
+            return 0
+
+        patched = 0
+        for node_id, attrs in g.nodes(data=True):
+            needs_patch = False
+            if "id" not in attrs:
+                attrs["id"] = node_id
+                needs_patch = True
+            if "type" not in attrs:
+                attrs["type"] = "entity"
+                needs_patch = True
+            if needs_patch:
+                patched += 1
+
+        if patched:
+            with pkl_path.open("wb") as f:
+                pickle.dump(g, f)
+            logger.warning(
+                "Backfilled missing id/type attributes on %d node(s) in %s",
+                patched,
+                pkl_path.name,
+            )
+
+        return patched
 
     def _restore_and_finalize(
         self,

--- a/src/arandu/kg/atlas_backend.py
+++ b/src/arandu/kg/atlas_backend.py
@@ -108,6 +108,14 @@ ATLAS_DEFAULTS: dict[str, Any] = {
 # Path to atlas-rag prompt files relative to the project root
 _PROMPTS_DIR = get_project_root() / "prompts" / "kg" / "atlas"
 
+# atlas-rag synthesizes event-entity participation triples with a hardcoded
+# predicate (json_to_csv.py:161, json_to_csv.py:364, json_to_graphml.py:145).
+# The post-extraction relabel sweep rewrites it for non-English corpora.
+SYNTHESIZED_EVENT_PARTICIPATION_PREDICATE_EN = "is participated by"
+SYNTHESIZED_EVENT_PARTICIPATION_PREDICATE_BY_LANG: dict[str, str] = {
+    "pt": "envolve",
+}
+
 # Lazy reference — populated on first use by _get_enriched_processor_cls()
 _MetadataEnrichedProcessorCls: type | None = None
 
@@ -610,6 +618,13 @@ class AtlasRagConstructor:
             self._run_concept_generation_with_resume(extractor, output_dir)
             extractor.create_concept_csv()
 
+        # Translate atlas-rag's hardcoded English event-entity participation
+        # predicate to a natural Portuguese form for pt-language runs. The
+        # framework synthesizes (Event, "is participated by", Entity) edges
+        # because the LLM's event_entity_relation_dict only emits {Event,
+        # Entity} pairs (no predicate). Pure CSV rewrite, no upstream change.
+        self._relabel_synthesized_event_participation(output_dir)
+
         # Backfill triple_nodes CSV with any endpoint referenced by
         # triple_edges but absent from triple_nodes. atlas-rag's
         # ``csvs_to_graphml`` calls ``g.add_edge`` on every edge endpoint;
@@ -1097,6 +1112,85 @@ class AtlasRagConstructor:
             nodes_csv.name,
         )
         return len(orphans)
+
+    def _relabel_synthesized_event_participation(self, output_dir: Path) -> int:
+        """Rewrite atlas-rag's hardcoded event-participation predicate.
+
+        atlas-rag synthesizes (Event, ``"is participated by"``, Entity) edges
+        from the LLM's ``event_entity_relation_dict`` (which has no
+        predicate field). The string is hardcoded in atlas-rag's
+        ``json_to_csv.py`` and ``json_to_graphml.py``, so for non-English
+        corpora we rewrite the relation column in the triple_edges CSVs
+        before ``convert_to_graphml`` reads them. No-op when
+        ``self._config.language`` has no mapping in
+        ``SYNTHESIZED_EVENT_PARTICIPATION_PREDICATE_BY_LANG``.
+
+        Args:
+            output_dir: Pipeline output directory (parent of ``atlas_output``).
+
+        Returns:
+            Number of edge rows whose relation was rewritten across all
+            target CSVs (0 if the language has no mapping).
+        """
+        target_predicate = SYNTHESIZED_EVENT_PARTICIPATION_PREDICATE_BY_LANG.get(
+            self._config.language
+        )
+        if not target_predicate:
+            return 0
+
+        atlas_output = output_dir / "atlas_output"
+        candidates: list[Path] = []
+        candidates.extend(
+            (atlas_output / "triples_csv").glob("triple_edges_*_from_json_without_emb.csv")
+        )
+        candidates.extend(
+            (atlas_output / "concept_csv").glob("triple_edges_*_from_json_with_concept.csv")
+        )
+        if not candidates:
+            logger.debug(
+                "No triple_edges CSVs in %s — skipping participation relabel sweep",
+                atlas_output,
+            )
+            return 0
+
+        total_rewritten = 0
+        for csv_path in candidates:
+            try:
+                with csv_path.open(newline="") as f:
+                    reader = csv.DictReader(f)
+                    fieldnames = reader.fieldnames
+                    if not fieldnames or "relation" not in fieldnames:
+                        continue
+                    rows = list(reader)
+            except (OSError, csv.Error) as exc:
+                logger.warning(
+                    "Failed to read %s for participation relabel (%s); skipping",
+                    csv_path.name,
+                    exc,
+                )
+                continue
+
+            rewritten = 0
+            for row in rows:
+                if row.get("relation") == SYNTHESIZED_EVENT_PARTICIPATION_PREDICATE_EN:
+                    row["relation"] = target_predicate
+                    rewritten += 1
+
+            if rewritten:
+                with csv_path.open("w", newline="") as f:
+                    writer = csv.DictWriter(f, fieldnames=fieldnames)
+                    writer.writeheader()
+                    writer.writerows(rows)
+                logger.info(
+                    "Relabeled %d %r → %r in %s",
+                    rewritten,
+                    SYNTHESIZED_EVENT_PARTICIPATION_PREDICATE_EN,
+                    target_predicate,
+                    csv_path.name,
+                )
+                total_rewritten += rewritten
+
+        return total_rewritten
 
     def _restore_and_finalize(
         self,

--- a/tests/kg/test_atlas_backend.py
+++ b/tests/kg/test_atlas_backend.py
@@ -1494,11 +1494,13 @@ class TestResumableConceptGeneration:
         from arandu.kg.atlas_backend import AtlasRagConstructor
 
         triples_dir = tmp_path / "atlas_output" / "triples_csv"
+        concept_dir = tmp_path / "atlas_output" / "concept_csv"
         triples_dir.mkdir(parents=True)
+        concept_dir.mkdir(parents=True)
 
         nodes_csv = triples_dir / "triple_nodes_test_from_json_without_emb.csv"
         nodes_csv.write_text("name:ID,type,concepts,synsets,:LABEL\nRio Guaíba,entity,,,Node\n")
-        edges_csv = triples_dir / "triple_edges_test_from_json_with_concept.csv"
+        edges_csv = concept_dir / "triple_edges_test_from_json_with_concept.csv"
         edges_csv.write_text(
             ":START_ID,:END_ID,relation,concepts,synsets,:TYPE\n"
             "Rio Guaíba,enchente,causou,,,Relation\n"
@@ -1530,7 +1532,9 @@ class TestResumableConceptGeneration:
         from arandu.kg.atlas_backend import AtlasRagConstructor
 
         triples_dir = tmp_path / "atlas_output" / "triples_csv"
+        concept_dir = tmp_path / "atlas_output" / "concept_csv"
         triples_dir.mkdir(parents=True)
+        concept_dir.mkdir(parents=True)
 
         nodes_csv = triples_dir / "triple_nodes_test_from_json_without_emb.csv"
         nodes_csv.write_text(
@@ -1538,7 +1542,7 @@ class TestResumableConceptGeneration:
             "Rio Guaíba,entity,,,Node\n"
             "enchente,event,,,Node\n"
         )
-        edges_csv = triples_dir / "triple_edges_test_from_json_with_concept.csv"
+        edges_csv = concept_dir / "triple_edges_test_from_json_with_concept.csv"
         edges_csv.write_text(
             ":START_ID,:END_ID,relation,concepts,synsets,:TYPE\n"
             "Rio Guaíba,enchente,causou,,,Relation\n"

--- a/tests/kg/test_atlas_backend.py
+++ b/tests/kg/test_atlas_backend.py
@@ -1261,6 +1261,145 @@ class TestResumableConceptGeneration:
         call_kwargs = mock_extractor.generate_concept_csv_temp.call_args[1]
         assert call_kwargs["language"] == "pt"
 
+    def test_phantom_missing_concept_dropped(self, tmp_path: Path, _mock_atlas_rag: dict) -> None:
+        """Rows in missing_concepts.csv whose node ID isn't in triple_nodes/edges are dropped.
+
+        Regression for the missing-node bug observed in cluster job 779433:
+        atlas-rag's ``generate_concept`` calls ``temp_kg.predecessors(node_id)``
+        for each missing-concepts row and raises ``NetworkXError`` when the
+        node isn't in the graph. The prefilter drops phantom rows before
+        atlas-rag sees them.
+        """
+        from arandu.kg.atlas_backend import AtlasRagConstructor
+
+        missing_csv, concepts_dir, triples_dir = self._setup_dirs(tmp_path)
+
+        # Re-write missing_concepts with a phantom row that isn't in any
+        # triple_*.csv source; the patch should drop it.
+        missing_csv.write_text(
+            "node,description,node_type\n"
+            "Rio Guaíba,grande rio do sul,entity\n"
+            "phantom_node,not in graph anywhere,entity\n"
+            "enchente,evento climático,event\n"
+        )
+
+        # Companion source CSVs the prefilter consults.
+        nodes_csv = triples_dir / "triple_nodes_test_from_json.csv"
+        nodes_csv.write_text("name:ID,type,concepts,synsets,:LABEL\nRio Guaíba,entity,,,Node\n")
+        edges_csv = triples_dir / "triple_edges_test_from_json.csv"
+        edges_csv.write_text(
+            ":START_ID,:END_ID,relation,concepts,synsets,:TYPE\n"
+            "Rio Guaíba,enchente,causou,,,Relation\n"
+        )
+
+        config = KGConfig(language="pt")
+        constructor = AtlasRagConstructor(config)
+        mock_extractor = MagicMock()
+
+        shard = concepts_dir / "concept_shard_0.csv"
+
+        def write_shard(**kwargs: Any) -> None:
+            shard.write_text(
+                "Rio Guaíba,large river in southern Brazil,entity\nenchente,climatic event,event\n"
+            )
+
+        mock_extractor.generate_concept_csv_temp.side_effect = write_shard
+
+        # Verify the phantom is dropped from the input atlas-rag ultimately sees.
+        # Capture the missing_csv content right before generate_concept_csv_temp is called.
+        captured: dict[str, list[str]] = {}
+
+        def capture_then_write(**kwargs: Any) -> None:
+            with missing_csv.open() as f:
+                captured["names"] = [row[0] for row in csv.reader(f) if row and row[0] != "node"]
+            write_shard(**kwargs)
+
+        mock_extractor.generate_concept_csv_temp.side_effect = capture_then_write
+
+        constructor._run_concept_generation_with_resume(mock_extractor, tmp_path)
+
+        # The phantom row must NOT have been visible to atlas-rag.
+        assert "phantom_node" not in captured["names"], (
+            f"phantom row leaked through to atlas-rag: {captured['names']}"
+        )
+        assert "Rio Guaíba" in captured["names"]
+        assert "enchente" in captured["names"]
+
+    def test_no_phantom_drop_when_all_present(self, tmp_path: Path, _mock_atlas_rag: dict) -> None:
+        """Prefilter is a no-op when every missing_concepts row is in the graph."""
+        from arandu.kg.atlas_backend import AtlasRagConstructor
+
+        missing_csv, concepts_dir, triples_dir = self._setup_dirs(tmp_path)
+
+        # _setup_dirs writes 3 nodes; build matching source CSVs.
+        nodes_csv = triples_dir / "triple_nodes_test_from_json.csv"
+        nodes_csv.write_text(
+            "name:ID,type,concepts,synsets,:LABEL\n"
+            "Rio Guaíba,entity,,,Node\n"
+            "enchente,event,,,Node\n"
+            "afeta,relation,,,Node\n"
+        )
+        edges_csv = triples_dir / "triple_edges_test_from_json.csv"
+        edges_csv.write_text(":START_ID,:END_ID,relation,concepts,synsets,:TYPE\n")
+
+        config = KGConfig(language="pt")
+        constructor = AtlasRagConstructor(config)
+        mock_extractor = MagicMock()
+
+        shard = concepts_dir / "concept_shard_0.csv"
+        captured: dict[str, list[str]] = {}
+
+        def write_shard(**kwargs: Any) -> None:
+            with missing_csv.open() as f:
+                captured["names"] = [row[0] for row in csv.reader(f) if row and row[0] != "node"]
+            shard.write_text(
+                "Rio Guaíba,large river,entity\n"
+                "enchente,climatic event,event\n"
+                "afeta,causal relation,relation\n"
+            )
+
+        mock_extractor.generate_concept_csv_temp.side_effect = write_shard
+
+        constructor._run_concept_generation_with_resume(mock_extractor, tmp_path)
+
+        # All 3 rows survive — no false drops.
+        assert set(captured["names"]) == {"Rio Guaíba", "enchente", "afeta"}
+
+    def test_phantom_drop_skipped_when_source_csvs_missing(
+        self, tmp_path: Path, _mock_atlas_rag: dict
+    ) -> None:
+        """Defensive: if triple_nodes/edges CSVs are absent, prefilter is a no-op.
+
+        Triple extraction must run before concept generation, so the source
+        CSVs *should* exist. But if a test or odd resume state leaves them
+        missing, the prefilter should not crash — atlas-rag will surface
+        any actual problem itself.
+        """
+        from arandu.kg.atlas_backend import AtlasRagConstructor
+
+        _missing_csv, concepts_dir, _triples_dir = self._setup_dirs(tmp_path)
+        # Intentionally do NOT create triple_nodes / triple_edges CSVs.
+
+        config = KGConfig(language="pt")
+        constructor = AtlasRagConstructor(config)
+        mock_extractor = MagicMock()
+
+        shard = concepts_dir / "concept_shard_0.csv"
+
+        def write_shard(**kwargs: Any) -> None:
+            shard.write_text(
+                "Rio Guaíba,large river,entity\n"
+                "enchente,climatic event,event\n"
+                "afeta,causal relation,relation\n"
+            )
+
+        mock_extractor.generate_concept_csv_temp.side_effect = write_shard
+
+        # Should NOT raise.
+        constructor._run_concept_generation_with_resume(mock_extractor, tmp_path)
+
+        mock_extractor.generate_concept_csv_temp.assert_called_once()
+
 
 class TestPatchedCsvsToTempGraphml:
     """Tests for _patched_csvs_to_temp_graphml orphan node handling."""

--- a/tests/kg/test_atlas_backend.py
+++ b/tests/kg/test_atlas_backend.py
@@ -1566,6 +1566,77 @@ class TestResumableConceptGeneration:
         constructor = AtlasRagConstructor(KGConfig(language="pt"))
         assert constructor._ensure_triple_node_csv_covers_endpoints(tmp_path) == 0
 
+    @staticmethod
+    def _write_participation_csvs(tmp_path: Path) -> tuple[Path, Path]:
+        triples_dir = tmp_path / "atlas_output" / "triples_csv"
+        concept_dir = tmp_path / "atlas_output" / "concept_csv"
+        triples_dir.mkdir(parents=True)
+        concept_dir.mkdir(parents=True)
+
+        without_emb = triples_dir / "triple_edges_test_from_json_without_emb.csv"
+        without_emb.write_text(
+            ":START_ID,:END_ID,relation,concepts,synsets,:TYPE\n"
+            "Enchente,Rio Guaíba,is participated by,,,Relation\n"
+            "Rio Guaíba,enchente,causou,,,Relation\n"
+            "Enchente,Porto Alegre,is participated by,,,Relation\n"
+        )
+        with_concept = concept_dir / "triple_edges_test_from_json_with_concept.csv"
+        with_concept.write_text(
+            ":START_ID,:END_ID,relation,concepts,synsets,:TYPE\n"
+            "Enchente,Rio Guaíba,is participated by,[],[],Relation\n"
+        )
+        return without_emb, with_concept
+
+    def test_participation_relabel_rewrites_pt_corpus(
+        self, tmp_path: Path, _mock_atlas_rag: dict
+    ) -> None:
+        """For language=pt, hardcoded English predicate is replaced in both CSVs."""
+        from arandu.kg.atlas_backend import AtlasRagConstructor
+
+        without_emb, with_concept = self._write_participation_csvs(tmp_path)
+
+        constructor = AtlasRagConstructor(KGConfig(language="pt"))
+        rewritten = constructor._relabel_synthesized_event_participation(tmp_path)
+
+        # 2 in _without_emb + 1 in _with_concept = 3 total.
+        assert rewritten == 3, f"expected 3 relabels, got {rewritten}"
+
+        for path in (without_emb, with_concept):
+            with path.open(newline="") as f:
+                rows = list(csv.DictReader(f))
+            relations = [r["relation"] for r in rows]
+            assert "is participated by" not in relations
+            assert "envolve" in relations
+
+        # The non-synthesized "causou" relation must be untouched.
+        with without_emb.open(newline="") as f:
+            relations = [r["relation"] for r in csv.DictReader(f)]
+        assert "causou" in relations
+
+    def test_participation_relabel_no_op_for_english(
+        self, tmp_path: Path, _mock_atlas_rag: dict
+    ) -> None:
+        """No mapping for language=en → CSVs untouched."""
+        from arandu.kg.atlas_backend import AtlasRagConstructor
+
+        without_emb, _ = self._write_participation_csvs(tmp_path)
+        mtime_before = without_emb.stat().st_mtime_ns
+
+        constructor = AtlasRagConstructor(KGConfig(language="en"))
+        assert constructor._relabel_synthesized_event_participation(tmp_path) == 0
+        assert without_emb.stat().st_mtime_ns == mtime_before
+
+    def test_participation_relabel_skipped_when_csvs_missing(
+        self, tmp_path: Path, _mock_atlas_rag: dict
+    ) -> None:
+        """No-op when no triple_edges CSVs exist (defensive)."""
+        from arandu.kg.atlas_backend import AtlasRagConstructor
+
+        (tmp_path / "atlas_output" / "triples_csv").mkdir(parents=True)
+
+        constructor = AtlasRagConstructor(KGConfig(language="pt"))
+        assert constructor._relabel_synthesized_event_participation(tmp_path) == 0
+
 
 class TestPatchedCsvsToTempGraphml:
     """Tests for _patched_csvs_to_temp_graphml orphan node handling."""

--- a/tests/kg/test_atlas_backend.py
+++ b/tests/kg/test_atlas_backend.py
@@ -1365,6 +1365,87 @@ class TestResumableConceptGeneration:
         # All 3 rows survive — no false drops.
         assert set(captured["names"]) == {"Rio Guaíba", "enchente", "afeta"}
 
+    def test_temp_kg_attribute_sweep_backfills_missing_id(
+        self, tmp_path: Path, _mock_atlas_rag: dict
+    ) -> None:
+        """Nodes added to temp_kg without an ``id`` attribute get backfilled.
+
+        Regression for the atlas-rag ``KeyError: 'id'`` crash in
+        ``generate_concept`` line 212 (cluster job 779946) — a code path
+        outside ``_patched_csvs_to_temp_graphml`` adds attributeless nodes
+        and the per-neighbor lookup raises.
+        """
+        import pickle
+
+        import networkx as nx
+
+        from arandu.kg.atlas_backend import AtlasRagConstructor
+
+        # Build a temp_kg with one well-formed node and one attributeless one.
+        kg_dir = tmp_path / "atlas_output" / "kg_graphml"
+        kg_dir.mkdir(parents=True)
+        pkl_path = kg_dir / "test_without_concept.pkl"
+
+        g = nx.DiGraph()
+        g.add_node("good", id="Rio Guaíba", type="entity")
+        g.add_node("bad")  # no attributes — simulates the bug
+        g.add_edge("good", "bad", relation="ref", type="Relation")
+        with pkl_path.open("wb") as f:
+            pickle.dump(g, f)
+
+        constructor = AtlasRagConstructor(KGConfig(language="pt"))
+        patched = constructor._ensure_temp_kg_node_attributes(tmp_path)
+
+        assert patched == 1, f"expected 1 node patched, got {patched}"
+
+        with pkl_path.open("rb") as f:
+            g2 = pickle.load(f)
+        assert g2.nodes["bad"]["id"] == "bad"
+        assert g2.nodes["bad"]["type"] == "entity"
+        # Existing well-formed node untouched.
+        assert g2.nodes["good"]["id"] == "Rio Guaíba"
+        assert g2.nodes["good"]["type"] == "entity"
+
+    def test_temp_kg_attribute_sweep_no_op_when_all_attributes_present(
+        self, tmp_path: Path, _mock_atlas_rag: dict
+    ) -> None:
+        """Sweep returns 0 and does not rewrite the pickle when all nodes are well-formed."""
+        import pickle
+
+        import networkx as nx
+
+        from arandu.kg.atlas_backend import AtlasRagConstructor
+
+        kg_dir = tmp_path / "atlas_output" / "kg_graphml"
+        kg_dir.mkdir(parents=True)
+        pkl_path = kg_dir / "test_without_concept.pkl"
+
+        g = nx.DiGraph()
+        g.add_node("a", id="A", type="entity")
+        g.add_node("b", id="B", type="event")
+        with pkl_path.open("wb") as f:
+            pickle.dump(g, f)
+        mtime_before = pkl_path.stat().st_mtime_ns
+
+        constructor = AtlasRagConstructor(KGConfig(language="pt"))
+        patched = constructor._ensure_temp_kg_node_attributes(tmp_path)
+
+        assert patched == 0
+        # Pickle should not have been rewritten.
+        assert pkl_path.stat().st_mtime_ns == mtime_before
+
+    def test_temp_kg_attribute_sweep_skipped_when_pickle_missing(
+        self, tmp_path: Path, _mock_atlas_rag: dict
+    ) -> None:
+        """No-op when the pickle directory is empty (defensive)."""
+        from arandu.kg.atlas_backend import AtlasRagConstructor
+
+        # Create the directory but leave it empty.
+        (tmp_path / "atlas_output" / "kg_graphml").mkdir(parents=True)
+
+        constructor = AtlasRagConstructor(KGConfig(language="pt"))
+        assert constructor._ensure_temp_kg_node_attributes(tmp_path) == 0
+
     def test_phantom_drop_skipped_when_source_csvs_missing(
         self, tmp_path: Path, _mock_atlas_rag: dict
     ) -> None:

--- a/tests/kg/test_atlas_backend.py
+++ b/tests/kg/test_atlas_backend.py
@@ -1481,6 +1481,87 @@ class TestResumableConceptGeneration:
 
         mock_extractor.generate_concept_csv_temp.assert_called_once()
 
+    def test_endpoint_coverage_sweep_backfills_orphans(
+        self, tmp_path: Path, _mock_atlas_rag: dict
+    ) -> None:
+        """Endpoints in triple_edges absent from triple_nodes get a backfill row.
+
+        Regression for the atlas-rag ``KeyError: 'type'`` crash in
+        ``csv_to_graphml.py`` line 185 (cluster job 780114) — atlas-rag's
+        ``g.add_edge`` implicitly creates attributeless nodes for any edge
+        endpoint missing from triple_nodes_*.csv.
+        """
+        from arandu.kg.atlas_backend import AtlasRagConstructor
+
+        triples_dir = tmp_path / "atlas_output" / "triples_csv"
+        triples_dir.mkdir(parents=True)
+
+        nodes_csv = triples_dir / "triple_nodes_test_from_json_without_emb.csv"
+        nodes_csv.write_text("name:ID,type,concepts,synsets,:LABEL\nRio Guaíba,entity,,,Node\n")
+        edges_csv = triples_dir / "triple_edges_test_from_json_with_concept.csv"
+        edges_csv.write_text(
+            ":START_ID,:END_ID,relation,concepts,synsets,:TYPE\n"
+            "Rio Guaíba,enchente,causou,,,Relation\n"
+            "enchente,Porto Alegre,atingiu,,,Relation\n"
+        )
+
+        constructor = AtlasRagConstructor(KGConfig(language="pt"))
+        backfilled = constructor._ensure_triple_node_csv_covers_endpoints(tmp_path)
+
+        assert backfilled == 2, f"expected 2 orphans backfilled, got {backfilled}"
+
+        with nodes_csv.open(newline="") as f:
+            rows = list(csv.DictReader(f))
+        names = {row["name:ID"] for row in rows}
+        assert names == {"Rio Guaíba", "enchente", "Porto Alegre"}
+
+        # Backfilled rows have type=entity and empty other columns.
+        backfilled_rows = [r for r in rows if r["name:ID"] in {"enchente", "Porto Alegre"}]
+        for row in backfilled_rows:
+            assert row["type"] == "entity"
+            assert row["concepts"] == ""
+            assert row["synsets"] == ""
+            assert row[":LABEL"] == ""
+
+    def test_endpoint_coverage_sweep_no_op_when_all_present(
+        self, tmp_path: Path, _mock_atlas_rag: dict
+    ) -> None:
+        """No backfill when every endpoint already has a row."""
+        from arandu.kg.atlas_backend import AtlasRagConstructor
+
+        triples_dir = tmp_path / "atlas_output" / "triples_csv"
+        triples_dir.mkdir(parents=True)
+
+        nodes_csv = triples_dir / "triple_nodes_test_from_json_without_emb.csv"
+        nodes_csv.write_text(
+            "name:ID,type,concepts,synsets,:LABEL\n"
+            "Rio Guaíba,entity,,,Node\n"
+            "enchente,event,,,Node\n"
+        )
+        edges_csv = triples_dir / "triple_edges_test_from_json_with_concept.csv"
+        edges_csv.write_text(
+            ":START_ID,:END_ID,relation,concepts,synsets,:TYPE\n"
+            "Rio Guaíba,enchente,causou,,,Relation\n"
+        )
+        mtime_before = nodes_csv.stat().st_mtime_ns
+
+        constructor = AtlasRagConstructor(KGConfig(language="pt"))
+        backfilled = constructor._ensure_triple_node_csv_covers_endpoints(tmp_path)
+
+        assert backfilled == 0
+        assert nodes_csv.stat().st_mtime_ns == mtime_before
+
+    def test_endpoint_coverage_sweep_skipped_when_csvs_missing(
+        self, tmp_path: Path, _mock_atlas_rag: dict
+    ) -> None:
+        """No-op when the source CSVs are absent (defensive)."""
+        from arandu.kg.atlas_backend import AtlasRagConstructor
+
+        (tmp_path / "atlas_output" / "triples_csv").mkdir(parents=True)
+
+        constructor = AtlasRagConstructor(KGConfig(language="pt"))
+        assert constructor._ensure_triple_node_csv_covers_endpoints(tmp_path) == 0
+
 
 class TestPatchedCsvsToTempGraphml:
     """Tests for _patched_csvs_to_temp_graphml orphan node handling."""


### PR DESCRIPTION
## Summary

Carries the full atlas-rag bug-hunt that came out of running the KG pipeline on the Portuguese corpus end-to-end. Originally a single phantom-row prefilter; grew over five sequential cluster failures into three on-disk shims + a Portuguese-language predicate relabel + two analytics scripts + a roadmap refresh.

## What's in here

### KG fixes (3 on-disk shims)

All three are file-rewriting sweeps in `_run_pipeline` rather than monkey-patches — they sidestep the import-order issue that made PR #89's monkey-patch dead code in production.

1. **`_drop_phantom_missing_concepts`** (`8c9a670`) — drops rows from `missing_concepts*_from_json.csv` whose node ID is absent from `triple_*.csv`. Empirical: 1,721 / 9,332 (~18%) phantoms on `test-kg-04`.
2. **`_ensure_temp_kg_node_attributes`** (`3d96229`) — backfills missing `id`/`type` attributes on every node in the `*_without_concept.pkl` temp-KG before `generate_concept_csv_temp` runs.
3. **`_ensure_triple_node_csv_covers_endpoints`** (`f6f2408` + `c5323c8`) — appends `triple_nodes_*.csv` rows for any `:START_ID` / `:END_ID` in `triple_edges_*.csv` that has no node row, so `csvs_to_graphml` doesn't crash on attributeless edge endpoints. Targets the correct file (`concept_csv/...with_concept.csv` when `include_concept=True`).

### Internationalisation

4. **`_relabel_synthesized_event_participation`** (`1d40ae3`) — atlas-rag synthesizes `(Event, "is participated by", Entity)` edges in `json_to_csv.py:161,364` and `json_to_graphml.py:145` because the LLM's `event_entity_relation_dict` has no predicate field. The string is hardcoded; for non-English corpora it dominates relation-frequency stats with an English label. New CSV-rewrite sweep translates the predicate per-language (currently `pt → "envolve"`), gated on `self._config.language`.

### Analytics

5. **`scripts/kg_structural_metrics.py`** (`9d80c9c`) — loads a GraphML with NetworkX and reports nodes/edges/density, weakly + strongly connected components, degree-distribution stats, clustering coefficients, and edge-type breakdown. The `1d40ae3` commit also adds a synthesized-vs-LLM-extracted relation split that reuses the predicate constants exported from `atlas_backend`.
6. **`scripts/kg_relabel_predicate.py`** (`88c1250`) — one-shot counterpart to the in-pipeline relabel sweep, for graphmls that pre-date this PR. `--dry-run` for a count, `--lang` for the target language, `.bak` written before rewrite.

### Documentation

7. **`docs/planning/ROADMAP.md`** (`e276e1d`) — refresh after ~5 weeks of work: Phase A marked substantially done with the `test-kg-04` outcome (14,617 nodes / 60,318 edges, 95.7% giant component); upstream fix in 0.0.6 noted; new Phase C′ section between C and D (fresh-corpus rerun); shard-and-merge downgraded to nice-to-have.

## Empirical validation (test-kg-04)

- Job 780114 ran 21h 44m on tupi: concept generation completed (~12,300 rows in `concept_shard_0.csv`); job crashed in `convert_to_graphml` with `KeyError: 'type'` on the third leak class.
- Pulled 22 MB of partial state to local; ran `convert_to_graphml` locally with shim 3 active. **1 orphan endpoint backfilled** → GraphML built and validated (14,617 nodes / 60,318 edges).
- Existing graphml relabeled in-place via `kg_relabel_predicate.py`: **3,976 edges** rewritten; `.bak` preserved.

## Upstream development (2026-04-29)

The maintainer of AutoSchemaKG answered [issue #45](https://github.com/HKUST-KnowComp/AutoSchemaKG/issues/45) the same day this PR was finalised, with a **three-layer fix on `release/v0.0.6`**:

1. `csvs_to_temp_graphml` pre-creates orphan endpoints with `type="Unknown"` + warning log.
2. `csvs_to_graphml` got the same guard in the full-export path.
3. `generate_concept` uses `.get('id', 'unknown')` defensive fallback.

Plus a mutable-default-arg fix in `get_node_id()`.

This obsoletes most of the shims in this PR. **Decision: merge as-is** so the branch isn't blocked on an upstream release; a follow-up PR after `atlas-rag>=0.0.6` lands will:

- Delete `_patched_csvs_to_temp_graphml` (PR #89 dead code).
- Delete `_ensure_temp_kg_node_attributes` (superseded by upstream layer 1 + 3).
- Delete `_ensure_triple_node_csv_covers_endpoints` (superseded by upstream layer 2).
- Decide empirically whether `_drop_phantom_missing_concepts` stays as a pre-filter or also goes.
- Keep `_relabel_synthesized_event_participation` (i18n, not a bug shim).
- Keep both analytics scripts.

That cleanup is tracked in a dedicated work session.

## Tests

- 64/64 in `tests/kg/test_atlas_backend.py` pass (3 new tests for endpoint coverage, 3 for participation relabel, plus existing).
- Full suite green except 1 pre-existing `tests/cli/test_app.py` failure (missing `plotly` extra in test environment, unrelated to this PR).

## Test plan

- [ ] CI green on the updated branch.
- [ ] No regressions in the unrelated transcription / QA tests.
- [ ] Spot-check the GraphML produced locally against expectations: node and edge counts match `kg_structural_metrics.py` output (14,617 / 60,318).

## Follow-up

- Bump `atlas-rag>=0.0.6` once the upstream release ships; strip the shims listed above.
- Phase B closes via the QA-judge calibration audit (separate PR territory).
- Phase C′ fresh-corpus rerun on the updated Drive corpus runs after Phase C completes.