### PR TITLE
feat(rag): Retriever Protocol + RAG schemas

### DIFF
--- a/src/arandu/shared/rag/__init__.py
+++ b/src/arandu/shared/rag/__init__.py
@@ -1,0 +1,6 @@
+"""Shared RAG primitives: Retriever Protocol and retrieval/answer record schemas."""
+
+from arandu.shared.rag.protocol import Retriever
+from arandu.shared.rag.schemas import AnswerRecord, RetrievalRecord, RetrievedPassage
+
+__all__ = ["AnswerRecord", "RetrievalRecord", "RetrievedPassage", "Retriever"]

--- a/src/arandu/shared/rag/protocol.py
+++ b/src/arandu/shared/rag/protocol.py
@@ -1,0 +1,24 @@
+"""Retriever Protocol — narrow contract for retrieval backends (spec §4.1)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from arandu.shared.rag.schemas import RetrievedPassage
+
+
+@runtime_checkable
+class Retriever(Protocol):
+    """A retrieval backend produces a ranked list of passages for a question.
+
+    Implementations must expose a stable ``retriever_id`` and a ``retrieve``
+    method that returns at most ``top_k`` :class:`RetrievedPassage` objects.
+    The NullRetriever is a valid implementation: it always returns ``[]``.
+    """
+
+    retriever_id: str
+
+    def retrieve(self, question: str, top_k: int) -> list[RetrievedPassage]:
+        """Retrieve up to ``top_k`` ranked passages for ``question``."""
+        ...

--- a/src/arandu/shared/rag/schemas.py
+++ b/src/arandu/shared/rag/schemas.py
@@ -1,0 +1,97 @@
+"""Pydantic schemas shared by the RAG retrieval, answerer, and judge stages.
+
+Defines:
+
+- :class:`RetrievedPassage` — a single ranked passage handed back by a retriever.
+- :class:`RetrievalRecord` — the complete output of a retrieval call for one
+  question against one retriever arm.
+- :class:`AnswerRecord` — extends :class:`RetrievalRecord` with the Answerer's
+  output and reuses Phase B's :class:`JudgeResultMixin` for verdict shape.
+
+All three are storage-stable: serialized once at retrieval/answer/judge time
+and joined in cross-arm comparison without re-running the upstream stages.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, Field, model_validator
+
+from arandu.shared.judge.schemas import JudgeResultMixin
+
+if TYPE_CHECKING:
+    from typing import Self
+
+
+class RetrievedPassage(BaseModel):
+    """A single ranked passage returned by a :class:`Retriever`.
+
+    Attributes:
+        chunk_id: Reference into the source :class:`ChunkSet` for the chunker view.
+        rank: 0-indexed position in the ranked list (lower is better).
+        score: Retriever-native relevance score. Sign and magnitude depend on
+            the backend (BM25-Okapi, cosine, PPR-weighted), so callers must
+            not compare raw scores across retriever IDs.
+        retriever_meta: Backend-specific metadata (PPR weights, BM25 score
+            components, embedding model, etc.). Free-form by design — never
+            consumed by downstream judging.
+    """
+
+    chunk_id: str = Field(..., min_length=1)
+    rank: int = Field(..., ge=0)
+    score: float
+    retriever_meta: dict[str, object] = Field(default_factory=dict)
+
+
+class RetrievalRecord(BaseModel):
+    """Complete output of one retrieval call for one question against one arm.
+
+    Attributes:
+        qa_pair_id: Composite identifier shared between :class:`QAPairCEP` and
+            ``NonAnswerableItem`` (e.g. ``"<file_id>:<chunk_id>:<idx>"``).
+        question: Verbatim question text as fed to the retriever.
+        retriever_id: Stable identifier of the retriever arm (e.g. ``"bm25_bm25_512t"``).
+        chunker_id: Identifier of the chunker view this retrieval ran against.
+        top_k: Number of passages requested. ``len(passages) <= top_k``.
+        passages: Ranked passages. May be empty (the NullRetriever returns ``[]``).
+        elapsed_ms: Wall-clock retrieval time in milliseconds.
+        is_answerable: Mirrored from the source QA item for downstream analysis.
+    """
+
+    qa_pair_id: str = Field(..., min_length=1)
+    question: str = Field(..., min_length=1)
+    retriever_id: str = Field(..., min_length=1)
+    chunker_id: str = Field(..., min_length=1)
+    top_k: int = Field(..., gt=0)
+    passages: list[RetrievedPassage]
+    elapsed_ms: float = Field(..., ge=0.0)
+    is_answerable: bool
+
+
+class AnswerRecord(RetrievalRecord, JudgeResultMixin):
+    """Answerer output for one retrieval, plus optional judge verdicts.
+
+    Inherits all :class:`RetrievalRecord` fields (so the joined record carries
+    the retrieval context that produced the answer) and the
+    :class:`JudgeResultMixin` for verdict storage.
+
+    The :attr:`abstained` flag and :attr:`answer_text` are mutually constrained:
+    ``answer_text is None`` if and only if ``abstained is True``.
+    """
+
+    answer_text: str | None = Field(default=None)
+    abstained: bool
+    rationale: str
+    answerer_model: str = Field(..., min_length=1)
+    answerer_temperature: float = Field(..., ge=0.0, le=2.0)
+    answerer_meta: dict[str, object] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def _enforce_abstained_invariant(self) -> Self:
+        """Require ``answer_text is None`` iff ``abstained is True``."""
+        if self.abstained and self.answer_text is not None:
+            raise ValueError("answer_text must be None when abstained is True")
+        if not self.abstained and self.answer_text is None:
+            raise ValueError("answer_text is required when abstained is False")
+        return self

