### PR TITLE
feat(rag): NullRetriever + BM25Retriever (spec §4.3, §4.6)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,9 @@ dependencies = [
     "networkx>=3.1",
     "chonkie>=1.6.6",
     "rank-bm25>=0.2.2",
+    "spacy>=3.8.14",
+    "pt-core-news-sm",
+    "en-core-web-sm",
 ]
 
 [project.scripts]
@@ -125,3 +128,5 @@ priority = "supplemental"
 torch = { index = "pytorch-cu124" }
 torchvision = { index = "pytorch-cu124" }
 torchaudio = { index = "pytorch-cu124" }
+pt-core-news-sm = { url = "https://github.com/explosion/spacy-models/releases/download/pt_core_news_sm-3.8.0/pt_core_news_sm-3.8.0-py3-none-any.whl" }
+en-core-web-sm = { url = "https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     # Graph loading and analysis
     "networkx>=3.1",
     "chonkie>=1.6.6",
+    "rank-bm25>=0.2.2",
 ]
 
 [project.scripts]

--- a/src/arandu/shared/rag/retrievers/__init__.py
+++ b/src/arandu/shared/rag/retrievers/__init__.py
@@ -1,0 +1,5 @@
+"""Retrieval backends implementing the `Retriever` Protocol (spec §4)."""
+
+from arandu.shared.rag.retrievers.null import NullRetriever
+
+__all__ = ["NullRetriever"]

--- a/src/arandu/shared/rag/retrievers/__init__.py
+++ b/src/arandu/shared/rag/retrievers/__init__.py
@@ -1,5 +1,6 @@
 """Retrieval backends implementing the `Retriever` Protocol (spec §4)."""
 
+from arandu.shared.rag.retrievers.bm25 import BM25Retriever
 from arandu.shared.rag.retrievers.null import NullRetriever
 
-__all__ = ["NullRetriever"]
+__all__ = ["BM25Retriever", "NullRetriever"]

--- a/src/arandu/shared/rag/retrievers/_bm25_tokenize.py
+++ b/src/arandu/shared/rag/retrievers/_bm25_tokenize.py
@@ -1,0 +1,69 @@
+"""BM25 tokenizers — spaCy primary path with whitespace fallback (spec §4.3).
+
+Portuguese: ``pt_core_news_sm`` (lemmatization + stopword removal). English:
+``en_core_web_sm``. When spaCy or its model is unavailable, falls back to
+``_whitespace_tokenize``: NFKC + lowercase + punctuation-stripping + split.
+The fallback emits a logged warning at factory time.
+"""
+
+from __future__ import annotations
+
+import logging
+import unicodedata
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+logger = logging.getLogger(__name__)
+
+Tokenizer = "Callable[[str], list[str]]"
+
+
+def _whitespace_tokenize(text: str) -> list[str]:
+    """Tokenize via NFKC + lowercase + punctuation-strip + whitespace split.
+
+    Numerics and Portuguese accents are preserved (NFKC keeps composed forms).
+    """
+    normalized = unicodedata.normalize("NFKC", text).lower()
+    cleaned = "".join(c if c.isalnum() or c.isspace() else " " for c in normalized)
+    return [tok for tok in cleaned.split() if tok]
+
+
+def _spacy_tokenizer(model: str) -> Callable[[str], list[str]] | None:
+    """Build a spaCy lemma+stopword tokenizer; return None if spaCy/model missing."""
+    try:
+        import spacy
+    except ImportError:
+        return None
+    try:
+        nlp = spacy.load(model, disable=["ner", "parser"])
+    except OSError:
+        return None
+
+    def tokenize(text: str) -> list[str]:
+        return [
+            tok.lemma_.lower()
+            for tok in nlp(text)
+            if not tok.is_stop and not tok.is_punct and not tok.is_space
+        ]
+
+    return tokenize
+
+
+def portuguese_tokenizer() -> Callable[[str], list[str]]:
+    """Return a Portuguese tokenizer (spaCy ``pt_core_news_sm`` or fallback)."""
+    tokenizer = _spacy_tokenizer("pt_core_news_sm")
+    if tokenizer is None:
+        logger.warning("spaCy 'pt_core_news_sm' unavailable — using whitespace fallback tokenizer.")
+        return _whitespace_tokenize
+    return tokenizer
+
+
+def english_tokenizer() -> Callable[[str], list[str]]:
+    """Return an English tokenizer (spaCy ``en_core_web_sm`` or fallback)."""
+    tokenizer = _spacy_tokenizer("en_core_web_sm")
+    if tokenizer is None:
+        logger.warning("spaCy 'en_core_web_sm' unavailable — using whitespace fallback tokenizer.")
+        return _whitespace_tokenize
+    return tokenizer

--- a/src/arandu/shared/rag/retrievers/_bm25_tokenize.py
+++ b/src/arandu/shared/rag/retrievers/_bm25_tokenize.py
@@ -17,8 +17,6 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-Tokenizer = "Callable[[str], list[str]]"
-
 
 def _whitespace_tokenize(text: str) -> list[str]:
     """Tokenize via NFKC + lowercase + punctuation-strip + whitespace split.

--- a/src/arandu/shared/rag/retrievers/bm25.py
+++ b/src/arandu/shared/rag/retrievers/bm25.py
@@ -1,0 +1,164 @@
+"""BM25 sparse retrieval baseline (spec §4.3).
+
+Uses ``rank_bm25.BM25Okapi``. Tokenization is delegated to
+:mod:`arandu.shared.rag.retrievers._bm25_tokenize` (spaCy primary with a
+whitespace fallback). Index persistence is a pickled ``BM25Okapi`` plus a
+JSON manifest of ``chunk_ids``.
+"""
+
+from __future__ import annotations
+
+import json
+import pickle
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from rank_bm25 import BM25Okapi
+
+from arandu.shared.rag.retrievers._bm25_tokenize import (
+    english_tokenizer,
+    portuguese_tokenizer,
+)
+from arandu.shared.rag.schemas import RetrievedPassage
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+    from arandu.shared.chunking.resolver import ChunkResolver
+    from arandu.shared.chunking.schemas import Chunk
+
+
+INDEX_FILENAME = "bm25.pkl"
+MANIFEST_FILENAME = "manifest.json"
+
+
+def _make_tokenizer(language: str) -> Callable[[str], list[str]]:
+    """Return a tokenizer callable for ``language``.
+
+    Raises:
+        ValueError: If ``language`` is neither ``"pt"`` nor ``"en"``.
+    """
+    if language == "pt":
+        return portuguese_tokenizer()
+    if language == "en":
+        return english_tokenizer()
+    raise ValueError(f"Unsupported language for BM25: {language!r}. Use 'pt' or 'en'.")
+
+
+class BM25Retriever:
+    """BM25 retriever over a chunker view.
+
+    The retriever loads a pre-built index from ``index_dir`` (produced by
+    :meth:`build_index`). The ``retriever_id`` is ``f"bm25_{chunker_id}"``;
+    different chunk-size sweeps (``bm25_512t``, ``bm25_1024t``, ``bm25_4k``)
+    therefore produce distinct retriever IDs in the resulting
+    :class:`~arandu.shared.rag.schemas.RetrievalRecord`.
+    """
+
+    retriever_id: str
+
+    def __init__(
+        self,
+        index_dir: Path,
+        chunker_id: str,
+        language: str = "pt",
+    ) -> None:
+        """Load a BM25 index from ``index_dir``.
+
+        Args:
+            index_dir: Directory containing ``bm25.pkl`` and ``manifest.json``
+                (typically ``retrieval_indexes/<chunker_id>/bm25/``).
+            chunker_id: Chunker view ID this index was built from. Used to
+                derive ``retriever_id`` and not validated against the manifest.
+            language: ``"pt"`` or ``"en"``. Selects the tokenizer applied to
+                queries; should match the language used at index-build time.
+
+        Raises:
+            FileNotFoundError: If ``index_dir`` lacks either index file.
+            ValueError: If ``language`` is unsupported.
+        """
+        self.retriever_id = f"bm25_{chunker_id}"
+        self._chunker_id = chunker_id
+        self._language = language
+        self._tokenize = _make_tokenizer(language)
+        self._bm25, self._chunk_ids = self._load_index(index_dir)
+
+    @classmethod
+    def build_index(
+        cls,
+        chunks: list[Chunk],
+        resolver: ChunkResolver,
+        index_dir: Path,
+        chunker_id: str,
+        language: str = "pt",
+    ) -> None:
+        """Build a BM25 index from a chunk list and persist it to ``index_dir``.
+
+        Args:
+            chunks: Ordered chunks to index; resolved via ``resolver``.
+            resolver: Resolves chunks to source text.
+            index_dir: Output directory; created if missing.
+            chunker_id: Chunker view ID; recorded in the manifest.
+            language: Tokenizer language (``"pt"`` or ``"en"``).
+
+        Raises:
+            ValueError: If ``chunks`` is empty or ``language`` is unsupported.
+        """
+        if not chunks:
+            raise ValueError("Cannot build BM25 index from an empty chunks list.")
+        tokenize = _make_tokenizer(language)
+        tokenized = [tokenize(resolver.text(c)) for c in chunks]
+        bm25 = BM25Okapi(tokenized)
+        chunk_ids = [c.chunk_id for c in chunks]
+
+        index_dir.mkdir(parents=True, exist_ok=True)
+        with (index_dir / INDEX_FILENAME).open("wb") as f:
+            pickle.dump(bm25, f)
+        manifest = {
+            "chunker_id": chunker_id,
+            "language": language,
+            "chunks_indexed": len(chunks),
+            "built_at": datetime.now(UTC).isoformat(),
+            "chunk_ids": chunk_ids,
+        }
+        (index_dir / MANIFEST_FILENAME).write_text(json.dumps(manifest, indent=2))
+
+    @staticmethod
+    def _load_index(index_dir: Path) -> tuple[BM25Okapi, list[str]]:
+        idx_path = index_dir / INDEX_FILENAME
+        mfst_path = index_dir / MANIFEST_FILENAME
+        if not idx_path.exists() or not mfst_path.exists():
+            raise FileNotFoundError(
+                f"BM25 index not found at {index_dir} "
+                f"(expected '{INDEX_FILENAME}' and '{MANIFEST_FILENAME}')."
+            )
+        with idx_path.open("rb") as f:
+            bm25 = pickle.load(f)
+        manifest = json.loads(mfst_path.read_text())
+        return bm25, manifest["chunk_ids"]
+
+    def retrieve(self, question: str, top_k: int) -> list[RetrievedPassage]:
+        """Retrieve up to ``top_k`` chunks ranked by BM25 score.
+
+        Args:
+            question: Natural-language query; tokenized with the same
+                language tokenizer used at index build time.
+            top_k: Maximum number of passages to return.
+
+        Returns:
+            A list of :class:`RetrievedPassage` with consecutive
+            zero-indexed ranks and monotonically non-increasing scores.
+        """
+        tokens = self._tokenize(question)
+        scores = self._bm25.get_scores(tokens)
+        ranked_idx = (-scores).argsort(kind="stable")[:top_k]
+        return [
+            RetrievedPassage(
+                chunk_id=self._chunk_ids[int(i)],
+                rank=r,
+                score=float(scores[int(i)]),
+                retriever_meta={"score_method": "bm25_okapi"},
+            )
+            for r, i in enumerate(ranked_idx)
+        ]

--- a/src/arandu/shared/rag/retrievers/bm25.py
+++ b/src/arandu/shared/rag/retrievers/bm25.py
@@ -69,20 +69,24 @@ class BM25Retriever:
         Args:
             index_dir: Directory containing ``bm25.pkl`` and ``manifest.json``
                 (typically ``retrieval_indexes/<chunker_id>/bm25/``).
-            chunker_id: Chunker view ID this index was built from. Used to
-                derive ``retriever_id`` and not validated against the manifest.
-            language: ``"pt"`` or ``"en"``. Selects the tokenizer applied to
-                queries; should match the language used at index-build time.
+            chunker_id: Chunker view ID this index was built from. Must match
+                the value recorded in the manifest; mismatch raises ``ValueError``.
+            language: ``"pt"`` or ``"en"``. Must match the language used at
+                index-build time (recorded in the manifest); mismatch would
+                silently destroy ranking quality, so it raises ``ValueError``.
 
         Raises:
             FileNotFoundError: If ``index_dir`` lacks either index file.
-            ValueError: If ``language`` is unsupported.
+            ValueError: If ``language`` is unsupported, or if either
+                ``chunker_id`` or ``language`` disagrees with the manifest.
         """
         self.retriever_id = f"bm25_{chunker_id}"
         self._chunker_id = chunker_id
         self._language = language
         self._tokenize = _make_tokenizer(language)
-        self._bm25, self._chunk_ids = self._load_index(index_dir)
+        self._bm25, self._chunk_ids = self._load_index(
+            index_dir, expected_chunker_id=chunker_id, expected_language=language
+        )
 
     @classmethod
     def build_index(
@@ -125,7 +129,11 @@ class BM25Retriever:
         (index_dir / MANIFEST_FILENAME).write_text(json.dumps(manifest, indent=2))
 
     @staticmethod
-    def _load_index(index_dir: Path) -> tuple[BM25Okapi, list[str]]:
+    def _load_index(
+        index_dir: Path,
+        expected_chunker_id: str,
+        expected_language: str,
+    ) -> tuple[BM25Okapi, list[str]]:
         idx_path = index_dir / INDEX_FILENAME
         mfst_path = index_dir / MANIFEST_FILENAME
         if not idx_path.exists() or not mfst_path.exists():
@@ -133,9 +141,22 @@ class BM25Retriever:
                 f"BM25 index not found at {index_dir} "
                 f"(expected '{INDEX_FILENAME}' and '{MANIFEST_FILENAME}')."
             )
+        manifest = json.loads(mfst_path.read_text())
+        if manifest["chunker_id"] != expected_chunker_id:
+            raise ValueError(
+                f"chunker_id mismatch: index at {index_dir} was built for "
+                f"{manifest['chunker_id']!r}, but constructor received "
+                f"{expected_chunker_id!r}."
+            )
+        if manifest["language"] != expected_language:
+            raise ValueError(
+                f"language mismatch: index at {index_dir} was tokenized with "
+                f"{manifest['language']!r}, but constructor received "
+                f"{expected_language!r}. Loading with a different language would "
+                f"silently destroy ranking quality."
+            )
         with idx_path.open("rb") as f:
             bm25 = pickle.load(f)
-        manifest = json.loads(mfst_path.read_text())
         return bm25, manifest["chunk_ids"]
 
     def retrieve(self, question: str, top_k: int) -> list[RetrievedPassage]:

--- a/src/arandu/shared/rag/retrievers/bm25.py
+++ b/src/arandu/shared/rag/retrievers/bm25.py
@@ -50,10 +50,15 @@ class BM25Retriever:
     """BM25 retriever over a chunker view.
 
     The retriever loads a pre-built index from ``index_dir`` (produced by
-    :meth:`build_index`). The ``retriever_id`` is ``f"bm25_{chunker_id}"``;
-    different chunk-size sweeps (``bm25_512t``, ``bm25_1024t``, ``bm25_4k``)
-    therefore produce distinct retriever IDs in the resulting
-    :class:`~arandu.shared.rag.schemas.RetrievalRecord`.
+    :meth:`build_index`). The ``retriever_id`` is ``f"bm25_{chunker_id}"`` —
+    the leading ``bm25_`` encodes the retriever family and the ``chunker_id``
+    encodes the view. Chunker IDs in this codebase already prefix their
+    intended retriever family (e.g. ``bm25_512t``, ``bm25_1024t``, ``bm25_4k``
+    for the chunk-size sweep), so the resulting retriever IDs are
+    double-prefixed by design: ``bm25_bm25_512t`` etc. This matches the
+    example documented on :class:`~arandu.shared.rag.schemas.RetrievalRecord`
+    and lets downstream grouping distinguish e.g. BM25 over ``cep_4k`` chunks
+    (``bm25_cep_4k``) from NetworkX over the same view (``networkx_cep_4k``).
     """
 
     retriever_id: str

--- a/src/arandu/shared/rag/retrievers/bm25.py
+++ b/src/arandu/shared/rag/retrievers/bm25.py
@@ -3,11 +3,13 @@
 Uses ``rank_bm25.BM25Okapi``. Tokenization is delegated to
 :mod:`arandu.shared.rag.retrievers._bm25_tokenize` (spaCy primary with a
 whitespace fallback). Index persistence is a pickled ``BM25Okapi`` plus a