--- a/src/arandu/shared/rag/schemas.py
+++ b/src/arandu/shared/rag/schemas.py
@@ -14,6 +14,7 @@ and joined in cross-arm comparison without re-running the upstream stages.
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from pydantic import BaseModel, Field, model_validator
@@ -67,6 +68,24 @@ class RetrievalRecord(BaseModel):
     passages: list[RetrievedPassage]
     elapsed_ms: float = Field(..., ge=0.0)
     is_answerable: bool
+
+    @model_validator(mode="after")
+    def _passages_within_top_k(self) -> Self:
+        """Enforce the documented invariant ``len(passages) <= top_k``."""
+        if len(self.passages) > self.top_k:
+            raise ValueError(
+                f"len(passages) ({len(self.passages)}) must be <= top_k ({self.top_k})"
+            )
+        return self
+
+    def save(self, path: str | Path) -> None:
+        """Serialize this record to ``path`` as JSON."""
+        Path(path).write_text(self.model_dump_json(indent=2))
+
+    @classmethod
+    def load(cls, path: str | Path) -> Self:
+        """Load a record from ``path``."""
+        return cls.model_validate_json(Path(path).read_text())
 
 
 class AnswerRecord(RetrievalRecord, JudgeResultMixin):

--- a/tests/shared/rag/test_protocol.py
+++ b/tests/shared/rag/test_protocol.py
@@ -1,0 +1,64 @@
+"""Tests for shared/rag/protocol.py — Retriever Protocol structural typing."""
+
+from __future__ import annotations
+
+from arandu.shared.rag.protocol import Retriever
+from arandu.shared.rag.schemas import RetrievedPassage
+
+
+class _StubRetriever:
+    """Minimal valid Retriever implementation used to exercise structural typing."""
+
+    def __init__(self, retriever_id: str = "stub_retriever") -> None:
+        self.retriever_id = retriever_id
+
+    def retrieve(self, question: str, top_k: int) -> list[RetrievedPassage]:
+        # Echoes top_k so tests can assert the argument plumbing.
+        return [
+            RetrievedPassage(
+                chunk_id=f"chunk{i:013d}",
+                rank=i,
+                score=1.0 - i * 0.1,
+                retriever_meta={"q": question, "top_k": top_k},
+            )
+            for i in range(top_k)
+        ]
+
+
+class _MissingMethodRetriever:
+    """Has retriever_id but no retrieve method."""
+
+    retriever_id = "broken"
+
+
+class TestRetrieverProtocol:
+    def test_stub_satisfies_protocol(self) -> None:
+        retriever = _StubRetriever()
+        assert isinstance(retriever, Retriever)
+
+    def test_missing_retrieve_method_fails_protocol_check(self) -> None:
+        broken = _MissingMethodRetriever()
+        assert not isinstance(broken, Retriever)
+
+    def test_retrieve_returns_ranked_passages(self) -> None:
+        retriever = _StubRetriever()
+        passages = retriever.retrieve("Em que ano?", top_k=3)
+        assert len(passages) == 3
+        assert [p.rank for p in passages] == [0, 1, 2]
+        # Argument plumbing preserved in the stub's meta
+        assert passages[0].retriever_meta["q"] == "Em que ano?"
+        assert passages[0].retriever_meta["top_k"] == 3
+
+    def test_retriever_id_exposed(self) -> None:
+        retriever = _StubRetriever(retriever_id="bm25_bm25_512t")
+        assert retriever.retriever_id == "bm25_bm25_512t"
+
+    def test_protocol_accepts_class_with_callable_retrieve(self) -> None:
+        # A different class shape (e.g. a lambda assigned to retrieve) should still satisfy.
+        class _Lambdic:
+            retriever_id = "lambdic"
+
+            def retrieve(self, question: str, top_k: int) -> list[RetrievedPassage]:
+                return []
+
+        assert isinstance(_Lambdic(), Retriever)

--- a/tests/shared/rag/test_schemas.py
+++ b/tests/shared/rag/test_schemas.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path  # noqa: TC003 — used as a parameter type at runtime
+
 import pytest
 from pydantic import ValidationError
 
@@ -99,6 +101,38 @@ class TestRetrievalRecord:
         loaded = RetrievalRecord.model_validate_json(dumped)
         assert [p.chunk_id for p in loaded.passages] == ["a" * 16, "b" * 16]
         assert [p.rank for p in loaded.passages] == [0, 1]
+
+    def test_rejects_passages_longer_than_top_k(self) -> None:
+        # Documented invariant: len(passages) <= top_k.
+        many = [_passage(chunk_id=f"c{i:015d}", rank=i) for i in range(5)]
+        with pytest.raises(ValidationError, match=r"top_k"):
+            _record(top_k=3, passages=many)
+
+    def test_accepts_passages_equal_to_top_k(self) -> None:
+        many = [_passage(chunk_id=f"c{i:015d}", rank=i) for i in range(3)]
+        r = _record(top_k=3, passages=many)
+        assert len(r.passages) == 3
+
+    def test_accepts_fewer_passages_than_top_k(self) -> None:
+        # Retriever may run out of candidates before reaching top_k.
+        r = _record(top_k=10, passages=[_passage()])
+        assert len(r.passages) == 1
+
+    def test_save_load_round_trip(self, tmp_path: Path) -> None:
+        path = tmp_path / "record.json"
+        r = _record(
+            passages=[
+                _passage(chunk_id="a" * 16, rank=0, score=2.5),
+                _passage(chunk_id="b" * 16, rank=1, score=1.5),
+            ],
+        )
+        r.save(path)
+        loaded = RetrievalRecord.load(path)
+        assert loaded.retriever_id == r.retriever_id
+        assert loaded.chunker_id == r.chunker_id
+        assert loaded.top_k == r.top_k
+        assert [p.chunk_id for p in loaded.passages] == ["a" * 16, "b" * 16]
+        assert [p.score for p in loaded.passages] == [2.5, 1.5]
 
 
 class TestAnswerRecord:

--- a/tests/shared/rag/test_schemas.py
+++ b/tests/shared/rag/test_schemas.py
@@ -1,0 +1,175 @@
+"""Tests for shared/rag/schemas.py — RetrievedPassage, RetrievalRecord, AnswerRecord."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from arandu.shared.judge.schemas import (
+    CriterionScore,
+    JudgePipelineResult,
+    JudgeResultMixin,
+    JudgeStepResult,
+)
+from arandu.shared.rag.schemas import AnswerRecord, RetrievalRecord, RetrievedPassage
+
+
+def _passage(
+    chunk_id: str = "abcdef1234567890",
+    rank: int = 0,
+    score: float = 1.2,
+    retriever_meta: dict[str, object] | None = None,
+) -> RetrievedPassage:
+    return RetrievedPassage(
+        chunk_id=chunk_id,
+        rank=rank,
+        score=score,
+        retriever_meta=retriever_meta or {},
+    )
+
+
+def _record(**overrides: object) -> RetrievalRecord:
+    defaults: dict[str, object] = {
+        "qa_pair_id": "src1:cep_4k:0",
+        "question": "Em que ano ocorreu a enchente?",
+        "retriever_id": "bm25_bm25_512t",
+        "chunker_id": "bm25_512t",
+        "top_k": 5,
+        "passages": [_passage()],
+        "elapsed_ms": 12.5,
+        "is_answerable": True,
+    }
+    defaults.update(overrides)
+    return RetrievalRecord(**defaults)  # type: ignore[arg-type]
+
+
+class TestRetrievedPassage:
+    def test_minimal_passage_validates(self) -> None:
+        p = _passage()
+        assert p.chunk_id == "abcdef1234567890"
+        assert p.rank == 0
+        assert p.score == 1.2
+        assert p.retriever_meta == {}
+
+    def test_rank_rejects_negative(self) -> None:
+        with pytest.raises(ValidationError):
+            _passage(rank=-1)
+
+    def test_retriever_meta_carries_backend_specific_keys(self) -> None:
+        p = _passage(retriever_meta={"score_method": "bm25_okapi", "ppr_weight": 0.42})
+        assert p.retriever_meta["score_method"] == "bm25_okapi"
+        assert p.retriever_meta["ppr_weight"] == 0.42
+
+    def test_score_can_be_negative(self) -> None:
+        # BM25 / cosine variants can produce negative or zero scores; don't gate on sign.
+        p = _passage(score=-0.5)
+        assert p.score == -0.5
+
+
+class TestRetrievalRecord:
+    def test_minimal_record_validates(self) -> None:
+        r = _record()
+        assert r.retriever_id == "bm25_bm25_512t"
+        assert r.chunker_id == "bm25_512t"
+        assert r.top_k == 5
+        assert r.is_answerable is True
+        assert r.elapsed_ms == 12.5
+        assert len(r.passages) == 1
+
+    def test_top_k_rejects_non_positive(self) -> None:
+        with pytest.raises(ValidationError):
+            _record(top_k=0)
+        with pytest.raises(ValidationError):
+            _record(top_k=-1)
+
+    def test_elapsed_ms_rejects_negative(self) -> None:
+        with pytest.raises(ValidationError):
+            _record(elapsed_ms=-0.001)
+
+    def test_empty_passages_allowed(self) -> None:
+        # NullRetriever returns []; rank-0 passage list is a valid retrieval outcome.
+        r = _record(passages=[])
+        assert r.passages == []
+
+    def test_passages_serialize_round_trip(self) -> None:
+        r = _record(
+            passages=[_passage(chunk_id="a" * 16, rank=0), _passage(chunk_id="b" * 16, rank=1)]
+        )
+        dumped = r.model_dump_json()
+        loaded = RetrievalRecord.model_validate_json(dumped)
+        assert [p.chunk_id for p in loaded.passages] == ["a" * 16, "b" * 16]
+        assert [p.rank for p in loaded.passages] == [0, 1]
+
+
+class TestAnswerRecord:
+    def _answer(self, **overrides: object) -> AnswerRecord:
+        defaults: dict[str, object] = {
+            "qa_pair_id": "src1:cep_4k:0",
+            "question": "Em que ano ocorreu a enchente?",
+            "retriever_id": "bm25_bm25_512t",
+            "chunker_id": "bm25_512t",
+            "top_k": 5,
+            "passages": [_passage()],
+            "elapsed_ms": 12.5,
+            "is_answerable": True,
+            "answer_text": "2024",
+            "abstained": False,
+            "rationale": "Found in passage 0.",
+            "answerer_model": "qwen3:14b",
+            "answerer_temperature": 0.2,
+            "answerer_meta": {},
+        }
+        defaults.update(overrides)
+        return AnswerRecord(**defaults)  # type: ignore[arg-type]
+
+    def test_answer_record_inherits_retrieval_fields(self) -> None:
+        a = self._answer()
+        assert isinstance(a, RetrievalRecord)
+        assert a.retriever_id == "bm25_bm25_512t"
+        assert a.answer_text == "2024"
+        assert a.abstained is False
+
+    def test_answer_record_inherits_judge_mixin(self) -> None:
+        a = self._answer()
+        assert isinstance(a, JudgeResultMixin)
+        # No judge run yet → validation is None, is_valid is None
+        assert a.validation is None
+        assert a.is_valid is None
+
+    def test_abstained_requires_null_answer_text(self) -> None:
+        # answer_text MUST be None when abstained=True
+        with pytest.raises(ValidationError, match="answer_text"):
+            self._answer(abstained=True, answer_text="2024")
+
+    def test_non_abstained_requires_non_null_answer_text(self) -> None:
+        with pytest.raises(ValidationError, match="answer_text"):
+            self._answer(abstained=False, answer_text=None)
+
+    def test_abstained_with_null_answer_text_validates(self) -> None:
+        a = self._answer(abstained=True, answer_text=None, rationale="Question not answerable.")
+        assert a.abstained is True
+        assert a.answer_text is None
+
+    def test_carries_judge_verdict_when_validation_set(self) -> None:
+        verdict = JudgePipelineResult(
+            stage_results={
+                "answer_correctness": JudgeStepResult(
+                    criterion_scores={
+                        "answer_correctness": CriterionScore(
+                            score=1.0, threshold=0.5, rationale="Answer matches gold."
+                        ),
+                    },
+                ),
+            },
+            passed=True,
+        )
+        a = self._answer(validation=verdict)
+        assert a.is_valid is True
+        assert a.validation is not None
+        assert a.validation.stage_results["answer_correctness"].passed is True
+
+    def test_answerer_temperature_bounded(self) -> None:
+        with pytest.raises(ValidationError):
+            self._answer(answerer_temperature=-0.1)
+        with pytest.raises(ValidationError):
+            self._answer(answerer_temperature=2.5)


### PR DESCRIPTION
## Summary

Phase C foundation (spec §4.1, §4.2). Closes the [retriever-protocol](https://github.com/FredDsR/arandu/issues/80) task — the contract layer every retrieval arm and the answerer/judge stages depend on.

- **`Retriever` Protocol** — `runtime_checkable`, `retriever_id: str` + `retrieve(question, top_k) -> list[RetrievedPassage]`.
- **`RetrievedPassage`** — `chunk_id`, `rank` (≥0), `score`, free-form `retriever_meta` (PPR weights / BM25 components / etc.).
- **`RetrievalRecord`** — `qa_pair_id`, `question`, `retriever_id`, `chunker_id`, `top_k` (>0), `passages` (may be empty for NullRetriever), `elapsed_ms` (≥0), `is_answerable`.
- **`AnswerRecord(RetrievalRecord, JudgeResultMixin)`** — adds `answer_text`, `abstained`, `rationale`, `answerer_model`, `answerer_temperature` (0–2), `answerer_meta`. Model validator enforces `answer_text is None` iff `abstained is True`. Reuses Phase B's verdict shape via `JudgeResultMixin`.

Unblocks: `bm25-baseline`, `graphrag-retriever`, `null-retriever`, `answerer-module`, `judge-answers-cli`, `retrieve-cli`.

## Test plan

- [x] 21 new unit tests across schemas (16) and protocol structural typing (5)
- [x] Full suite green: 1108 passed (38s)
- [x] `ruff check` and `ruff format` clean
- [x] `AnswerRecord` invariant tested in both directions (abstained → no answer, non-abstained → answer required)
- [x] Protocol's `isinstance` check verified against both a conforming stub and a missing-method class