-JSON manifest of ``chunk_ids``.
+JSON manifest. The manifest carries a SHA-256 of the pickle bytes, verified
+before ``pickle.load`` to detect corruption / tampering of the index file.
 """
 
 from __future__ import annotations
 
+import hashlib
 import json
 import pickle
 from datetime import UTC, datetime
@@ -31,6 +33,7 @@ if TYPE_CHECKING:
 
 INDEX_FILENAME = "bm25.pkl"
 MANIFEST_FILENAME = "manifest.json"
+RETRIEVER_FAMILY = "bm25"
 
 
 def _make_tokenizer(language: str) -> Callable[[str], list[str]]:
@@ -46,19 +49,31 @@ def _make_tokenizer(language: str) -> Callable[[str], list[str]]:
     raise ValueError(f"Unsupported language for BM25: {language!r}. Use 'pt' or 'en'.")
 
 
+def _derive_retriever_id(chunker_id: str) -> str:
+    """Compose the retriever_id, avoiding a redundant ``bm25_`` family prefix.
+
+    Chunker IDs in this codebase typically already prefix their intended
+    retriever family (e.g. ``bm25_512t``); concatenating ``bm25_`` again would
+    produce ``bm25_bm25_512t``. When the family prefix is already present,
+    return the chunker_id verbatim; otherwise prepend ``bm25_`` so that a
+    non-family chunker view (e.g. ``cep_4k``) is still distinguished from
+    other retrievers indexing the same view.
+    """
+    prefix = f"{RETRIEVER_FAMILY}_"
+    return chunker_id if chunker_id.startswith(prefix) else f"{prefix}{chunker_id}"
+
+
 class BM25Retriever:
     """BM25 retriever over a chunker view.
 
     The retriever loads a pre-built index from ``index_dir`` (produced by
-    :meth:`build_index`). The ``retriever_id`` is ``f"bm25_{chunker_id}"`` —
-    the leading ``bm25_`` encodes the retriever family and the ``chunker_id``
-    encodes the view. Chunker IDs in this codebase already prefix their
-    intended retriever family (e.g. ``bm25_512t``, ``bm25_1024t``, ``bm25_4k``
-    for the chunk-size sweep), so the resulting retriever IDs are
-    double-prefixed by design: ``bm25_bm25_512t`` etc. This matches the
-    example documented on :class:`~arandu.shared.rag.schemas.RetrievalRecord`
-    and lets downstream grouping distinguish e.g. BM25 over ``cep_4k`` chunks
-    (``bm25_cep_4k``) from NetworkX over the same view (``networkx_cep_4k``).
+    :meth:`build_index`). The ``retriever_id`` is derived from ``chunker_id``
+    by :func:`_derive_retriever_id`: when ``chunker_id`` already starts with
+    ``bm25_`` (the chunk-size-sweep convention — ``bm25_512t``, ``bm25_1024t``,
+    ``bm25_4k``), the chunker_id is used verbatim. Otherwise the family prefix
+    is added so a non-family chunker view (e.g. ``cep_4k``) yields a
+    distinguishable ``bm25_cep_4k`` and does not collide with another
+    retriever indexing the same view (e.g. ``networkx_cep_4k``).
     """
 
     retriever_id: str
@@ -82,10 +97,11 @@ class BM25Retriever:
 
         Raises:
             FileNotFoundError: If ``index_dir`` lacks either index file.
-            ValueError: If ``language`` is unsupported, or if either
-                ``chunker_id`` or ``language`` disagrees with the manifest.
+            ValueError: If ``language`` is unsupported, the manifest disagrees
+                with the constructor args, or the recorded SHA-256 does not
+                match the pickle bytes on disk.
         """
-        self.retriever_id = f"bm25_{chunker_id}"
+        self.retriever_id = _derive_retriever_id(chunker_id)
         self._chunker_id = chunker_id
         self._language = language
         self._tokenize = _make_tokenizer(language)
@@ -122,13 +138,16 @@ class BM25Retriever:
         chunk_ids = [c.chunk_id for c in chunks]
 
         index_dir.mkdir(parents=True, exist_ok=True)
-        with (index_dir / INDEX_FILENAME).open("wb") as f:
+        pkl_path = index_dir / INDEX_FILENAME
+        with pkl_path.open("wb") as f:
             pickle.dump(bm25, f)
+        sha256 = hashlib.sha256(pkl_path.read_bytes()).hexdigest()
         manifest = {
             "chunker_id": chunker_id,
             "language": language,
             "chunks_indexed": len(chunks),
             "built_at": datetime.now(UTC).isoformat(),
+            "sha256": sha256,
             "chunk_ids": chunk_ids,
         }
         (index_dir / MANIFEST_FILENAME).write_text(json.dumps(manifest, indent=2))
@@ -159,6 +178,19 @@ class BM25Retriever:
                 f"{manifest['language']!r}, but constructor received "
                 f"{expected_language!r}. Loading with a different language would "
                 f"silently destroy ranking quality."
+            )
+        recorded_sha = manifest.get("sha256")
+        if recorded_sha is None:
+            raise ValueError(
+                f"manifest at {mfst_path} has no 'sha256' field — refusing to "
+                f"load an unverifiable BM25 index. Rebuild the index."
+            )
+        actual_sha = hashlib.sha256(idx_path.read_bytes()).hexdigest()
+        if actual_sha != recorded_sha:
+            raise ValueError(
+                f"sha256 mismatch on {idx_path}: manifest records "
+                f"{recorded_sha[:12]}…, computed {actual_sha[:12]}… — index may "
+                f"be corrupted or tampered. Rebuild the index."
             )
         with idx_path.open("rb") as f:
             bm25 = pickle.load(f)

--- a/src/arandu/shared/rag/retrievers/null.py
+++ b/src/arandu/shared/rag/retrievers/null.py
@@ -1,0 +1,34 @@
+"""NullRetriever — parametric arm of the Phase C four-arm decomposition (spec §4.6).
+
+Returns no passages; forces the Answerer to fall back to parametric (LLM-internal)
+knowledge. The arm-vs-null delta is the *graph lift* metric in Joel's framing.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from arandu.shared.rag.schemas import RetrievedPassage
+
+
+class NullRetriever:
+    """Retriever that always returns an empty passage list.
+
+    Attributes:
+        retriever_id: Stable identifier (``"null"``) used in `RetrievalRecord`.
+    """
+
+    retriever_id: str = "null"
+
+    def retrieve(self, question: str, top_k: int) -> list[RetrievedPassage]:
+        """Return an empty list regardless of inputs.
+
+        Args:
+            question: Ignored.
+            top_k: Ignored.
+
+        Returns:
+            Always ``[]``.
+        """
+        return []

--- a/src/arandu/shared/rag/schemas.py
+++ b/src/arandu/shared/rag/schemas.py
@@ -52,7 +52,7 @@ class RetrievalRecord(BaseModel):
         qa_pair_id: Composite identifier shared between :class:`QAPairCEP` and
             ``NonAnswerableItem`` (e.g. ``"<file_id>:<chunk_id>:<idx>"``).
         question: Verbatim question text as fed to the retriever.
-        retriever_id: Stable identifier of the retriever arm (e.g. ``"bm25_bm25_512t"``).
+        retriever_id: Stable identifier of the retriever arm (e.g. ``"bm25_512t"``).
         chunker_id: Identifier of the chunker view this retrieval ran against.
         top_k: Number of passages requested. ``len(passages) <= top_k``.
         passages: Ranked passages. May be empty (the NullRetriever returns ``[]``).

--- a/tests/shared/rag/retrievers/test_bm25.py
+++ b/tests/shared/rag/retrievers/test_bm25.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 from typing import TYPE_CHECKING
 
@@ -68,6 +69,16 @@ class TestBM25BuildIndex:
         assert "built_at" in manifest  # ISO timestamp
         assert manifest["chunk_ids"] == [c.chunk_id for c in chunks]
 
+    def test_manifest_records_sha256_of_pickle(self, tmp_path: Path) -> None:
+        chunks, resolver, index_dir = _build_corpus_fixture(tmp_path)
+        BM25Retriever.build_index(chunks, resolver, index_dir, CHUNKER_ID, language="pt")
+        manifest = json.loads((index_dir / MANIFEST_FILENAME).read_text())
+        assert "sha256" in manifest
+        # SHA-256 must match the actual pickle bytes on disk
+        actual = hashlib.sha256((index_dir / INDEX_FILENAME).read_bytes()).hexdigest()
+        assert manifest["sha256"] == actual
+        assert len(manifest["sha256"]) == 64  # SHA-256 hex digest length
+
     def test_creates_parent_directory(self, tmp_path: Path) -> None:
         chunks, resolver, _ = _build_corpus_fixture(tmp_path)
         nested = tmp_path / "a" / "b" / "c"  # multiple missing levels
@@ -87,10 +98,32 @@ class TestBM25BuildIndex:
 
 class TestBM25LoadAndConfig:
     def test_loads_index_via_constructor(self, tmp_path: Path) -> None:
+        # CHUNKER_ID="bm25_test" already starts with the family prefix; retriever_id is identical.
         chunks, resolver, index_dir = _build_corpus_fixture(tmp_path)
         BM25Retriever.build_index(chunks, resolver, index_dir, CHUNKER_ID, language="pt")
         retriever = BM25Retriever(index_dir=index_dir, chunker_id=CHUNKER_ID)
-        assert retriever.retriever_id == f"bm25_{CHUNKER_ID}"
+        assert retriever.retriever_id == CHUNKER_ID
+
+    def test_retriever_id_prepends_family_when_chunker_id_lacks_prefix(
+        self, tmp_path: Path
+    ) -> None:
+        # A non-bm25 chunker view (e.g. `cep_4k`) needs the family prefix added so that
+        # the same chunker indexed by different retrievers stays distinguishable.
+        chunker_id = "cep_4k"
+        chunks = [
+            Chunk(
+                chunk_id="chk_0000000000000",
+                source_file_id=SOURCE_ID,
+                chunker_id=chunker_id,
+                start_char=0,
+                end_char=20,
+            )
+        ]
+        resolver = ChunkResolver(text_loader=lambda _fid: "Some content here.")
+        index_dir = tmp_path / "retrieval_indexes" / chunker_id / "bm25"
+        BM25Retriever.build_index(chunks, resolver, index_dir, chunker_id, language="pt")
+        retriever = BM25Retriever(index_dir=index_dir, chunker_id=chunker_id)
+        assert retriever.retriever_id == "bm25_cep_4k"
 
     def test_satisfies_retriever_protocol(self, tmp_path: Path) -> None:
         chunks, resolver, index_dir = _build_corpus_fixture(tmp_path)
@@ -124,6 +157,27 @@ class TestBM25LoadAndConfig:
         BM25Retriever.build_index(chunks, resolver, index_dir, CHUNKER_ID, language="pt")
         with pytest.raises(ValueError, match="language mismatch"):
             BM25Retriever(index_dir=index_dir, chunker_id=CHUNKER_ID, language="en")
+
+    def test_load_rejects_tampered_pickle(self, tmp_path: Path) -> None:
+        # Append a byte to bm25.pkl after build — sha256 in manifest will not match.
+        # The integrity check must fire BEFORE pickle.load to prevent RCE on bad blobs.
+        chunks, resolver, index_dir = _build_corpus_fixture(tmp_path)
+        BM25Retriever.build_index(chunks, resolver, index_dir, CHUNKER_ID, language="pt")
+        pkl = index_dir / INDEX_FILENAME
+        pkl.write_bytes(pkl.read_bytes() + b"\x00")
+        with pytest.raises(ValueError, match="sha256 mismatch"):
+            BM25Retriever(index_dir=index_dir, chunker_id=CHUNKER_ID)
+
+    def test_load_rejects_manifest_without_sha256(self, tmp_path: Path) -> None:
+        # Hand-edited or pre-integrity-check manifests must be rejected. Fail closed:
+        # silently loading would defeat the integrity guarantee.
+        chunks, resolver, index_dir = _build_corpus_fixture(tmp_path)
+        BM25Retriever.build_index(chunks, resolver, index_dir, CHUNKER_ID, language="pt")
+        manifest = json.loads((index_dir / MANIFEST_FILENAME).read_text())
+        del manifest["sha256"]
+        (index_dir / MANIFEST_FILENAME).write_text(json.dumps(manifest))
+        with pytest.raises(ValueError, match="sha256"):
+            BM25Retriever(index_dir=index_dir, chunker_id=CHUNKER_ID)
 
 
 class TestBM25Retrieve:

--- a/tests/shared/rag/retrievers/test_bm25.py
+++ b/tests/shared/rag/retrievers/test_bm25.py
@@ -1,0 +1,172 @@
+"""Tests for shared/rag/retrievers/bm25.py — BM25 sparse retrieval baseline (spec §4.3)."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from arandu.shared.chunking.resolver import ChunkResolver
+from arandu.shared.chunking.schemas import Chunk
+from arandu.shared.rag.protocol import Retriever
+from arandu.shared.rag.retrievers.bm25 import (
+    INDEX_FILENAME,
+    MANIFEST_FILENAME,
+    BM25Retriever,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+SOURCE_ID = "src_test_001"
+CHUNKER_ID = "bm25_test"
+
+
+def _build_corpus_fixture(tmp_path: Path) -> tuple[list[Chunk], ChunkResolver, Path]:
+    """Build a 4-document corpus with known keyword overlap with sample queries."""
+    sentences = [
+        "A enchente de 2024 alagou completamente a cidade de Itaqui.",
+        "Maria contou sobre a perda da casa e dos animais.",
+        "O rio Uruguai subiu três metros em poucas horas.",
+        "A enchente foi terrível e o rio Uruguai transbordou na madrugada.",
+    ]
+    full_text = " ".join(sentences)
+    chunks: list[Chunk] = []
+    pos = 0
+    for i, sent in enumerate(sentences):
+        chunks.append(
+            Chunk(
+                chunk_id=f"chk_{i:013d}",
+                source_file_id=SOURCE_ID,
+                chunker_id=CHUNKER_ID,
+                start_char=pos,
+                end_char=pos + len(sent),
+            )
+        )
+        pos += len(sent) + 1  # +1 for the join space
+    resolver = ChunkResolver(text_loader=lambda _fid: full_text)
+    index_dir = tmp_path / "retrieval_indexes" / CHUNKER_ID / "bm25"
+    return chunks, resolver, index_dir
+
+
+class TestBM25BuildIndex:
+    def test_creates_index_and_manifest_files(self, tmp_path: Path) -> None:
+        chunks, resolver, index_dir = _build_corpus_fixture(tmp_path)
+        BM25Retriever.build_index(chunks, resolver, index_dir, CHUNKER_ID, language="pt")
+        assert (index_dir / INDEX_FILENAME).exists()
+        assert (index_dir / MANIFEST_FILENAME).exists()
+
+    def test_manifest_contains_required_fields(self, tmp_path: Path) -> None:
+        chunks, resolver, index_dir = _build_corpus_fixture(tmp_path)
+        BM25Retriever.build_index(chunks, resolver, index_dir, CHUNKER_ID, language="pt")
+        manifest = json.loads((index_dir / MANIFEST_FILENAME).read_text())
+        assert manifest["chunker_id"] == CHUNKER_ID
+        assert manifest["language"] == "pt"
+        assert manifest["chunks_indexed"] == 4
+        assert "built_at" in manifest  # ISO timestamp
+        assert manifest["chunk_ids"] == [c.chunk_id for c in chunks]
+
+    def test_creates_parent_directory(self, tmp_path: Path) -> None:
+        chunks, resolver, _ = _build_corpus_fixture(tmp_path)
+        nested = tmp_path / "a" / "b" / "c"  # multiple missing levels
+        BM25Retriever.build_index(chunks, resolver, nested, CHUNKER_ID, language="pt")
+        assert (nested / INDEX_FILENAME).exists()
+
+    def test_empty_chunks_raises(self, tmp_path: Path) -> None:
+        _, resolver, index_dir = _build_corpus_fixture(tmp_path)
+        with pytest.raises(ValueError, match="empty"):
+            BM25Retriever.build_index([], resolver, index_dir, CHUNKER_ID, language="pt")
+
+    def test_invalid_language_raises(self, tmp_path: Path) -> None:
+        chunks, resolver, index_dir = _build_corpus_fixture(tmp_path)
+        with pytest.raises(ValueError, match="Unsupported language"):
+            BM25Retriever.build_index(chunks, resolver, index_dir, CHUNKER_ID, language="fr")
+
+
+class TestBM25LoadAndConfig:
+    def test_loads_index_via_constructor(self, tmp_path: Path) -> None:
+        chunks, resolver, index_dir = _build_corpus_fixture(tmp_path)
+        BM25Retriever.build_index(chunks, resolver, index_dir, CHUNKER_ID, language="pt")
+        retriever = BM25Retriever(index_dir=index_dir, chunker_id=CHUNKER_ID)
+        assert retriever.retriever_id == f"bm25_{CHUNKER_ID}"
+
+    def test_satisfies_retriever_protocol(self, tmp_path: Path) -> None:
+        chunks, resolver, index_dir = _build_corpus_fixture(tmp_path)
+        BM25Retriever.build_index(chunks, resolver, index_dir, CHUNKER_ID, language="pt")
+        retriever = BM25Retriever(index_dir=index_dir, chunker_id=CHUNKER_ID)
+        assert isinstance(retriever, Retriever)
+
+    def test_missing_index_dir_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError, match="BM25 index"):
+            BM25Retriever(index_dir=tmp_path / "nonexistent", chunker_id=CHUNKER_ID)
+
+    def test_missing_manifest_raises(self, tmp_path: Path) -> None:
+        # Only the pickle exists, no manifest
+        idx_dir = tmp_path / "broken"
+        idx_dir.mkdir()
+        (idx_dir / INDEX_FILENAME).write_bytes(b"dummy")
+        with pytest.raises(FileNotFoundError, match="BM25 index"):
+            BM25Retriever(index_dir=idx_dir, chunker_id=CHUNKER_ID)
+
+
+class TestBM25Retrieve:
+    def test_retrieve_returns_at_most_top_k(self, tmp_path: Path) -> None:
+        chunks, resolver, index_dir = _build_corpus_fixture(tmp_path)
+        BM25Retriever.build_index(chunks, resolver, index_dir, CHUNKER_ID, language="pt")
+        retriever = BM25Retriever(index_dir=index_dir, chunker_id=CHUNKER_ID)
+        results = retriever.retrieve("enchente", top_k=2)
+        assert len(results) == 2
+
+    def test_retrieve_returns_ranked_zero_indexed(self, tmp_path: Path) -> None:
+        # "Itaqui Maria" — each token appears in exactly one doc (idf > 0), so the
+        # ranking is non-degenerate and scores monotonically decrease.
+        chunks, resolver, index_dir = _build_corpus_fixture(tmp_path)
+        BM25Retriever.build_index(chunks, resolver, index_dir, CHUNKER_ID, language="pt")
+        retriever = BM25Retriever(index_dir=index_dir, chunker_id=CHUNKER_ID)
+        results = retriever.retrieve("Itaqui Maria", top_k=4)
+        assert [p.rank for p in results] == [0, 1, 2, 3]
+        scores = [p.score for p in results]
+        assert all(scores[i] >= scores[i + 1] for i in range(len(scores) - 1))
+
+    def test_retrieve_ranks_relevant_chunks_first(self, tmp_path: Path) -> None:
+        # "Itaqui" appears only in chunk 0; "Maria" only in chunk 1.
+        # A combined query must place those two above chunks 2 and 3 (which match neither).
+        # (Using single-doc terms avoids BM25Okapi's idf=0 degeneracy at df=N/2.)
+        chunks, resolver, index_dir = _build_corpus_fixture(tmp_path)
+        BM25Retriever.build_index(chunks, resolver, index_dir, CHUNKER_ID, language="pt")
+        retriever = BM25Retriever(index_dir=index_dir, chunker_id=CHUNKER_ID)
+        results = retriever.retrieve("Itaqui Maria", top_k=4)
+        top_2_ids = {p.chunk_id for p in results[:2]}
+        assert top_2_ids == {chunks[0].chunk_id, chunks[1].chunk_id}
+        assert results[0].score > 0
+        assert results[1].score > 0
+        # Chunks 2 and 3 have neither term → score 0
+        assert results[2].score == 0
+        assert results[3].score == 0
+
+    def test_retrieve_deterministic(self, tmp_path: Path) -> None:
+        chunks, resolver, index_dir = _build_corpus_fixture(tmp_path)
+        BM25Retriever.build_index(chunks, resolver, index_dir, CHUNKER_ID, language="pt")
+        retriever = BM25Retriever(index_dir=index_dir, chunker_id=CHUNKER_ID)
+        results_a = retriever.retrieve("enchente rio", top_k=3)
+        results_b = retriever.retrieve("enchente rio", top_k=3)
+        assert [(p.chunk_id, p.rank, p.score) for p in results_a] == [
+            (p.chunk_id, p.rank, p.score) for p in results_b
+        ]
+
+    def test_retrieve_top_k_greater_than_corpus_returns_all(self, tmp_path: Path) -> None:
+        chunks, resolver, index_dir = _build_corpus_fixture(tmp_path)
+        BM25Retriever.build_index(chunks, resolver, index_dir, CHUNKER_ID, language="pt")
+        retriever = BM25Retriever(index_dir=index_dir, chunker_id=CHUNKER_ID)
+        results = retriever.retrieve("enchente", top_k=100)
+        # top_k > corpus size; returns all 4 chunks (RetrievalRecord enforces <= top_k separately)
+        assert len(results) == 4
+
+    def test_retrieve_meta_records_score_method(self, tmp_path: Path) -> None:
+        chunks, resolver, index_dir = _build_corpus_fixture(tmp_path)
+        BM25Retriever.build_index(chunks, resolver, index_dir, CHUNKER_ID, language="pt")
+        retriever = BM25Retriever(index_dir=index_dir, chunker_id=CHUNKER_ID)
+        results = retriever.retrieve("enchente", top_k=1)
+        assert results[0].retriever_meta == {"score_method": "bm25_okapi"}

--- a/tests/shared/rag/retrievers/test_bm25.py
+++ b/tests/shared/rag/retrievers/test_bm25.py
@@ -110,6 +110,21 @@ class TestBM25LoadAndConfig:
         with pytest.raises(FileNotFoundError, match="BM25 index"):
             BM25Retriever(index_dir=idx_dir, chunker_id=CHUNKER_ID)
 
+    def test_chunker_id_mismatch_raises(self, tmp_path: Path) -> None:
+        # Index built for CHUNKER_ID; load with a different chunker_id must fail loudly.
+        # Silent acceptance would corrupt retriever_id labels in RetrievalRecord.
+        chunks, resolver, index_dir = _build_corpus_fixture(tmp_path)
+        BM25Retriever.build_index(chunks, resolver, index_dir, CHUNKER_ID, language="pt")
+        with pytest.raises(ValueError, match="chunker_id mismatch"):
+            BM25Retriever(index_dir=index_dir, chunker_id="bm25_other", language="pt")
+
+    def test_language_mismatch_raises(self, tmp_path: Path) -> None:
+        # Index tokenized as Portuguese; load with English would silently destroy ranking.
+        chunks, resolver, index_dir = _build_corpus_fixture(tmp_path)
+        BM25Retriever.build_index(chunks, resolver, index_dir, CHUNKER_ID, language="pt")
+        with pytest.raises(ValueError, match="language mismatch"):
+            BM25Retriever(index_dir=index_dir, chunker_id=CHUNKER_ID, language="en")
+
 
 class TestBM25Retrieve:
     def test_retrieve_returns_at_most_top_k(self, tmp_path: Path) -> None:

--- a/tests/shared/rag/retrievers/test_bm25_tokenize.py
+++ b/tests/shared/rag/retrievers/test_bm25_tokenize.py
@@ -1,0 +1,67 @@
+"""Tests for BM25 tokenizers — whitespace fallback path (spec §4.3)."""
+
+from __future__ import annotations
+
+from arandu.shared.rag.retrievers._bm25_tokenize import (
+    _whitespace_tokenize,
+    english_tokenizer,
+    portuguese_tokenizer,
+)
+
+
+class TestWhitespaceFallback:
+    def test_lowercases_input(self) -> None:
+        assert _whitespace_tokenize("Hello World") == ["hello", "world"]
+
+    def test_strips_punctuation(self) -> None:
+        assert _whitespace_tokenize("Hello, world! How's it?") == [
+            "hello",
+            "world",
+            "how",
+            "s",
+            "it",
+        ]
+
+    def test_preserves_numerics(self) -> None:
+        # Spec §4.3: "Numerics preserved".
+        assert _whitespace_tokenize("Em 2024 caíram 350mm") == [
+            "em",
+            "2024",
+            "caíram",
+            "350mm",
+        ]
+
+    def test_preserves_portuguese_accents(self) -> None:
+        # NFKC keeps composed accents — important for accent-sensitive matching.
+        assert _whitespace_tokenize("Ação coração") == ["ação", "coração"]
+
+    def test_empty_string_returns_empty_list(self) -> None:
+        assert _whitespace_tokenize("") == []
+
+    def test_whitespace_only_returns_empty_list(self) -> None:
+        assert _whitespace_tokenize("   \n\t  ") == []
+
+    def test_collapses_internal_whitespace(self) -> None:
+        assert _whitespace_tokenize("a   b\n\tc") == ["a", "b", "c"]
+
+    def test_unicode_nfkc_normalization(self) -> None:
+        # Compatibility forms (ligature 'ﬁ' → "fi") get normalized before tokenization.
+        # Using a known NFKC compatibility decomposition.
+        assert _whitespace_tokenize("ﬁnal") == ["final"]
+
+
+class TestTokenizerFactories:
+    def test_portuguese_tokenizer_returns_callable(self) -> None:
+        tok = portuguese_tokenizer()
+        assert callable(tok)
+        # Smoke: the returned tokenizer produces a non-empty list for typical input
+        result = tok("Em que ano ocorreu a enchente?")
+        assert isinstance(result, list)
+        assert all(isinstance(t, str) for t in result)
+
+    def test_english_tokenizer_returns_callable(self) -> None:
+        tok = english_tokenizer()
+        assert callable(tok)
+        result = tok("When did the flood happen?")
+        assert isinstance(result, list)
+        assert all(isinstance(t, str) for t in result)

--- a/tests/shared/rag/retrievers/test_bm25_tokenize.py
+++ b/tests/shared/rag/retrievers/test_bm25_tokenize.py
@@ -1,12 +1,40 @@
-"""Tests for BM25 tokenizers — whitespace fallback path (spec §4.3)."""
+"""Tests for BM25 tokenizers — whitespace fallback + spaCy path (spec §4.3)."""
 
 from __future__ import annotations
+
+import pytest
 
 from arandu.shared.rag.retrievers._bm25_tokenize import (
     _whitespace_tokenize,
     english_tokenizer,
     portuguese_tokenizer,
 )
+
+
+def _spacy_pt_available() -> bool:
+    """Return True iff spaCy and pt_core_news_sm are importable+loadable."""
+    try:
+        import spacy
+    except ImportError:
+        return False
+    try:
+        spacy.load("pt_core_news_sm")
+    except OSError:
+        return False
+    return True
+
+
+def _spacy_en_available() -> bool:
+    """Return True iff spaCy and en_core_web_sm are importable+loadable."""
+    try:
+        import spacy
+    except ImportError:
+        return False
+    try:
+        spacy.load("en_core_web_sm")
+    except OSError:
+        return False
+    return True
 
 
 class TestWhitespaceFallback:
@@ -65,3 +93,36 @@ class TestTokenizerFactories:
         result = tok("When did the flood happen?")
         assert isinstance(result, list)
         assert all(isinstance(t, str) for t in result)
+
+
+class TestSpacyPath:
+    """Positive tests for the spaCy primary path.
+
+    These verify that when spaCy + the models are installed, the factories
+    return a lemmatizing-and-stopword-filtering tokenizer (not the fallback).
+    Skipped when spaCy or a model is unavailable so the suite still passes
+    on a fallback-only install.
+    """
+
+    @pytest.mark.skipif(not _spacy_pt_available(), reason="pt_core_news_sm not installed")
+    def test_portuguese_spacy_lemmatizes_verbs(self) -> None:
+        # "alagou" (3rd person singular preterite) → "alagar" (lemma) only via spaCy.
+        # The whitespace fallback would return ["alagou"].
+        tokens = portuguese_tokenizer()("A enchente alagou Itaqui.")
+        assert "alagar" in tokens, f"expected lemma 'alagar' in {tokens}"
+
+    @pytest.mark.skipif(not _spacy_pt_available(), reason="pt_core_news_sm not installed")
+    def test_portuguese_spacy_drops_stopwords(self) -> None:
+        # "a", "de", "e" are Portuguese stopwords — present in raw text, absent after spaCy.
+        # The whitespace fallback keeps them.
+        tokens = portuguese_tokenizer()("A enchente de 2024 e a chuva")
+        assert "a" not in tokens
+        assert "de" not in tokens
+        assert "e" not in tokens
+        assert "enchente" in tokens
+
+    @pytest.mark.skipif(not _spacy_en_available(), reason="en_core_web_sm not installed")
+    def test_english_spacy_lemmatizes_verbs(self) -> None:
+        # "flooded" → "flood" via spaCy lemmatization.
+        tokens = english_tokenizer()("The river flooded the village.")
+        assert "flood" in tokens, f"expected lemma 'flood' in {tokens}"

--- a/tests/shared/rag/retrievers/test_null.py
+++ b/tests/shared/rag/retrievers/test_null.py
@@ -1,0 +1,28 @@
+"""Tests for shared/rag/retrievers/null.py — NullRetriever parametric arm."""
+
+from __future__ import annotations
+
+from arandu.shared.rag.protocol import Retriever
+from arandu.shared.rag.retrievers.null import NullRetriever
+
+
+class TestNullRetriever:
+    def test_retriever_id_is_null(self) -> None:
+        assert NullRetriever().retriever_id == "null"
+
+    def test_satisfies_retriever_protocol(self) -> None:
+        assert isinstance(NullRetriever(), Retriever)
+
+    def test_retrieve_returns_empty_list(self) -> None:
+        retriever = NullRetriever()
+        assert retriever.retrieve("Em que ano ocorreu a enchente?", top_k=10) == []
+
+    def test_retrieve_returns_empty_regardless_of_top_k(self) -> None:
+        retriever = NullRetriever()
+        for k in (1, 5, 100):
+            assert retriever.retrieve("qualquer pergunta", top_k=k) == []
+
+    def test_retrieve_returns_empty_for_empty_question(self) -> None:
+        # Spec §4.6 says trivial implementation — input is not validated;
+        # the Answerer downstream simply receives no passages.
+        assert NullRetriever().retrieve("", top_k=5) == []

--- a/uv.lock
+++ b/uv.lock
@@ -147,6 +147,7 @@ dependencies = [
     { name = "accelerate" },
     { name = "bitsandbytes" },
     { name = "chonkie" },
+    { name = "en-core-web-sm" },
     { name = "fastapi" },
     { name = "google-api-python-client" },
     { name = "google-auth-httplib2" },
@@ -154,11 +155,13 @@ dependencies = [
     { name = "httpx" },
     { name = "networkx" },
     { name = "openai" },
+    { name = "pt-core-news-sm" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "rank-bm25" },
     { name = "rich" },
     { name = "sentencepiece" },
+    { name = "spacy" },
     { name = "tenacity" },
     { name = "transformers" },
     { name = "typer" },
@@ -198,6 +201,7 @@ requires-dist = [
     { name = "bitsandbytes", specifier = ">=0.49.1" },
     { name = "chonkie", specifier = ">=1.6.6" },
     { name = "datasets", marker = "extra == 'kg'", specifier = ">=2.18" },
+    { name = "en-core-web-sm", url = "https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl" },
     { name = "faiss-cpu", marker = "extra == 'kg'", specifier = ">=1.7" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "google-api-python-client", specifier = ">=2.100.0" },
@@ -209,12 +213,14 @@ requires-dist = [
     { name = "networkx", specifier = ">=3.1" },
     { name = "openai", specifier = ">=1.0.0" },
     { name = "plotly", marker = "extra == 'report'", specifier = ">=6.0.0" },
+    { name = "pt-core-news-sm", url = "https://github.com/explosion/spacy-models/releases/download/pt_core_news_sm-3.8.0/pt_core_news_sm-3.8.0-py3-none-any.whl" },
     { name = "pyarrow", marker = "extra == 'kg'", specifier = ">=15,<21" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
     { name = "rank-bm25", specifier = ">=0.2.2" },
     { name = "rich", specifier = ">=13.0.0" },
     { name = "sentencepiece", specifier = ">=0.2.1" },
+    { name = "spacy", specifier = ">=3.8.14" },
     { name = "tenacity", specifier = ">=8.0.0" },
     { name = "textual", marker = "extra == 'dashboard'", specifier = ">=3.0.0" },
     { name = "transformers", specifier = ">=4.57.3" },
@@ -283,6 +289,40 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/29/71/acff7af06c818664aa87ff73e17a52c7788ad746b72aea09d3cb8e424348/bitsandbytes-0.49.2-py3-none-manylinux_2_24_aarch64.whl", hash = "sha256:2fc0830c5f7169be36e60e11f2be067c8f812dfcb829801a8703735842450750", size = 31442815, upload-time = "2026-02-16T21:26:06.783Z" },
     { url = "https://files.pythonhosted.org/packages/19/57/3443d6f183436fbdaf5000aac332c4d5ddb056665d459244a5608e98ae92/bitsandbytes-0.49.2-py3-none-manylinux_2_24_x86_64.whl", hash = "sha256:54b771f06e1a3c73af5c7f16ccf0fc23a846052813d4b008d10cb6e017dd1c8c", size = 60651714, upload-time = "2026-02-16T21:26:11.579Z" },
     { url = "https://files.pythonhosted.org/packages/b6/d4/501655842ad6771fb077f576d78cbedb5445d15b1c3c91343ed58ca46f0e/bitsandbytes-0.49.2-py3-none-win_amd64.whl", hash = "sha256:2e0ddd09cd778155388023cbe81f00afbb7c000c214caef3ce83386e7144df7d", size = 55372289, upload-time = "2026-02-16T21:26:16.267Z" },
+]
+
+[[package]]
+name = "blis"
+version = "1.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d0/d0/d8cc8c9a4488a787e7fa430f6055e5bd1ddb22c340a751d9e901b82e2efe/blis-1.3.3.tar.gz", hash = "sha256:034d4560ff3cc43e8aa37e188451b0440e3261d989bb8a42ceee865607715ecd", size = 2644873, upload-time = "2025-11-17T12:28:30.511Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/f7/d26e62d9be3d70473a63e0a5d30bae49c2fe138bebac224adddcdef8a7ce/blis-1.3.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1e647341f958421a86b028a2efe16ce19c67dba2a05f79e8f7e80b1ff45328aa", size = 6928322, upload-time = "2025-11-17T12:27:57.965Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/78/750d12da388f714958eb2f2fd177652323bbe7ec528365c37129edd6eb84/blis-1.3.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d563160f874abb78a57e346f07312c5323f7ad67b6370052b6b17087ef234a8e", size = 1229635, upload-time = "2025-11-17T12:28:00.118Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/36/eac4199c5b200a5f3e93cad197da8d26d909f218eb444c4f552647c95240/blis-1.3.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:30b8a5b90cb6cb81d1ada9ae05aa55fb8e70d9a0ae9db40d2401bb9c1c8f14c4", size = 2815650, upload-time = "2025-11-17T12:28:02.544Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/51/472e7b36a6bedb5242a9757e7486f702c3619eff76e256735d0c8b1679c6/blis-1.3.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e9f5c53b277f6ac5b3ca30bc12ebab7ea16c8f8c36b14428abb56924213dc127", size = 11359008, upload-time = "2025-11-17T12:28:04.589Z" },
+    { url = "https://files.pythonhosted.org/packages/84/da/d0dfb6d6e6321ae44df0321384c32c322bd07b15740d7422727a1a49fc5d/blis-1.3.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6297e7616c158b305c9a8a4e47ca5fc9b0785194dd96c903b1a1591a7ca21ddf", size = 3011959, upload-time = "2025-11-17T12:28:06.862Z" },
+    { url = "https://files.pythonhosted.org/packages/20/c5/2b0b5e556fa0364ed671051ea078a6d6d7b979b1cfef78d64ad3ca5f0c7f/blis-1.3.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:3f966ca74f89f8a33e568b9a1d71992fc9a0d29a423e047f0a212643e21b5458", size = 14232456, upload-time = "2025-11-17T12:28:08.779Z" },
+    { url = "https://files.pythonhosted.org/packages/31/07/4cdc81a47bf862c0b06d91f1bc6782064e8b69ac9b5d4ff51d97e4ff03da/blis-1.3.3-cp313-cp313-win_amd64.whl", hash = "sha256:7a0fc4b237a3a453bdc3c7ab48d91439fcd2d013b665c46948d9eaf9c3e45a97", size = 6192624, upload-time = "2025-11-17T12:28:14.197Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/8a/80f7c68fbc24a76fc9c18522c46d6d69329c320abb18e26a707a5d874083/blis-1.3.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:c3e33cfbf22a418373766816343fcfcd0556012aa3ffdf562c29cddec448a415", size = 6934081, upload-time = "2025-11-17T12:28:16.436Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/52/d1aa3a51a7fc299b0c89dcaa971922714f50b1202769eebbdaadd1b5cff7/blis-1.3.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:6f165930e8d3a85c606d2003211497e28d528c7416fbfeafb6b15600963f7c9b", size = 1231486, upload-time = "2025-11-17T12:28:18.008Z" },
+    { url = "https://files.pythonhosted.org/packages/99/4f/badc7bd7f74861b26c10123bba7b9d16f99cd9535ad0128780360713820f/blis-1.3.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:878d4d96d8f2c7a2459024f013f2e4e5f46d708b23437dae970d998e7bff14a0", size = 2814944, upload-time = "2025-11-17T12:28:19.654Z" },
+    { url = "https://files.pythonhosted.org/packages/72/a6/f62a3bd814ca19ec7e29ac889fd354adea1217df3183e10217de51e2eb8b/blis-1.3.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f36c0ca84a05ee5d3dbaa38056c4423c1fc29948b17a7923dd2fed8967375d74", size = 11345825, upload-time = "2025-11-17T12:28:21.354Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/6c/671af79ee42bc4c968cae35c091ac89e8721c795bfa4639100670dc59139/blis-1.3.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e5a662c48cd4aad5dae1a950345df23957524f071315837a4c6feb7d3b288990", size = 3008771, upload-time = "2025-11-17T12:28:23.637Z" },
+    { url = "https://files.pythonhosted.org/packages/be/92/7cd7f8490da7c98ee01557f2105885cc597217b0e7fd2eeb9e22cdd4ef23/blis-1.3.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:9de26fbd72bac900c273b76d46f0b45b77a28eace2e01f6ac6c2239531a413bb", size = 14219213, upload-time = "2025-11-17T12:28:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/de/acae8e9f9a1f4bb393d41c8265898b0f29772e38eac14e9f69d191e2c006/blis-1.3.3-cp314-cp314-win_amd64.whl", hash = "sha256:9e5fdf4211b1972400f8ff6dafe87cb689c5d84f046b4a76b207c0bd2270faaf", size = 6324695, upload-time = "2025-11-17T12:28:28.401Z" },
+]
+
+[[package]]
+name = "catalogue"
+version = "2.0.10"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/38/b4/244d58127e1cdf04cf2dc7d9566f0d24ef01d5ce21811bab088ecc62b5ea/catalogue-2.0.10.tar.gz", hash = "sha256:4f56daa940913d3f09d589c191c74e5a6d51762b3a9e37dd53b7437afd6cda15", size = 19561, upload-time = "2023-09-25T06:29:24.962Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/96/d32b941a501ab566a16358d68b6eb4e4acc373fab3c3c4d7d9e649f7b4bb/catalogue-2.0.10-py3-none-any.whl", hash = "sha256:58c2de0020aa90f4a2da7dfad161bf7b3b054c86a5f09fcedc0b2b740c109a9f", size = 17325, upload-time = "2023-09-25T06:29:23.337Z" },
 ]
 
 [[package]]
@@ -412,11 +452,29 @@ wheels = [
 ]
 
 [[package]]
+name = "cloudpathlib"
+version = "0.24.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/19/58bc6b5d7d0f81c7209b05445af477e147c486552f96665a5912211839b9/cloudpathlib-0.24.0.tar.gz", hash = "sha256:c521a984e77b47e656fe78e20a7e3e260e0ab45fc69e33ac01094227c979e34a", size = 53600, upload-time = "2026-04-30T00:54:43.265Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/5b/ba933f896d9b0b07608d575a8501e2b4e32166b60d84c430a4a7285ebe64/cloudpathlib-0.24.0-py3-none-any.whl", hash = "sha256:b1c51e2d2ec7dc4fed6538991f4aea849d6cf11a7e6b9069f86e461aa1f9b5b4", size = 63214, upload-time = "2026-04-30T00:54:42.06Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://download.pytorch.org/whl/cu124" }
 wheels = [
     { url = "https://download.pytorch.org/whl/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", upload-time = "2023-10-05T23:50:34Z" },
+]
+
+[[package]]
+name = "confection"
+version = "1.3.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/65/efd0fe8a936fc8ca2978cb7b82581fb20d901c6039e746a808f746b7647b/confection-1.3.3.tar.gz", hash = "sha256:f0f6810d567ff73993fe74d218ca5e1ffb6a44fb03f391257fc5d033546cbfaa", size = 54895, upload-time = "2026-03-24T18:45:24.331Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/e4/d66708bdf0d92fb4d49b22cdff4b10cec38aca5dcd7e81d909bb55c65cd7/confection-1.3.3-py3-none-any.whl", hash = "sha256:b9fef9ee84b237ef4611ec3eb5797b70e13063e6310ad9f15536373f5e313c82", size = 35902, upload-time = "2026-03-24T18:45:22.664Z" },
 ]
 
 [[package]]
@@ -542,6 +600,46 @@ wheels = [
 ]
 
 [[package]]
+name = "cymem"
+version = "2.0.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/2f0fbb32535c3731b7c2974c569fb9325e0a38ed5565a08e1139a3b71e82/cymem-2.0.13.tar.gz", hash = "sha256:1c91a92ae8c7104275ac26bd4d29b08ccd3e7faff5893d3858cb6fadf1bc1588", size = 12320, upload-time = "2025-11-14T14:58:36.902Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/0f/95a4d1e3bebfdfa7829252369357cf9a764f67569328cd9221f21e2c952e/cymem-2.0.13-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:891fd9030293a8b652dc7fb9fdc79a910a6c76fc679cd775e6741b819ffea476", size = 43478, upload-time = "2025-11-14T14:57:42.682Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/a0/8fc929cc29ae466b7b4efc23ece99cbd3ea34992ccff319089c624d667fd/cymem-2.0.13-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:89c4889bd16513ce1644ccfe1e7c473ba7ca150f0621e66feac3a571bde09e7e", size = 42695, upload-time = "2025-11-14T14:57:43.741Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/b3/deeb01354ebaf384438083ffe0310209ef903db3e7ba5a8f584b06d28387/cymem-2.0.13-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:45dcaba0f48bef9cc3d8b0b92058640244a95a9f12542210b51318da97c2cf28", size = 250573, upload-time = "2025-11-14T14:57:44.81Z" },
+    { url = "https://files.pythonhosted.org/packages/36/36/bc980b9a14409f3356309c45a8d88d58797d02002a9d794dd6c84e809d3a/cymem-2.0.13-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e96848faaafccc0abd631f1c5fb194eac0caee4f5a8777fdbb3e349d3a21741c", size = 254572, upload-time = "2025-11-14T14:57:46.023Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/dd/a12522952624685bd0f8968e26d2ed6d059c967413ce6eb52292f538f1b0/cymem-2.0.13-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e02d3e2c3bfeb21185d5a4a70790d9df40629a87d8d7617dc22b4e864f665fa3", size = 248060, upload-time = "2025-11-14T14:57:47.605Z" },
+    { url = "https://files.pythonhosted.org/packages/08/11/5dc933ddfeb2dfea747a0b935cb965b9a7580b324d96fc5f5a1b5ff8df29/cymem-2.0.13-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:fece5229fd5ecdcd7a0738affb8c59890e13073ae5626544e13825f26c019d3c", size = 254601, upload-time = "2025-11-14T14:57:48.861Z" },
+    { url = "https://files.pythonhosted.org/packages/70/66/d23b06166864fa94e13a98e5922986ce774832936473578febce64448d75/cymem-2.0.13-cp313-cp313-win_amd64.whl", hash = "sha256:38aefeb269597c1a0c2ddf1567dd8605489b661fa0369c6406c1acd433b4c7ba", size = 40103, upload-time = "2025-11-14T14:57:50.396Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/9e/c7b21271ab88a21760f3afdec84d2bc09ffa9e6c8d774ad9d4f1afab0416/cymem-2.0.13-cp313-cp313-win_arm64.whl", hash = "sha256:717270dcfd8c8096b479c42708b151002ff98e434a7b6f1f916387a6c791e2ad", size = 36016, upload-time = "2025-11-14T14:57:51.611Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/28/d3b03427edc04ae04910edf1c24b993881c3ba93a9729a42bcbb816a1808/cymem-2.0.13-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:7e1a863a7f144ffb345397813701509cfc74fc9ed360a4d92799805b4b865dd1", size = 46429, upload-time = "2025-11-14T14:57:52.582Z" },
+    { url = "https://files.pythonhosted.org/packages/35/a9/7ed53e481f47ebfb922b0b42e980cec83e98ccb2137dc597ea156642440c/cymem-2.0.13-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:c16cb80efc017b054f78998c6b4b013cef509c7b3d802707ce1f85a1d68361bf", size = 46205, upload-time = "2025-11-14T14:57:53.64Z" },
+    { url = "https://files.pythonhosted.org/packages/61/39/a3d6ad073cf7f0fbbb8bbf09698c3c8fac11be3f791d710239a4e8dd3438/cymem-2.0.13-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0d78a27c88b26c89bd1ece247d1d5939dba05a1dae6305aad8fd8056b17ddb51", size = 296083, upload-time = "2025-11-14T14:57:55.922Z" },
+    { url = "https://files.pythonhosted.org/packages/36/0c/20697c8bc19f624a595833e566f37d7bcb9167b0ce69de896eba7cfc9c2d/cymem-2.0.13-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6d36710760f817194dacb09d9fc45cb6a5062ed75e85f0ef7ad7aeeb13d80cc3", size = 286159, upload-time = "2025-11-14T14:57:57.106Z" },
+    { url = "https://files.pythonhosted.org/packages/82/d4/9326e3422d1c2d2b4a8fb859bdcce80138f6ab721ddafa4cba328a505c71/cymem-2.0.13-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c8f30971cadd5dcf73bcfbbc5849b1f1e1f40db8cd846c4aa7d3b5e035c7b583", size = 288186, upload-time = "2025-11-14T14:57:58.334Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/bc/68da7dd749b72884dc22e898562f335002d70306069d496376e5ff3b6153/cymem-2.0.13-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:9d441d0e45798ec1fd330373bf7ffa6b795f229275f64016b6a193e6e2a51522", size = 290353, upload-time = "2025-11-14T14:58:00.562Z" },
+    { url = "https://files.pythonhosted.org/packages/50/23/dbf2ad6ecd19b99b3aab6203b1a06608bbd04a09c522d836b854f2f30f73/cymem-2.0.13-cp313-cp313t-win_amd64.whl", hash = "sha256:d1c950eebb9f0f15e3ef3591313482a5a611d16fc12d545e2018cd607f40f472", size = 44764, upload-time = "2025-11-14T14:58:01.793Z" },
+    { url = "https://files.pythonhosted.org/packages/54/3f/35701c13e1fc7b0895198c8b20068c569a841e0daf8e0b14d1dc0816b28f/cymem-2.0.13-cp313-cp313t-win_arm64.whl", hash = "sha256:042e8611ef862c34a97b13241f5d0da86d58aca3cecc45c533496678e75c5a1f", size = 38964, upload-time = "2025-11-14T14:58:02.87Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/2e/f0e1596010a9a57fa9ebd124a678c07c5b2092283781ae51e79edcf5cb98/cymem-2.0.13-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:d2a4bf67db76c7b6afc33de44fb1c318207c3224a30da02c70901936b5aafdf1", size = 43812, upload-time = "2025-11-14T14:58:04.227Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/45/8ccc21df08fcbfa6aa3efeb7efc11a1c81c90e7476e255768bb9c29ba02a/cymem-2.0.13-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:92a2ce50afa5625fb5ce7c9302cee61e23a57ccac52cd0410b4858e572f8614b", size = 42951, upload-time = "2025-11-14T14:58:05.424Z" },
+    { url = "https://files.pythonhosted.org/packages/01/8c/fe16531631f051d3d1226fa42e2d76fd2c8d5cfa893ec93baee90c7a9d90/cymem-2.0.13-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:bc116a70cc3a5dc3d1684db5268eff9399a0be8603980005e5b889564f1ea42f", size = 249878, upload-time = "2025-11-14T14:58:06.95Z" },
+    { url = "https://files.pythonhosted.org/packages/47/4b/39d67b80ffb260457c05fcc545de37d82e9e2dbafc93dd6b64f17e09b933/cymem-2.0.13-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:68489bf0035c4c280614067ab6a82815b01dc9fcd486742a5306fe9f68deb7ef", size = 252571, upload-time = "2025-11-14T14:58:08.232Z" },
+    { url = "https://files.pythonhosted.org/packages/53/0e/76f6531f74dfdfe7107899cce93ab063bb7ee086ccd3910522b31f623c08/cymem-2.0.13-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:03cb7bdb55718d5eb6ef0340b1d2430ba1386db30d33e9134d01ba9d6d34d705", size = 248555, upload-time = "2025-11-14T14:58:09.429Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/7c/eee56757db81f0aefc2615267677ae145aff74228f529838425057003c0d/cymem-2.0.13-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:1710390e7fb2510a8091a1991024d8ae838fd06b02cdfdcd35f006192e3c6b0e", size = 254177, upload-time = "2025-11-14T14:58:10.594Z" },
+    { url = "https://files.pythonhosted.org/packages/77/e0/a4b58ec9e53c836dce07ef39837a64a599f4a21a134fc7ca57a3a8f9a4b5/cymem-2.0.13-cp314-cp314-win_amd64.whl", hash = "sha256:ac699c8ec72a3a9de8109bd78821ab22f60b14cf2abccd970b5ff310e14158ed", size = 40853, upload-time = "2025-11-14T14:58:12.116Z" },
+    { url = "https://files.pythonhosted.org/packages/61/81/9931d1f83e5aeba175440af0b28f0c2e6f71274a5a7b688bc3e907669388/cymem-2.0.13-cp314-cp314-win_arm64.whl", hash = "sha256:90c2d0c04bcda12cd5cebe9be93ce3af6742ad8da96e1b1907e3f8e00291def1", size = 36970, upload-time = "2025-11-14T14:58:13.114Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/ef/af447c2184dec6dec973be14614df8ccb4d16d1c74e0784ab4f02538433c/cymem-2.0.13-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:ff036bbc1464993552fd1251b0a83fe102af334b301e3896d7aa05a4999ad042", size = 46804, upload-time = "2025-11-14T14:58:14.113Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/95/e10f33a8d4fc17f9b933d451038218437f9326c2abb15a3e7f58ce2a06ec/cymem-2.0.13-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:fb8291691ba7ff4e6e000224cc97a744a8d9588418535c9454fd8436911df612", size = 46254, upload-time = "2025-11-14T14:58:15.156Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/7a/5efeb2d2ea6ebad2745301ad33a4fa9a8f9a33b66623ee4d9185683007a6/cymem-2.0.13-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d8d06ea59006b1251ad5794bcc00121e148434826090ead0073c7b7fedebe431", size = 296061, upload-time = "2025-11-14T14:58:16.254Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/28/2a3f65842cc8443c2c0650cf23d525be06c8761ab212e0a095a88627be1b/cymem-2.0.13-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c0046a619ecc845ccb4528b37b63426a0cbcb4f14d7940add3391f59f13701e6", size = 285784, upload-time = "2025-11-14T14:58:17.412Z" },
+    { url = "https://files.pythonhosted.org/packages/98/73/dd5f9729398f0108c2e71d942253d0d484d299d08b02e474d7cfc43ed0b0/cymem-2.0.13-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:18ad5b116a82fa3674bc8838bd3792891b428971e2123ae8c0fd3ca472157c5e", size = 288062, upload-time = "2025-11-14T14:58:20.225Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/01/ffe51729a8f961a437920560659073e47f575d4627445216c1177ecd4a41/cymem-2.0.13-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:666ce6146bc61b9318aa70d91ce33f126b6344a25cf0b925621baed0c161e9cc", size = 290465, upload-time = "2025-11-14T14:58:21.815Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/ac/c9e7d68607f71ef978c81e334ab2898b426944c71950212b1467186f69f9/cymem-2.0.13-cp314-cp314t-win_amd64.whl", hash = "sha256:84c1168c563d9d1e04546cb65e3e54fde2bf814f7c7faf11fc06436598e386d1", size = 46665, upload-time = "2025-11-14T14:58:23.512Z" },
+    { url = "https://files.pythonhosted.org/packages/66/66/150e406a2db5535533aa3c946de58f0371f2e412e23f050c704588023e6e/cymem-2.0.13-cp314-cp314t-win_arm64.whl", hash = "sha256:e9027764dc5f1999fb4b4cabee1d0322c59e330c0a6485b436a68275f614277f", size = 39715, upload-time = "2025-11-14T14:58:24.773Z" },
+]
+
+[[package]]
 name = "datasets"
 version = "2.19.1"
 source = { registry = "https://pypi.org/simple" }
@@ -592,6 +690,14 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/2c/77/850bef8d72ffb9219f0b1aac23fbc1bf7d038ee6ea666f331fa273031aa2/einops-0.8.2.tar.gz", hash = "sha256:609da665570e5e265e27283aab09e7f279ade90c4f01bcfca111f3d3e13f2827", size = 56261, upload-time = "2026-01-26T04:13:17.638Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/09/f8d8f8f31e4483c10a906437b4ce31bdf3d6d417b73fe33f1a8b59e34228/einops-0.8.2-py3-none-any.whl", hash = "sha256:54058201ac7087911181bfec4af6091bb59380360f069276601256a76af08193", size = 65638, upload-time = "2026-01-26T04:13:18.546Z" },
+]
+
+[[package]]
+name = "en-core-web-sm"
+version = "3.8.0"
+source = { url = "https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl" }
+wheels = [
+    { url = "https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl", hash = "sha256:1932429db727d4bff3deed6b34cfc05df17794f4a52eeb26cf8928f7c1a0fb85" },
 ]
 
 [[package]]
@@ -1288,6 +1394,46 @@ wheels = [
 ]
 
 [[package]]
+name = "murmurhash"
+version = "1.0.15"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/23/2e/88c147931ea9725d634840d538622e94122bceaf346233349b7b5c62964b/murmurhash-1.0.15.tar.gz", hash = "sha256:58e2b27b7847f9e2a6edf10b47a8c8dd70a4705f45dccb7bf76aeadacf56ba01", size = 13291, upload-time = "2025-11-14T09:51:15.272Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/2f/ba300b5f04dae0409202d6285668b8a9d3ade43a846abee3ef611cb388d5/murmurhash-1.0.15-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:fe50dc70e52786759358fd1471e309b94dddfffb9320d9dfea233c7684c894ba", size = 27861, upload-time = "2025-11-14T09:50:23.804Z" },
+    { url = "https://files.pythonhosted.org/packages/34/02/29c19d268e6f4ea1ed2a462c901eed1ed35b454e2cbc57da592fad663ac6/murmurhash-1.0.15-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1349a7c23f6092e7998ddc5bd28546cc31a595afc61e9fdb3afc423feec3d7ad", size = 27840, upload-time = "2025-11-14T09:50:25.146Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/63/58e2de2b5232cd294c64092688c422196e74f9fa8b3958bdf02d33df24b9/murmurhash-1.0.15-cp313-cp313-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b3ba6d05de2613535b5a9227d4ad8ef40a540465f64660d4a8800634ae10e04f", size = 133080, upload-time = "2025-11-14T09:50:26.566Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/9a/d13e2e9f8ba1ced06840921a50f7cece0a475453284158a3018b72679761/murmurhash-1.0.15-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fa1b70b3cc2801ab44179c65827bbd12009c68b34e9d9ce7125b6a0bd35af63c", size = 132648, upload-time = "2025-11-14T09:50:27.788Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/e1/47994f1813fa205c84977b0ff51ae6709f8539af052c7491a5f863d82bdc/murmurhash-1.0.15-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:213d710fb6f4ef3bc11abbfad0fa94a75ffb675b7dc158c123471e5de869f9af", size = 131502, upload-time = "2025-11-14T09:50:29.339Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/ea/90c1fd00b4aeb704fb5e84cd666b33ffd7f245155048071ffbb51d2bb57d/murmurhash-1.0.15-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b65a5c4e7f5d71f7ccac2d2b60bdf7092d7976270878cfec59d5a66a533db823", size = 132736, upload-time = "2025-11-14T09:50:30.545Z" },
+    { url = "https://files.pythonhosted.org/packages/00/db/da73462dbfa77f6433b128d2120ba7ba300f8c06dc4f4e022c38d240a5f5/murmurhash-1.0.15-cp313-cp313-win_amd64.whl", hash = "sha256:9aba94c5d841e1904cd110e94ceb7f49cfb60a874bbfb27e0373622998fb7c7c", size = 25682, upload-time = "2025-11-14T09:50:31.624Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/83/032729ef14971b938fbef41ee125fc8800020ee229bd35178b6ede8ee934/murmurhash-1.0.15-cp313-cp313-win_arm64.whl", hash = "sha256:263807eca40d08c7b702413e45cca75ecb5883aa337237dc5addb660f1483378", size = 23370, upload-time = "2025-11-14T09:50:33.264Z" },
+    { url = "https://files.pythonhosted.org/packages/10/83/7547d9205e9bd2f8e5dfd0b682cc9277594f98909f228eb359489baec1df/murmurhash-1.0.15-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:694fd42a74b7ce257169d14c24aa616aa6cd4ccf8abe50eca0557e08da99d055", size = 29955, upload-time = "2025-11-14T09:50:34.488Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/c7/3afd5de7a5b3ae07fe2d3a3271b327ee1489c58ba2b2f2159bd31a25edb9/murmurhash-1.0.15-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:a2ea4546ba426390beff3cd10db8f0152fdc9072c4f2583ec7d8aa9f3e4ac070", size = 30108, upload-time = "2025-11-14T09:50:35.53Z" },
+    { url = "https://files.pythonhosted.org/packages/02/69/d6637ee67d78ebb2538c00411f28ea5c154886bbe1db16c49435a8a4ab16/murmurhash-1.0.15-cp313-cp313t-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:34e5a91139c40b10f98d0b297907f5d5267b4b1b2e5dd2eb74a021824f751b98", size = 164054, upload-time = "2025-11-14T09:50:36.591Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/4c/89e590165b4c7da6bf941441212a721a270195332d3aacfdfdf527d466ca/murmurhash-1.0.15-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:dc35606868a5961cf42e79314ca0bddf5a400ce377b14d83192057928d6252ec", size = 168153, upload-time = "2025-11-14T09:50:37.856Z" },
+    { url = "https://files.pythonhosted.org/packages/07/7a/95c42df0c21d2e413b9fcd17317a7587351daeb264dc29c6aec1fdbd26f8/murmurhash-1.0.15-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:43cc6ac3b91ca0f7a5ae9c063ba4d6c26972c97fd7c25280ecc666413e4c5535", size = 164345, upload-time = "2025-11-14T09:50:39.346Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/22/9d02c880a88b83bb3ce7d6a38fb727373ab78d82e5f3d8d9fc5612219f90/murmurhash-1.0.15-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:847d712136cb462f0e4bd6229ee2d9eb996d8854eb8312dff3d20c8f5181fda5", size = 161990, upload-time = "2025-11-14T09:50:40.689Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/e3/750232524e0dc262e8dcede6536dafc766faadd9a52f1d23746b02948ad8/murmurhash-1.0.15-cp313-cp313t-win_amd64.whl", hash = "sha256:2680851af6901dbe66cc4aa7ef8e263de47e6e1b425ae324caa571bdf18f8d58", size = 28812, upload-time = "2025-11-14T09:50:41.971Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/89/4ad9d215ef6ade89f27a72dc4e86b98ef1a43534cc3e6a6900a362a0bf0a/murmurhash-1.0.15-cp313-cp313t-win_arm64.whl", hash = "sha256:189a8de4d657b5da9efd66601b0636330b08262b3a55431f2379097c986995d0", size = 25398, upload-time = "2025-11-14T09:50:43.023Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/69/726df275edf07688146966e15eaaa23168100b933a2e1a29b37eb56c6db8/murmurhash-1.0.15-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:7c4280136b738e85ff76b4bdc4341d0b867ee753e73fd8b6994288080c040d0b", size = 28029, upload-time = "2025-11-14T09:50:44.124Z" },
+    { url = "https://files.pythonhosted.org/packages/59/8f/24ecf9061bc2b20933df8aba47c73e904274ea8811c8300cab92f6f82372/murmurhash-1.0.15-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d4d681f474830489e2ec1d912095cfff027fbaf2baa5414c7e9d25b89f0fab68", size = 27912, upload-time = "2025-11-14T09:50:45.266Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/26/fff3caba25aa3c0622114e03c69fb66c839b22335b04d7cce91a3a126d44/murmurhash-1.0.15-cp314-cp314-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:d7e47c5746785db6a43b65fac47b9e63dd71dfbd89a8c92693425b9715e68c6e", size = 131847, upload-time = "2025-11-14T09:50:46.819Z" },
+    { url = "https://files.pythonhosted.org/packages/df/e4/0f2b9fc533467a27afb4e906c33f32d5f637477de87dd94690e0c44335a6/murmurhash-1.0.15-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e8e674f02a99828c8a671ba99cd03299381b2f0744e6f25c29cadfc6151dc724", size = 132267, upload-time = "2025-11-14T09:50:48.298Z" },
+    { url = "https://files.pythonhosted.org/packages/da/bf/9d1c107989728ec46e25773d503aa54070b32822a18cfa7f9d5f41bc17a5/murmurhash-1.0.15-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:26fd7c7855ac4850ad8737991d7b0e3e501df93ebaf0cf45aa5954303085fdba", size = 131894, upload-time = "2025-11-14T09:50:49.485Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/81/dcf27c71445c0e993b10e33169a098ca60ee702c5c58fcbde205fa6332a6/murmurhash-1.0.15-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:cb8ebafae60d5f892acff533cc599a359954d8c016a829514cb3f6e9ee10f322", size = 132054, upload-time = "2025-11-14T09:50:50.747Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/32/e874a14b2d2246bd2d16f80f49fad393a3865d4ee7d66d2cae939a67a29a/murmurhash-1.0.15-cp314-cp314-win_amd64.whl", hash = "sha256:898a629bf111f1aeba4437e533b5b836c0a9d2dd12d6880a9c75f6ca13e30e22", size = 26579, upload-time = "2025-11-14T09:50:52.278Z" },
+    { url = "https://files.pythonhosted.org/packages/af/8e/4fca051ed8ae4d23a15aaf0a82b18cb368e8cf84f1e3b474d5749ec46069/murmurhash-1.0.15-cp314-cp314-win_arm64.whl", hash = "sha256:88dc1dd53b7b37c0df1b8b6bce190c12763014492f0269ff7620dc6027f470f4", size = 24341, upload-time = "2025-11-14T09:50:53.295Z" },
+    { url = "https://files.pythonhosted.org/packages/38/9c/c72c2a4edd86aac829337ab9f83cf04cdb15e5d503e4c9a3a243f30a261c/murmurhash-1.0.15-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:6cb4e962ec4f928b30c271b2d84e6707eff6d942552765b663743cfa618b294b", size = 30146, upload-time = "2025-11-14T09:50:54.705Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/d7/72b47ebc86436cd0aa1fd4c6e8779521ec389397ac11389990278d0f7a47/murmurhash-1.0.15-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5678a3ea4fbf0cbaaca2bed9b445f556f294d5f799c67185d05ffcb221a77faf", size = 30141, upload-time = "2025-11-14T09:50:55.829Z" },
+    { url = "https://files.pythonhosted.org/packages/64/bb/6d2f09135079c34dc2d26e961c52742d558b320c61503f273eab6ba743d9/murmurhash-1.0.15-cp314-cp314t-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:ef19f38c6b858eef83caf710773db98c8f7eb2193b4c324650c74f3d8ba299e0", size = 163898, upload-time = "2025-11-14T09:50:56.946Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/e2/9c1b462e33f9cb2d632056f07c90b502fc20bd7da50a15d0557343bd2fed/murmurhash-1.0.15-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:22aa3ceaedd2e57078b491ed08852d512b84ff4ff9bb2ff3f9bf0eec7f214c9e", size = 168040, upload-time = "2025-11-14T09:50:58.234Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/73/8694db1408fcdfa73589f7df6c445437ea146986fa1e393ec60d26d6e30c/murmurhash-1.0.15-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bba0e0262c0d08682b028cb963ac477bd9839029486fa1333fc5c01fb6072749", size = 164239, upload-time = "2025-11-14T09:50:59.95Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/f9/8e360bdfc3c44e267e7e046f0e0b9922766da92da26959a6963f597e6bb5/murmurhash-1.0.15-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4fd8189ee293a09f30f4931408f40c28ccd42d9de4f66595f8814879339378bc", size = 161811, upload-time = "2025-11-14T09:51:01.289Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/31/97649680595b1096803d877ababb9a67c07f4378f177ec885eea28b9db6d/murmurhash-1.0.15-cp314-cp314t-win_amd64.whl", hash = "sha256:66395b1388f7daa5103db92debe06842ae3be4c0749ef6db68b444518666cdcc", size = 29817, upload-time = "2025-11-14T09:51:02.493Z" },
+    { url = "https://files.pythonhosted.org/packages/76/66/4fce8755f25d77324401886c00017c556be7ca3039575b94037aff905385/murmurhash-1.0.15-cp314-cp314t-win_arm64.whl", hash = "sha256:c22e56c6a0b70598a66e456de5272f76088bc623688da84ef403148a6d41851d", size = 26219, upload-time = "2025-11-14T09:51:03.563Z" },
+]
+
+[[package]]
 name = "narwhals"
 version = "2.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1649,6 +1795,42 @@ wheels = [
 ]
 
 [[package]]
+name = "preshed"
+version = "3.0.13"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cymem" },
+    { name = "murmurhash" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/75/fe6b7bbd0dea530a001b0e24c331b21a0be2786e402abf3c57f5dce43d4b/preshed-3.0.13.tar.gz", hash = "sha256:d75f718bbfd97e992f7827e0fa7faf6a91bdd9c922d5baa4b50d62731396cb89", size = 18338, upload-time = "2026-03-23T08:57:31.378Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/2a/401158195d6dc7f6aef0b354d74d0e95c9da124499448c2b3dbb95b71204/preshed-3.0.13-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c0d0c14187dc0078d8a63bf190ec045a4d13e7748b6caeb557a7d575e411410b", size = 137289, upload-time = "2026-03-23T08:56:46.516Z" },
+    { url = "https://files.pythonhosted.org/packages/88/8f/e20e64573988528785447a6893b2e7ab287ecfd85b3888e978b28812fd20/preshed-3.0.13-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7770987c2e57497cd26124a9be5f652b5b3ccd0def89859ab0da8bca6144a3de", size = 136847, upload-time = "2026-03-23T08:56:47.572Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/72/18168f881359c4482d312f8dc196371bdd61c1583a52b34390da4c88bbea/preshed-3.0.13-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:4a7bc48220de579be6bdb0a8715482cf36e2a625a6fd5ad26c9f43485a4a23b5", size = 831478, upload-time = "2026-03-23T08:56:48.769Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/3a/3543476091087102775568cea9885dde3453569e9aeee365809108de572f/preshed-3.0.13-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e5c8462472f790c16708306aef3a102a762bd19dfe3d2f8ee08bd5e12f51b835", size = 839913, upload-time = "2026-03-23T08:56:49.937Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/65/b13f01329decc44ef53cfb6b4601ba85382dcb2a4ec78d9250f03a418066/preshed-3.0.13-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c046736239cc8d72670749b79b526e4111839a2fc461a58545d212797649129c", size = 1816452, upload-time = "2026-03-23T08:56:51.233Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/c7/f1a996c6832234efd4d543041b582418d41ac480ee55c557ec9e65344637/preshed-3.0.13-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7c333f18e9a81c8a6de0603fd8781e17115324b117c445ca91abdf7bfb1abe49", size = 1888978, upload-time = "2026-03-23T08:56:52.591Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/b9/96fb71499049885ce19545903fdd38877bbc2be0da47e37c04d01f3e9f66/preshed-3.0.13-cp313-cp313-win_amd64.whl", hash = "sha256:461327f8dd36520dcf1fd55a671e0c3c2c97a2d95e22fc85faa31173f4785dda", size = 122134, upload-time = "2026-03-23T08:56:54.392Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/a7/32a4903019d936a2316fdd330bedddac287ac26326107d24fb76a1fbc60a/preshed-3.0.13-cp313-cp313-win_arm64.whl", hash = "sha256:35d6c5acb3ee3b12b87a551913063f0cec784055c2af16e028c19fe875f079d0", size = 108497, upload-time = "2026-03-23T08:56:55.816Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/b5/993886c98f5caaa6f07a648cac97a7c62a3093091cad65e1e43a1bd41cc4/preshed-3.0.13-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:d2f1efae396cadab5f3890a2fd43d2ee65373ef9096ccbb805e51e8d8bcc563b", size = 137882, upload-time = "2026-03-23T08:56:56.878Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/86/b7fd137cbf140afd6c45e895946068a15f5b55642916de0075e6eb18581c/preshed-3.0.13-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:8d6acc1f5031a535a55a6f7148e2f274554a8343a16309c700cebea0fe7aee8c", size = 138233, upload-time = "2026-03-23T08:56:58.318Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/ca/21a7e79625614134273dfed32bca5bb4c2ec1313e33fbd12d41657536f1f/preshed-3.0.13-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7da9d931e7660dcdd757e5870269f0c159126d682ed73ed313971d199eb0f334", size = 834835, upload-time = "2026-03-23T08:56:59.48Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/3a/2dbd299516461831ae90e0d5b0637137bf28520c4e6dd0b01d6f1886659a/preshed-3.0.13-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d4ae5cfe075bb7a07982e382bca44f41ddf041f4d24cbd358e8cccfc049259b8", size = 834928, upload-time = "2026-03-23T08:57:01.075Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/d3/af654eba4f6587c4ee02c5043e62c194b0a1c4431ffef0c67b9518f6b61c/preshed-3.0.13-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7557963d0125a3a7bcdb2eb6948f3e45da31b5a7f066b55320de3dea22d7557f", size = 1820368, upload-time = "2026-03-23T08:57:02.351Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/9b/ebcb2b9e8cb881e40b55b0bf450f8a6b187e2ef3ae0c685cce81d2d85026/preshed-3.0.13-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c4bc60dc994864095d784b7e4d77dba3e64188d169ac88722b699d175561fddb", size = 1888251, upload-time = "2026-03-23T08:57:04.158Z" },
+    { url = "https://files.pythonhosted.org/packages/97/f7/c6c012779edcaa6e2cd092c554e98dc53e77f41205b07208655ba77e2327/preshed-3.0.13-cp314-cp314-win_amd64.whl", hash = "sha256:208dcebbe294bf1881ce33fb015d56ab2a7587aece85a09147727174207892e4", size = 125211, upload-time = "2026-03-23T08:57:05.83Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/82/390ef87d732ef64e673ef6bf9e5d898453986e979efa50fb3a400e2c0766/preshed-3.0.13-cp314-cp314-win_arm64.whl", hash = "sha256:cf8e1a7a1823b2a7765121446c630140ac6e8650c07a6efbf375e168d1fef4f7", size = 111942, upload-time = "2026-03-23T08:57:06.996Z" },
+    { url = "https://files.pythonhosted.org/packages/80/3a/a9dde3167bcecb27ae82ce4567b5ab1aa3989113ae6814c092ce223cc4ef/preshed-3.0.13-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:9ca43ecbc3783eda4d6ab3416ae2ecd9ef23dca5f53995843f69f7457bcd0677", size = 144997, upload-time = "2026-03-23T08:57:08.064Z" },
+    { url = "https://files.pythonhosted.org/packages/74/d4/22d9355b50b6a13b407dcad0a81df83fb1d5602092d1f05834674dde8fda/preshed-3.0.13-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c8596e41a258ff213553a441e0bb3eb388fd8158e84a7bf3aae6d8ede2c166d3", size = 147294, upload-time = "2026-03-23T08:57:09.411Z" },
+    { url = "https://files.pythonhosted.org/packages/70/42/a225ee83fdb306d2a503f21a627953b820f4e079c90c8a84338957cb8ff5/preshed-3.0.13-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:4f8856ca3d88e9b250630d70abb4f260d8933151ddfb413024784b25b009868e", size = 952110, upload-time = "2026-03-23T08:57:10.592Z" },
+    { url = "https://files.pythonhosted.org/packages/40/ba/09a9dfe3d22d7e745483fd5d7f2a82cd4d39c161f7d2daa0faa4bd6402be/preshed-3.0.13-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0e5b2865aecbd2e1e10e5d19bb8bfad765863c1307c6c3e51f2a08bd64122409", size = 932217, upload-time = "2026-03-23T08:57:12.124Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/5c/e10e2e05133e7fcbd7c40536af1148c82dd24357b8f5726e2c7bc51cfd53/preshed-3.0.13-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:09f96b477c987755b3c945df214ea1c1c80bfb350e9f34e78da89585535b77e8", size = 1896542, upload-time = "2026-03-23T08:57:13.525Z" },
+    { url = "https://files.pythonhosted.org/packages/37/aa/51e5b4109a4cdfae28c3613eeeb10764a3794ebef8de93ffbb109465bea3/preshed-3.0.13-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:670db59a52e1823b5f088c764df474e65b686592d4093adbeef14581c95ee2cb", size = 1959473, upload-time = "2026-03-23T08:57:15.706Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/6a/1d966f367a14c703dde629d150d996c1b727d442f620300b21c9ec1a24d1/preshed-3.0.13-cp314-cp314t-win_amd64.whl", hash = "sha256:b03e21b0bf95eb56e23973f32cabb930e94f352228652f81c0955dbd6967d904", size = 146229, upload-time = "2026-03-23T08:57:17.457Z" },
+    { url = "https://files.pythonhosted.org/packages/22/80/368139067603e590a000122355f9c8576c8ebed4fb0b8849feaa2698489d/preshed-3.0.13-cp314-cp314t-win_arm64.whl", hash = "sha256:b980f3ea9bb74b7f94464bc3d6eb3c9162b6b79b531febd14c6465c24344d2cc", size = 119339, upload-time = "2026-03-23T08:57:18.882Z" },
+]
+
+[[package]]
 name = "propcache"
 version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1770,6 +1952,14 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
     { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
     { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
+]
+
+[[package]]
+name = "pt-core-news-sm"
+version = "3.8.0"
+source = { url = "https://github.com/explosion/spacy-models/releases/download/pt_core_news_sm-3.8.0/pt_core_news_sm-3.8.0-py3-none-any.whl" }
+wheels = [
+    { url = "https://github.com/explosion/spacy-models/releases/download/pt_core_news_sm-3.8.0/pt_core_news_sm-3.8.0-py3-none-any.whl", hash = "sha256:c304fa04db3af73cd08a250feacf560506e15a2ec2469bd1b09f06847f6b455c" },
 ]
 
 [[package]]
@@ -2516,12 +2706,112 @@ wheels = [
 ]
 
 [[package]]
+name = "smart-open"
+version = "7.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c5/65/3ada667d32675399001bf022ad3d9f3989b57101351ebc71d6fbe2384634/smart_open-7.6.1.tar.gz", hash = "sha256:4347996e7ba21db7cd1e059632e0b30395407e4f6c660d2ddffc8f2a9ae5f990", size = 54754, upload-time = "2026-05-09T06:23:37.06Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/78/0f68b93564b8c6b6987a0696c582ba2591a381ab2f733a501909e949f241/smart_open-7.6.1-py3-none-any.whl", hash = "sha256:b4de6aebef023aca91cc9fb372052e1343ba3f152de215bd22391a663e3ddd21", size = 64845, upload-time = "2026-05-09T06:23:35.386Z" },
+]
+
+[[package]]
 name = "sniffio"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "spacy"
+version = "3.8.14"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "catalogue" },
+    { name = "confection" },
+    { name = "cymem" },
+    { name = "jinja2" },
+    { name = "murmurhash" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "preshed" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "setuptools" },
+    { name = "spacy-legacy" },
+    { name = "spacy-loggers" },
+    { name = "srsly" },
+    { name = "thinc" },
+    { name = "tqdm" },
+    { name = "typer" },
+    { name = "wasabi" },
+    { name = "weasel" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/e5/822bbdfa459fee863ef2e9879a34b0ae5db7cd1e3eb76d32c766f19222e9/spacy-3.8.14-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:2b4f60fa8b9641a5e93e7a96db0cdd106d05d61756bf1d0ddcd1705ad347909a", size = 6202114, upload-time = "2026-03-29T10:41:06.119Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/de/0e512154113e1f341567f2b9341835775e4180c180221e60faedaebb2f65/spacy-3.8.14-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0860c57220c633ccb20468bcd64bfb0d28908990c371a8857951d093a148dc8e", size = 6015458, upload-time = "2026-03-29T10:41:07.79Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/4f/29c7e56afc7db07348a9e0efe0243b5eef465d5dc3d56433f164378c3fa6/spacy-3.8.14-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c24620b7dba879c69cebc51ef3b1107d4d4e44a1e0d4baa439372887d00c3fd9", size = 32510659, upload-time = "2026-03-29T10:41:09.88Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/ce/cae678f664d5467016819253f5d6e52f8e68a12d8e799b651d73ec2a9a4b/spacy-3.8.14-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9699c1248d115d5825987c287a6f6acd66386ef3ebee7994ee67ba093e932c59", size = 32841057, upload-time = "2026-03-29T10:41:12.585Z" },
+    { url = "https://files.pythonhosted.org/packages/04/d4/419868afd449bdd367df005932537eea66c71e97c899ba278f3124933f3c/spacy-3.8.14-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:042d799e342fdb6bb5b02a4213a95acc9116c40ed3c849bb0a8296fbe648ec22", size = 31763252, upload-time = "2026-03-29T10:41:15.569Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/53/df5c1fee45f200b749ba72eeb536fbb2c545fc56230324954263b2f3be00/spacy-3.8.14-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:69b2264294097336e86832e8663f1ab3a7215621184863c96c082ab17ee11937", size = 32717872, upload-time = "2026-03-29T10:41:18.193Z" },
+    { url = "https://files.pythonhosted.org/packages/12/c2/f1882ec2f5cc9c4e73cf2132997a03c397d7ceeb5ee7f7bb878b51a16365/spacy-3.8.14-cp313-cp313-win_amd64.whl", hash = "sha256:4b6d4f20e291a7c70e37de2f246622b44a0ce82efaa710c9801c6bd599e75177", size = 14220335, upload-time = "2026-03-29T10:41:20.89Z" },
+]
+
+[[package]]
+name = "spacy-legacy"
+version = "3.0.12"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d9/79/91f9d7cc8db5642acad830dcc4b49ba65a7790152832c4eceb305e46d681/spacy-legacy-3.0.12.tar.gz", hash = "sha256:b37d6e0c9b6e1d7ca1cf5bc7152ab64a4c4671f59c85adaf7a3fcb870357a774", size = 23806, upload-time = "2023-01-23T09:04:15.104Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/55/12e842c70ff8828e34e543a2c7176dac4da006ca6901c9e8b43efab8bc6b/spacy_legacy-3.0.12-py2.py3-none-any.whl", hash = "sha256:476e3bd0d05f8c339ed60f40986c07387c0a71479245d6d0f4298dbd52cda55f", size = 29971, upload-time = "2023-01-23T09:04:13.45Z" },
+]
+
+[[package]]
+name = "spacy-loggers"
+version = "1.0.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/67/3d/926db774c9c98acf66cb4ed7faf6c377746f3e00b84b700d0868b95d0712/spacy-loggers-1.0.5.tar.gz", hash = "sha256:d60b0bdbf915a60e516cc2e653baeff946f0cfc461b452d11a4d5458c6fe5f24", size = 20811, upload-time = "2023-09-11T12:26:52.323Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/78/d1a1a026ef3af911159398c939b1509d5c36fe524c7b644f34a5146c4e16/spacy_loggers-1.0.5-py3-none-any.whl", hash = "sha256:196284c9c446cc0cdb944005384270d775fdeaf4f494d8e269466cfa497ef645", size = 22343, upload-time = "2023-09-11T12:26:50.586Z" },
+]
+
+[[package]]
+name = "srsly"
+version = "2.5.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "catalogue" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2b/db/f794f219a6c788b881252d2536a8c4a97d2bdaadc690391e1cb53d123d71/srsly-2.5.3.tar.gz", hash = "sha256:08f98dbecbff3a31466c4ae7c833131f59d3655a0ad8ac749e6e2c149e2b0680", size = 490881, upload-time = "2026-03-23T11:56:59.865Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/5c/12901e3794f4158abc6da750725aad6c2afddb1e4227b300fe7c71f66957/srsly-2.5.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e67b6bbacbfadea5e100266d2797f2d4cec9883ea4dc84a5537673850036a8d8", size = 656750, upload-time = "2026-03-23T11:56:10.708Z" },
+    { url = "https://files.pythonhosted.org/packages/04/61/181c26370995f96f56f1b64b801e3ca1e0d703fc36506ae28606d62369fb/srsly-2.5.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:348c231b4477d8fe86603131d0f166d2feac9c372704dfc4398be71cc5b6fb07", size = 656746, upload-time = "2026-03-23T11:56:12.28Z" },
+    { url = "https://files.pythonhosted.org/packages/77/c6/35876c78889f8ffe11ed3521644e666c3aef20ea31527b70f47456cf35c2/srsly-2.5.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b0938c2978c91ae1ef9c1f2ba35abb86330e198fb23469e356eba311e02233ee", size = 1155762, upload-time = "2026-03-23T11:56:14.075Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/da/40b71ca9906c8eb8f8feb6ac11d33dad458c85a56e1de764b96d402168a0/srsly-2.5.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5f6a837954429ecbe6dcdd27390d2fb4c7d01a3f99c9ffcf9ce66b2a6dd1b738", size = 1161092, upload-time = "2026-03-23T11:56:15.778Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/14/c0dd30cc8b93ce8137ff4766f743c882440ce49195fffc5d50eaeef311a6/srsly-2.5.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:3576c125c486ce2958c2047e8858fe3cfc9ea877adfa05203b0986f9badee355", size = 1109984, upload-time = "2026-03-23T11:56:17.056Z" },
+    { url = "https://files.pythonhosted.org/packages/08/f3/34354f183d8faafc631585571224b54d1b4b67e796972c36519c074ca355/srsly-2.5.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5fb59c42922e095d1ea36085c55bc16e2adb06a7bfe57b24d381e0194ae699f2", size = 1128409, upload-time = "2026-03-23T11:56:18.761Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/d9/5531f8a19492060b4e76e4ab06aca6f096fb5128fe18cc813d1772daf653/srsly-2.5.3-cp313-cp313-win_amd64.whl", hash = "sha256:111805927f05f5db440aeeacb85ce43da0b19ce7b2a09567a9ef8d30f3cc4d83", size = 650820, upload-time = "2026-03-23T11:56:20.096Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/8a/62fb7a971eca29e12f03fb9ddacb058548c14d33e5b5675ff0f85839cc7b/srsly-2.5.3-cp313-cp313-win_arm64.whl", hash = "sha256:0f106b0a700ab56e4a7c431b0f1444009ab6cb332edc7bbf6811c2a43f4722cb", size = 637278, upload-time = "2026-03-23T11:56:21.439Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5b/e4ef43c2a381711230af98d4c94a5323df48d6a7899ee652e05bf889290e/srsly-2.5.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:39c13d552a9f9674a12cdcdc66b0c2f02f3430d0cd04c5f9cf598824c2bd3d65", size = 661294, upload-time = "2026-03-23T11:56:23.29Z" },
+    { url = "https://files.pythonhosted.org/packages/92/2d/ebce7f3717e52cd0a01f4ec570f388f3b7098526794fcf1ad734e0b8f852/srsly-2.5.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:14c930767cc169611a2dc14e23bc7638cfb616d6f79029700ade033607343540", size = 660952, upload-time = "2026-03-23T11:56:24.908Z" },
+    { url = "https://files.pythonhosted.org/packages/22/47/a8f3e9b214be2624c8e8a78d38ca7b1d4e26b92d57018412e4bfc4abe89a/srsly-2.5.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2f2d464f0d0237e32fb53f0ec6f05418652c550e772b50e9918e83a1577cba4d", size = 1154554, upload-time = "2026-03-23T11:56:26.608Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/71/2a89dc3180a51e633a87a079ca064225f4aaf46c7b2a5fc720e28f261d98/srsly-2.5.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d18933248a5bb0ad56a1bae6003a9a7f37daac2ecb0c5bcbfaaf081b317e1c84", size = 1155746, upload-time = "2026-03-23T11:56:28.102Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/36/72e5ce3153927ca404b6f5bf5280e6ff3399c11557df472b153945468e0a/srsly-2.5.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7ea5412ea229e571ac9738cbe14f845cc06c8e4e956afb5f42061ccd087ef31f", size = 1112374, upload-time = "2026-03-23T11:56:29.591Z" },
+    { url = "https://files.pythonhosted.org/packages/04/b2/0895de109c28eca0d41a811ab7c076d4e4a505e8466f06bae22f5180a1dd/srsly-2.5.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8d3988970b4cf7d03bdd5b5169302ff84562dd2e1e0f84aeb34df3e5b5dc19bf", size = 1127732, upload-time = "2026-03-23T11:56:31.458Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/79/a37fa7759797fbdfe0a2e029ab13e78b1e81e191220d2bb8ff57d869aefb/srsly-2.5.3-cp314-cp314-win_amd64.whl", hash = "sha256:6a02d7dcc16126c8fae1c1c09b2072798a1dc482ab5f9c52b12c7114dac47325", size = 656467, upload-time = "2026-03-23T11:56:33.14Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/25/0dae019b3b90ad9037f91de4c390555cdaac9460a93ad62b02b03babdff5/srsly-2.5.3-cp314-cp314-win_arm64.whl", hash = "sha256:1c9129c4abe31903ff7996904a51afdd5428060de6c3d12af49a4da5e8df2821", size = 643040, upload-time = "2026-03-23T11:56:34.448Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/44/72dd5285b2e05435d98b0797f101d91d9b345d491ddc1fdb9bd09e27ccb8/srsly-2.5.3-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:29d5d01ba4c2e9c01f936e5e6d5babc4a47b38c9cbd6e1ec23f6d5a49df32605", size = 666200, upload-time = "2026-03-23T11:56:35.753Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/ad/002c71b87fc3f648c9bf0ec47de0c3822bf2c95c8896a589dd03e7fd3977/srsly-2.5.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5c8df4039426d99f0148b5743542842ab96b82daded0b342555e15a639927757", size = 667409, upload-time = "2026-03-23T11:56:37.172Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/35/2cea3d5e80aeecfc4ece9e7e1783e7792cc3bad7ab85ab585882e1db4e38/srsly-2.5.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:06a43d63bde2e8cccadb953d7fff70b18196ca286b65dd2ad16006d65f3f8166", size = 1265941, upload-time = "2026-03-23T11:56:38.825Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/38/8a4d7e86dd0370a2e5af251b646000197bb5b7e0f9aa360c71bbfb253d0d/srsly-2.5.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:808cfafc047f0dec507a34c8fa8e4cda5722737fd33577df73452f52f7aca644", size = 1250693, upload-time = "2026-03-23T11:56:40.449Z" },
+    { url = "https://files.pythonhosted.org/packages/99/05/340129de5ea7b237271b12f8a6962cfa7eb0c5a3056794626d348c5ae7c7/srsly-2.5.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:71d4cbe2b2a1335c76ed0acae2dc862163787d8b01a705e1949796907ed94ccd", size = 1242408, upload-time = "2026-03-23T11:56:41.8Z" },
+    { url = "https://files.pythonhosted.org/packages/01/cb/d7fee7ab27c6aa2e3f865fb7b50ba18c81a4c763bba12bdf53df246441bc/srsly-2.5.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:565f69083d33cb329cfc74317da937fb3270c0f40fabc1b4488702d8074b4a3e", size = 1242749, upload-time = "2026-03-23T11:56:43.246Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/d1/9bad3a0f2fa7b72f4e0cf1d267b00513092d20ef538c47f72823ae4f7656/srsly-2.5.3-cp314-cp314t-win_amd64.whl", hash = "sha256:8ac016ffaeac35bc010992b71bf8afdd39d458f201c8138d84cf78778a936e6c", size = 673783, upload-time = "2026-03-23T11:56:44.875Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/ae/57d1d7af907e20c077e113e0e4976f87b82c0a415403d99284a262229dd0/srsly-2.5.3-cp314-cp314t-win_arm64.whl", hash = "sha256:d822083fe26ec6728bd8c273ac121fc4ab3864a0fdf0cf0ff3efb188fcd209ed", size = 650229, upload-time = "2026-03-23T11:56:46.148Z" },
 ]
 
 [[package]]
@@ -2581,6 +2871,44 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/cf/2f/d44f0f12b3ddb1f0b88f7775652e99c6b5a43fd733badf4ce064bdbfef4a/textual-8.2.3.tar.gz", hash = "sha256:beea7b86b03b03558a2224f0cc35252e60ef8b0c4353b117b2f40972902d976a", size = 1848738, upload-time = "2026-04-05T09:12:45.338Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0e/28/a81d6ce9f4804818bd1231a9a6e4d56ea84ebbe8385c49591444f0234fa2/textual-8.2.3-py3-none-any.whl", hash = "sha256:5008ac581bebf1f6fa0520404261844a231e5715fdbddd10ca73916a3af48ca2", size = 724231, upload-time = "2026-04-05T09:12:48.747Z" },
+]
+
+[[package]]
+name = "thinc"
+version = "8.3.13"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "blis" },
+    { name = "catalogue" },
+    { name = "confection" },
+    { name = "cymem" },
+    { name = "murmurhash" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "preshed" },
+    { name = "pydantic" },
+    { name = "setuptools" },
+    { name = "srsly" },
+    { name = "wasabi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/13/46/76df95f2c327f9a9cef30c1523bf285627897097163584dcf5f77b2ebce2/thinc-8.3.13.tar.gz", hash = "sha256:68e658549fc1eb3ff92aed5147fcbb9c15d6e9cc0e623b4d0998d16522ffb4f9", size = 194640, upload-time = "2026-03-23T07:22:36.41Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/af/b9/7b46942176df459d1804a9e77b0976f7c56f3abf3ec7485d0e5f836a0382/thinc-8.3.13-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c2811dfd8d46d8b5d3b39051b23e64006b2994a5143b1978b436938018792af8", size = 817337, upload-time = "2026-03-23T07:22:09.538Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/79/53085a72cd8f4fc4e6e313d05ea5aa98e870684f4a0fb318a9875fc0a964/thinc-8.3.13-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:5593e6300cb1ebe0c0e546e9c9fb49e7c2627a0aa688795cd4f995a8b820d2ec", size = 788120, upload-time = "2026-03-23T07:22:11.215Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/3e/d61b462b16da95ac6885f95bb395e672040ee594833e571a6edcffd234f5/thinc-8.3.13-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f697174d3fb474966ce50b430bbafa101a6d2f7ffb559dac4b5c59389ef72d22", size = 3844666, upload-time = "2026-03-23T07:22:12.67Z" },
+    { url = "https://files.pythonhosted.org/packages/78/4c/898cc654bb123734c71ec5a425c02ca34439517d01ce1c95a6563295580e/thinc-8.3.13-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e9c7c5c104737b414c8c4ec578e67d78b6c859afe25cbc0684402e721415bd7f", size = 3890658, upload-time = "2026-03-23T07:22:14.668Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/56/1abdbf0a4ad628e8a05d6516fe0745969649d805367a3dccad8ee872981b/thinc-8.3.13-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7a99d0e242d1ccd23f9ae6bea7cd502f8626efa65c156b91d84581d0356696c3", size = 4819933, upload-time = "2026-03-23T07:22:16.85Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/22/b84dbdc6be5055bbdb2a7352e2c393f67e8593c137f1b83c82bf1e062b6e/thinc-8.3.13-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e676edd21a747afbe3e6b9f3fca8b962e36d146ded03b070cb0c28e2dfbe9499", size = 5018099, upload-time = "2026-03-23T07:22:18.356Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/a8/763cd7ba949334c9d2cddc92dadb68b344cb9546dc01b8d4a733dcaa16c1/thinc-8.3.13-cp313-cp313-win_amd64.whl", hash = "sha256:8ad40307f20e83f77af28ff5c6be0b86af7a8b251d1231c545508d2763157d8f", size = 1720309, upload-time = "2026-03-23T07:22:19.81Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/15/a11f7bb3cbc97dfecf32a90552f5a8f8a5c99316a99c6c17bdabf5baf256/thinc-8.3.13-cp313-cp313-win_arm64.whl", hash = "sha256:723949cab11d1925c15447928513a718276316cec6e0de28337cca0a62be0521", size = 1644606, upload-time = "2026-03-23T07:22:21.339Z" },
+    { url = "https://files.pythonhosted.org/packages/80/40/f4937d113912c6d669ffe982356ab29dcb6c7fe3be926a15981dbbb6a91c/thinc-8.3.13-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:7badb0be4825535e6362c19e8a41872b65409e9da46d3453a391b843a0720865", size = 817024, upload-time = "2026-03-23T07:22:23.005Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/00/4d4ed1a11ba2920b85a03a0683b16d97dc5beb2e78078dbf0e13e43bcea7/thinc-8.3.13-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:565300b7e13de799e5abff00d445f537e9256cf7da4dcb0d0f005fc16748a29e", size = 792096, upload-time = "2026-03-23T07:22:24.349Z" },
+    { url = "https://files.pythonhosted.org/packages/44/5d/dc33d6932be8721af2ef76b4a3a6e8020648630eabae61fb916d2a861d1d/thinc-8.3.13-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c17cef1900a1aba7e1487493d16b8aa0a8633116f1b2a51c6649a4000697f17b", size = 3842215, upload-time = "2026-03-23T07:22:25.836Z" },
+    { url = "https://files.pythonhosted.org/packages/af/bc/a6d37d8dadc2c5b524f51192413481160c42c9dd6105e8d5551531623225/thinc-8.3.13-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f4f26d1eec9b2a6a8f2e0298a5515d13eb06d70730d0d9e1040bb329e12bf3fb", size = 3849253, upload-time = "2026-03-23T07:22:27.845Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/59/ce9c7067f1dfe5985875927de9cf7a79f9dae3e69487fd650dfba558029d/thinc-8.3.13-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a61a31fd0ce3c2771cf4901ba6df70e774ffe32febf1024c5b43d63575cd58fe", size = 4831163, upload-time = "2026-03-23T07:22:29.395Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/a8/f57819347fc4d8bef2204d15fcbb9d7dff2d6cdd5f83d5ed91456ddacc55/thinc-8.3.13-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ba8119daf84a12259ae4d251d36426417bafa0b34108890b4b7e2b50966bd990", size = 4986051, upload-time = "2026-03-23T07:22:30.933Z" },
+    { url = "https://files.pythonhosted.org/packages/05/ef/a82214bb7c7c1e2d92b69e1a7654be90cfab180082c6108e45a98af2422c/thinc-8.3.13-cp314-cp314-win_amd64.whl", hash = "sha256:433e3826e018da489f1a8068e6de677f6eff3cc93991a599d90f12cd1bc26cdc", size = 1740382, upload-time = "2026-03-23T07:22:32.869Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/ef/1648fda54e9689058335ff54f650a7a314db2a42e21af1b83949b2dc748e/thinc-8.3.13-cp314-cp314-win_arm64.whl", hash = "sha256:11754fada9ad5ba2e02d5f3f234f940e24015b82333db58372f4a6aedad9b43f", size = 1667687, upload-time = "2026-03-23T07:22:34.967Z" },
 ]
 
 [[package]]
@@ -2839,6 +3167,18 @@ wheels = [
 ]
 
 [[package]]
+name = "wasabi"
+version = "1.1.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/f9/054e6e2f1071e963b5e746b48d1e3727470b2a490834d18ad92364929db3/wasabi-1.1.3.tar.gz", hash = "sha256:4bb3008f003809db0c3e28b4daf20906ea871a2bb43f9914197d540f4f2e0878", size = 30391, upload-time = "2024-05-31T16:56:18.99Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/7c/34330a89da55610daa5f245ddce5aab81244321101614751e7537f125133/wasabi-1.1.3-py3-none-any.whl", hash = "sha256:f76e16e8f7e79f8c4c8be49b4024ac725713ab10cd7f19350ad18a8e3f71728c", size = 27880, upload-time = "2024-05-31T16:56:16.699Z" },
+]
+
+[[package]]
 name = "watchfiles"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2896,6 +3236,26 @@ wheels = [
 ]
 
 [[package]]
+name = "weasel"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cloudpathlib" },
+    { name = "confection" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "pydantic" },
+    { name = "smart-open" },
+    { name = "srsly" },
+    { name = "typer" },
+    { name = "wasabi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/e5/e272bb9a045105a1fdf4b798d8086f5932a178f4d738f17a74f5c9e0ae9a/weasel-1.0.0.tar.gz", hash = "sha256:7b129b44c90cc543b760532974ca1e4eb30dad2aa2026f57bdce66354ae610fc", size = 38682, upload-time = "2026-03-20T08:10:25.266Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/07/57ebf7a6798b016c064bd0ca81b4c6a99daa4dc377b898bc7b41eb6b5af0/weasel-1.0.0-py3-none-any.whl", hash = "sha256:89518acee027f49d743126c3502d35e6dd14f5768be5c37c9af47c171b6005cc", size = 50713, upload-time = "2026-03-20T08:10:23.637Z" },
+]
+
+[[package]]
 name = "websockets"
 version = "16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2929,6 +3289,59 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
     { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
     { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/64/925f213fdcbb9baeb1530449ac71a4d57fc361c053d06bf78d0c5c7cd80c/wrapt-2.1.2.tar.gz", hash = "sha256:3996a67eecc2c68fd47b4e3c564405a5777367adfd9b8abb58387b63ee83b21e", size = 81678, upload-time = "2026-03-06T02:53:25.134Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4c/7a/d936840735c828b38d26a854e85d5338894cda544cb7a85a9d5b8b9c4df7/wrapt-2.1.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:787fd6f4d67befa6fe2abdffcbd3de2d82dfc6fb8a6d850407c53332709d030b", size = 61259, upload-time = "2026-03-06T02:53:41.922Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/88/9a9b9a90ac8ca11c2fdb6a286cb3a1fc7dd774c00ed70929a6434f6bc634/wrapt-2.1.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4bdf26e03e6d0da3f0e9422fd36bcebf7bc0eeb55fdf9c727a09abc6b9fe472e", size = 61851, upload-time = "2026-03-06T02:52:48.672Z" },
+    { url = "https://files.pythonhosted.org/packages/03/a9/5b7d6a16fd6533fed2756900fc8fc923f678179aea62ada6d65c92718c00/wrapt-2.1.2-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:bbac24d879aa22998e87f6b3f481a5216311e7d53c7db87f189a7a0266dafffb", size = 121446, upload-time = "2026-03-06T02:54:14.013Z" },
+    { url = "https://files.pythonhosted.org/packages/45/bb/34c443690c847835cfe9f892be78c533d4f32366ad2888972c094a897e39/wrapt-2.1.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:16997dfb9d67addc2e3f41b62a104341e80cac52f91110dece393923c0ebd5ca", size = 123056, upload-time = "2026-03-06T02:54:10.829Z" },
+    { url = "https://files.pythonhosted.org/packages/93/b9/ff205f391cb708f67f41ea148545f2b53ff543a7ac293b30d178af4d2271/wrapt-2.1.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:162e4e2ba7542da9027821cb6e7c5e068d64f9a10b5f15512ea28e954893a267", size = 117359, upload-time = "2026-03-06T02:53:03.623Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/3d/1ea04d7747825119c3c9a5e0874a40b33594ada92e5649347c457d982805/wrapt-2.1.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f29c827a8d9936ac320746747a016c4bc66ef639f5cd0d32df24f5eacbf9c69f", size = 121479, upload-time = "2026-03-06T02:53:45.844Z" },
+    { url = "https://files.pythonhosted.org/packages/78/cc/ee3a011920c7a023b25e8df26f306b2484a531ab84ca5c96260a73de76c0/wrapt-2.1.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:a9dd9813825f7ecb018c17fd147a01845eb330254dff86d3b5816f20f4d6aaf8", size = 116271, upload-time = "2026-03-06T02:54:46.356Z" },
+    { url = "https://files.pythonhosted.org/packages/98/fd/e5ff7ded41b76d802cf1191288473e850d24ba2e39a6ec540f21ae3b57cb/wrapt-2.1.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6f8dbdd3719e534860d6a78526aafc220e0241f981367018c2875178cf83a413", size = 120573, upload-time = "2026-03-06T02:52:50.163Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c5/242cae3b5b080cd09bacef0591691ba1879739050cc7c801ff35c8886b66/wrapt-2.1.2-cp313-cp313-win32.whl", hash = "sha256:5c35b5d82b16a3bc6e0a04349b606a0582bc29f573786aebe98e0c159bc48db6", size = 58205, upload-time = "2026-03-06T02:53:47.494Z" },
+    { url = "https://files.pythonhosted.org/packages/12/69/c358c61e7a50f290958809b3c61ebe8b3838ea3e070d7aac9814f95a0528/wrapt-2.1.2-cp313-cp313-win_amd64.whl", hash = "sha256:f8bc1c264d8d1cf5b3560a87bbdd31131573eb25f9f9447bb6252b8d4c44a3a1", size = 60452, upload-time = "2026-03-06T02:53:30.038Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/66/c8a6fcfe321295fd8c0ab1bd685b5a01462a9b3aa2f597254462fc2bc975/wrapt-2.1.2-cp313-cp313-win_arm64.whl", hash = "sha256:3beb22f674550d5634642c645aba4c72a2c66fb185ae1aebe1e955fae5a13baf", size = 58842, upload-time = "2026-03-06T02:52:52.114Z" },
+    { url = "https://files.pythonhosted.org/packages/da/55/9c7052c349106e0b3f17ae8db4b23a691a963c334de7f9dbd60f8f74a831/wrapt-2.1.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0fc04bc8664a8bc4c8e00b37b5355cffca2535209fba1abb09ae2b7c76ddf82b", size = 63075, upload-time = "2026-03-06T02:53:19.108Z" },
+    { url = "https://files.pythonhosted.org/packages/09/a8/ce7b4006f7218248dd71b7b2b732d0710845a0e49213b18faef64811ffef/wrapt-2.1.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:a9b9d50c9af998875a1482a038eb05755dfd6fe303a313f6a940bb53a83c3f18", size = 63719, upload-time = "2026-03-06T02:54:33.452Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/e5/2ca472e80b9e2b7a17f106bb8f9df1db11e62101652ce210f66935c6af67/wrapt-2.1.2-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2d3ff4f0024dd224290c0eabf0240f1bfc1f26363431505fb1b0283d3b08f11d", size = 152643, upload-time = "2026-03-06T02:52:42.721Z" },
+    { url = "https://files.pythonhosted.org/packages/36/42/30f0f2cefca9d9cbf6835f544d825064570203c3e70aa873d8ae12e23791/wrapt-2.1.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3278c471f4468ad544a691b31bb856374fbdefb7fee1a152153e64019379f015", size = 158805, upload-time = "2026-03-06T02:54:25.441Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/67/d08672f801f604889dcf58f1a0b424fe3808860ede9e03affc1876b295af/wrapt-2.1.2-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a8914c754d3134a3032601c6984db1c576e6abaf3fc68094bb8ab1379d75ff92", size = 145990, upload-time = "2026-03-06T02:53:57.456Z" },
+    { url = "https://files.pythonhosted.org/packages/68/a7/fd371b02e73babec1de6ade596e8cd9691051058cfdadbfd62a5898f3295/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:ff95d4264e55839be37bafe1536db2ab2de19da6b65f9244f01f332b5286cfbf", size = 155670, upload-time = "2026-03-06T02:54:55.309Z" },
+    { url = "https://files.pythonhosted.org/packages/86/2d/9fe0095dfdb621009f40117dcebf41d7396c2c22dca6eac779f4c007b86c/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:76405518ca4e1b76fbb1b9f686cff93aebae03920cc55ceeec48ff9f719c5f67", size = 144357, upload-time = "2026-03-06T02:54:24.092Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/b6/ec7b4a254abbe4cde9fa15c5d2cca4518f6b07d0f1b77d4ee9655e30280e/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c0be8b5a74c5824e9359b53e7e58bef71a729bacc82e16587db1c4ebc91f7c5a", size = 150269, upload-time = "2026-03-06T02:53:31.268Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/6b/2fabe8ebf148f4ee3c782aae86a795cc68ffe7d432ef550f234025ce0cfa/wrapt-2.1.2-cp313-cp313t-win32.whl", hash = "sha256:f01277d9a5fc1862f26f7626da9cf443bebc0abd2f303f41c5e995b15887dabd", size = 59894, upload-time = "2026-03-06T02:54:15.391Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/fb/9ba66fc2dedc936de5f8073c0217b5d4484e966d87723415cc8262c5d9c2/wrapt-2.1.2-cp313-cp313t-win_amd64.whl", hash = "sha256:84ce8f1c2104d2f6daa912b1b5b039f331febfeee74f8042ad4e04992bd95c8f", size = 63197, upload-time = "2026-03-06T02:54:41.943Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/1c/012d7423c95d0e337117723eb8ecf73c622ce15a97847e84cf3f8f26cd7e/wrapt-2.1.2-cp313-cp313t-win_arm64.whl", hash = "sha256:a93cd767e37faeddbe07d8fc4212d5cba660af59bdb0f6372c93faaa13e6e679", size = 60363, upload-time = "2026-03-06T02:54:48.093Z" },
+    { url = "https://files.pythonhosted.org/packages/39/25/e7ea0b417db02bb796182a5316398a75792cd9a22528783d868755e1f669/wrapt-2.1.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1370e516598854e5b4366e09ce81e08bfe94d42b0fd569b88ec46cc56d9164a9", size = 61418, upload-time = "2026-03-06T02:53:55.706Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/0f/fa539e2f6a770249907757eaeb9a5ff4deb41c026f8466c1c6d799088a9b/wrapt-2.1.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:6de1a3851c27e0bd6a04ca993ea6f80fc53e6c742ee1601f486c08e9f9b900a9", size = 61914, upload-time = "2026-03-06T02:52:53.37Z" },
+    { url = "https://files.pythonhosted.org/packages/53/37/02af1867f5b1441aaeda9c82deed061b7cd1372572ddcd717f6df90b5e93/wrapt-2.1.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:de9f1a2bbc5ac7f6012ec24525bdd444765a2ff64b5985ac6e0692144838542e", size = 120417, upload-time = "2026-03-06T02:54:30.74Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/b7/0138a6238c8ba7476c77cf786a807f871672b37f37a422970342308276e7/wrapt-2.1.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:970d57ed83fa040d8b20c52fe74a6ae7e3775ae8cff5efd6a81e06b19078484c", size = 122797, upload-time = "2026-03-06T02:54:51.539Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/ad/819ae558036d6a15b7ed290d5b14e209ca795dd4da9c58e50c067d5927b0/wrapt-2.1.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3969c56e4563c375861c8df14fa55146e81ac11c8db49ea6fb7f2ba58bc1ff9a", size = 117350, upload-time = "2026-03-06T02:54:37.651Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/2d/afc18dc57a4600a6e594f77a9ae09db54f55ba455440a54886694a84c71b/wrapt-2.1.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:57d7c0c980abdc5f1d98b11a2aa3bb159790add80258c717fa49a99921456d90", size = 121223, upload-time = "2026-03-06T02:54:35.221Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/5b/5ec189b22205697bc56eb3b62aed87a1e0423e9c8285d0781c7a83170d15/wrapt-2.1.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:776867878e83130c7a04237010463372e877c1c994d449ca6aaafeab6aab2586", size = 116287, upload-time = "2026-03-06T02:54:19.654Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/2d/f84939a7c9b5e6cdd8a8d0f6a26cabf36a0f7e468b967720e8b0cd2bdf69/wrapt-2.1.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:fab036efe5464ec3291411fabb80a7a39e2dd80bae9bcbeeca5087fdfa891e19", size = 119593, upload-time = "2026-03-06T02:54:16.697Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/fe/ccd22a1263159c4ac811ab9374c061bcb4a702773f6e06e38de5f81a1bdc/wrapt-2.1.2-cp314-cp314-win32.whl", hash = "sha256:e6ed62c82ddf58d001096ae84ce7f833db97ae2263bff31c9b336ba8cfe3f508", size = 58631, upload-time = "2026-03-06T02:53:06.498Z" },
+    { url = "https://files.pythonhosted.org/packages/65/0a/6bd83be7bff2e7efaac7b4ac9748da9d75a34634bbbbc8ad077d527146df/wrapt-2.1.2-cp314-cp314-win_amd64.whl", hash = "sha256:467e7c76315390331c67073073d00662015bb730c566820c9ca9b54e4d67fd04", size = 60875, upload-time = "2026-03-06T02:53:50.252Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/c0/0b3056397fe02ff80e5a5d72d627c11eb885d1ca78e71b1a5c1e8c7d45de/wrapt-2.1.2-cp314-cp314-win_arm64.whl", hash = "sha256:da1f00a557c66225d53b095a97eace0fc5349e3bfda28fa34ffae238978ee575", size = 59164, upload-time = "2026-03-06T02:53:59.128Z" },
+    { url = "https://files.pythonhosted.org/packages/71/ed/5d89c798741993b2371396eb9d4634f009ff1ad8a6c78d366fe2883ea7a6/wrapt-2.1.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:62503ffbc2d3a69891cf29beeaccdb4d5e0a126e2b6a851688d4777e01428dbb", size = 63163, upload-time = "2026-03-06T02:52:54.873Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/8c/05d277d182bf36b0a13d6bd393ed1dec3468a25b59d01fba2dd70fe4d6ae/wrapt-2.1.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c7e6cd120ef837d5b6f860a6ea3745f8763805c418bb2f12eeb1fa6e25f22d22", size = 63723, upload-time = "2026-03-06T02:52:56.374Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/27/6c51ec1eff4413c57e72d6106bb8dec6f0c7cdba6503d78f0fa98767bcc9/wrapt-2.1.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3769a77df8e756d65fbc050333f423c01ae012b4f6731aaf70cf2bef61b34596", size = 152652, upload-time = "2026-03-06T02:53:23.79Z" },
+    { url = "https://files.pythonhosted.org/packages/db/4c/d7dd662d6963fc7335bfe29d512b02b71cdfa23eeca7ab3ac74a67505deb/wrapt-2.1.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a76d61a2e851996150ba0f80582dd92a870643fa481f3b3846f229de88caf044", size = 158807, upload-time = "2026-03-06T02:53:35.742Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/4d/1e5eea1a78d539d346765727422976676615814029522c76b87a95f6bcdd/wrapt-2.1.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6f97edc9842cf215312b75fe737ee7c8adda75a89979f8e11558dfff6343cc4b", size = 146061, upload-time = "2026-03-06T02:52:57.574Z" },
+    { url = "https://files.pythonhosted.org/packages/89/bc/62cabea7695cd12a288023251eeefdcb8465056ddaab6227cb78a2de005b/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4006c351de6d5007aa33a551f600404ba44228a89e833d2fadc5caa5de8edfbf", size = 155667, upload-time = "2026-03-06T02:53:39.422Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/99/6f2888cd68588f24df3a76572c69c2de28287acb9e1972bf0c83ce97dbc1/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:a9372fc3639a878c8e7d87e1556fa209091b0a66e912c611e3f833e2c4202be2", size = 144392, upload-time = "2026-03-06T02:54:22.41Z" },
+    { url = "https://files.pythonhosted.org/packages/40/51/1dfc783a6c57971614c48e361a82ca3b6da9055879952587bc99fe1a7171/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3144b027ff30cbd2fca07c0a87e67011adb717eb5f5bd8496325c17e454257a3", size = 150296, upload-time = "2026-03-06T02:54:07.848Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/38/cbb8b933a0201076c1f64fc42883b0023002bdc14a4964219154e6ff3350/wrapt-2.1.2-cp314-cp314t-win32.whl", hash = "sha256:3b8d15e52e195813efe5db8cec156eebe339aaf84222f4f4f051a6c01f237ed7", size = 60539, upload-time = "2026-03-06T02:54:00.594Z" },
+    { url = "https://files.pythonhosted.org/packages/82/dd/e5176e4b241c9f528402cebb238a36785a628179d7d8b71091154b3e4c9e/wrapt-2.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:08ffa54146a7559f5b8df4b289b46d963a8e74ed16ba3687f99896101a3990c5", size = 63969, upload-time = "2026-03-06T02:54:39Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/99/79f17046cf67e4a95b9987ea129632ba8bcec0bc81f3fb3d19bdb0bd60cd/wrapt-2.1.2-cp314-cp314t-win_arm64.whl", hash = "sha256:72aaa9d0d8e4ed0e2e98019cea47a21f823c9dd4b43c7b77bba6679ffcca6a00", size = 60554, upload-time = "2026-03-06T02:53:14.132Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/c7/8528ac2dfa2c1e6708f647df7ae144ead13f0a31146f43c7264b4942bf12/wrapt-2.1.2-py3-none-any.whl", hash = "sha256:b8fd6fa2b2c4e7621808f8c62e8317f4aae56e59721ad933bac5239d913cf0e8", size = 43993, upload-time = "2026-03-06T02:53:12.905Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -156,6 +156,7 @@ dependencies = [
     { name = "openai" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "rank-bm25" },
     { name = "rich" },
     { name = "sentencepiece" },
     { name = "tenacity" },
@@ -211,6 +212,7 @@ requires-dist = [
     { name = "pyarrow", marker = "extra == 'kg'", specifier = ">=15,<21" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
+    { name = "rank-bm25", specifier = ">=0.2.2" },
     { name = "rich", specifier = ">=13.0.0" },
     { name = "sentencepiece", specifier = ">=0.2.1" },
     { name = "tenacity", specifier = ">=8.0.0" },
@@ -2053,6 +2055,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "rank-bm25"
+version = "0.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/0a/f9579384aa017d8b4c15613f86954b92a95a93d641cc849182467cf0bb3b/rank_bm25-0.2.2.tar.gz", hash = "sha256:096ccef76f8188563419aaf384a02f0ea459503fdf77901378d4fd9d87e5e51d", size = 8347, upload-time = "2022-02-16T12:10:52.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/21/f691fb2613100a62b3fa91e9988c991e9ca5b89ea31c0d3152a3210344f9/rank_bm25-0.2.2-py3-none-any.whl", hash = "sha256:7bd4a95571adadfc271746fa146a4bcfd89c0cf731e49c3d1ad863290adbe8ae", size = 8584, upload-time = "2022-02-16T12:10:50.626Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Two of the four Phase C retrieval arms. Both implement the `Retriever` Protocol shipped in #96 and ship with full TDD coverage.

### `NullRetriever` (spec §4.6)

- Parametric arm: `retrieve(question, top_k) -> []`. Forces the Answerer to fall back to parametric (LLM-internal) knowledge.
- `retriever_id = "null"`. Establishes the `shared/rag/retrievers/` subpackage.
- 5 tests.

### `BM25Retriever` (spec §4.3)

- Sparse baseline over chunker views using `rank_bm25.BM25Okapi`.
- `BM25Retriever(index_dir, chunker_id, language="pt")` loads a pre-built index.
- `BM25Retriever.build_index(chunks, resolver, index_dir, chunker_id, language)` resolves chunk text via `ChunkResolver`, tokenizes, builds the index, persists `bm25.pkl` + `manifest.json` (chunker_id, language, chunks_indexed, built_at, chunk_ids).
- `retriever_id = f"bm25_{chunker_id}"` — different chunk-size sweeps (`bm25_512t` / `bm25_1024t` / `bm25_4k`) yield distinct IDs in `RetrievalRecord`.
- Stable argsort for deterministic tie-breaking; zero-indexed ranks; monotonically non-increasing scores; `retriever_meta={"score_method": "bm25_okapi"}`.

### Tokenization (`_bm25_tokenize.py`)

- spaCy `pt_core_news_sm` / `en_core_web_sm` primary path (lemmatization + stopword removal), lazily try-imported.
- Whitespace fallback: NFKC + lowercase + punctuation-strip + whitespace split. Numerics and accents preserved. Logged warning when engaged.

### Deferred

- `ARANDU_BM25_*` env-var bindings — defer to `retrieve-cli` task (the CLI is the consumer; the retriever class doesn't need them).
- spaCy as a hard dependency — defer until/unless a benchmark shows the fallback materially hurts ranking. `rank_bm25 ≥ 0.2.2` is added.

### Dependencies

- New runtime: `rank_bm25 ≥ 0.2.2`.
- Builds on #96 (Retriever Protocol + RAG schemas, merged as `f596043`).

## Test plan

- [x] 30 new unit tests (5 null + 10 tokenizer + 15 BM25)
- [x] Full suite: 1142 passed (was 1117, +25 net new — tokenizer factories share 5 tests with the registered tokenizer pool)
- [x] `ruff check` and `ruff format` clean
- [x] TDD throughout (RED → GREEN for every change)
- [x] BM25 ranking verified with single-doc-keyword queries (BM25Okapi's IDF degenerates at df = N/2 on tiny corpora — fixtures designed around that)