### PR TITLE
docs: document results/<run-id>/<stage>/ persistence convention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ Before making any changes:
 4. **Docstrings**: Use Google style for all public functions/classes
 5. **Testing**: Write tests and run pytest before committing
 6. **No `print()`**: Use Rich console utilities (`print_info`, `print_error`, etc.)
+7. **Persistence**: Pipeline stages write under `results/<run-id>/<stage>/outputs/` via `ResultsManager`. Never default a stage's output to a flat top-level directory — see [Results Directory Layout](docs/development/architecture.md#results-directory-layout)
 
 ## Standard Development Workflow
 
@@ -344,6 +345,7 @@ uv run arandu --help
 | **Line Length** | 100 characters max | Enforced by Ruff |
 | **Output** | Rich console only | `print_info()`, never `print()` |
 | **LLM Calls** | Unified `LLMClient` | Never use provider SDKs directly |
+| **Persistence** | `results/<run-id>/<stage>/outputs/` via `ResultsManager` | See [Results Directory Layout](docs/development/architecture.md#results-directory-layout) |
 | **Design** | DRY, SOLID, KISS, YAGNI | See Design Principles |
 
 ## References

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Arandu is a comprehensive pipeline for processing ethnographic media collections
 - **Rich CLI**: Beautiful command-line interface with progress bars and structured output
 - **Structured Output**: JSON output with transcription text, timestamps, and metadata
 - **Transcription Quality Validation**: Heuristic-based quality scoring detecting wrong language/script, repetition, suspicious patterns, and empty content
-- **Results Versioning**: Pipeline-ID-first directory layout with comprehensive run metadata and execution environment tracking
+- **Results Versioning**: Pipeline-ID-first directory layout with comprehensive run metadata and execution environment tracking — every run lives at `results/<run-id>/`, with each stage as a child subdir carrying `<stage>_checkpoint.json`, `run_metadata.json`, and `outputs/` (see [Results Directory Layout](docs/development/architecture.md#results-directory-layout))
 
 ### CEP QA Generation
 - **Cognitive Elicitation Pipeline (CEP)**: Generate QA pairs with Bloom's Taxonomy scaffolding (remember, understand, analyze, evaluate)

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -10,11 +10,12 @@
 
 1. [Architecture Overview](#architecture-overview)
 2. [Checkpoint System Pattern](#checkpoint-system-pattern)
-3. [Batch Processing Pattern](#batch-processing-pattern)
-4. [Worker Initialization Pattern](#worker-initialization-pattern)
-5. [CLI Command Pattern](#cli-command-pattern)
-6. [Error Handling Pattern](#error-handling-pattern)
-7. [Applying Patterns to Phase 2](#applying-patterns-to-phase-2)
+3. [Results Directory Layout](#results-directory-layout)
+4. [Batch Processing Pattern](#batch-processing-pattern)
+5. [Worker Initialization Pattern](#worker-initialization-pattern)
+6. [CLI Command Pattern](#cli-command-pattern)
+7. [Error Handling Pattern](#error-handling-pattern)
+8. [Applying Patterns to Phase 2](#applying-patterns-to-phase-2)
 
 ---
 
@@ -130,6 +131,43 @@ completed, total = checkpoint.get_progress()
 2. **Thread-safe**: Can be called from multiple processes (file-based locking)
 3. **Corruption handling**: Invalid checkpoint files fall back to fresh start
 4. **Set conversion**: Converts list ↔ set for JSON serialization
+
+---
+
+## Results Directory Layout
+
+### Location
+
+`src/arandu/shared/results_manager.py` — `ResultsManager` is the single writer for everything under `results/`. Schema contracts live in `src/arandu/shared/schemas.py` (`PipelineMetadata`, `RunMetadata`, `PipelineType`, `RunStatus`).
+
+### Purpose
+
+Give every pipeline run a self-describing home on disk so different stages can compose without overwriting each other, and so a fresh agent can re-derive the state of a run by reading files instead of code.
+
+### The convention
+
+Every run is a directory under `results/`, named with the run's `pipeline_id` (an opaque ID; locally that is `YYYYMMDD_HHMMSS_local`, on SLURM it is `YYYYMMDD_HHMMSS_slurm_<partition>_<job_id>`). The `pipeline_id` is the run identifier — pipeline ID and run ID are the same value.
+
+Every stage of the run lives as a child subdirectory of the run dir, named after the stage (the value of its `PipelineType`: `transcription`, `cep`, `kg`, `qa`, `evaluation`, etc.). Each stage subdirectory has the same shape, regardless of which stage it is:
+
+- A `<stage>_checkpoint.json` (or `checkpoint.json` for transcription, kept for historical reasons) — the `CheckpointManager` state file. This is what `mark_completed()` and `mark_failed()` write to; only its contents differ between stages, never its location.
+- A `run_metadata.json` — a `RunMetadata` snapshot capturing `started_at`, `ended_at`, `status` (`RunStatus`), the `ConfigSnapshot` of whatever `BaseSettings`/`BaseModel` the stage was given, the `HardwareInfo`, the `ExecutionEnvironment` (local vs SLURM, partition, job id), the arandu version, and progress counters (`completed_items`, `failed_items`, `total_items`).
+- An `outputs/` subdirectory — the only part of a stage's footprint that is stage-specific. Anything domain-specific (transcription JSONs, CEP QA records, KG GraphML, atlas-rag intermediates, retrieval JSONL, etc.) goes here.
+
+The run root carries one extra file, `pipeline.json` — a `PipelineMetadata` document. It records the `pipeline_id`, `created_at`, the list of `steps_run` accumulated as each stage attaches to the run, and the `schema_version`. When a new stage attaches to an existing run, `ResultsManager.create_run` appends its step name to `pipeline.json` rather than rewriting the file.
+
+The `results/` root itself carries a single aggregate file, `index.json`, which the manager rewrites under an `fcntl` exclusive lock every time a run completes (`complete_run` or `register_external_run`). Each entry summarises one stage of one run; CLI commands like `arandu list-runs` and `arandu run-info` read this index.
+
+### What this means in practice
+
+- **A stage never writes outside its run.** If you are extending the codebase with a new stage, instantiate a `ResultsManager(base_results_dir, pipeline_type, pipeline_id=...)`, call `create_run(config)`, and write artifacts under `manager.outputs_dir`. Do not default a CLI flag to a flat top-level directory like `Path("chunks")` — that defeats the convention and breaks cross-stage lookups.
+- **A stage can find peer stages by `pipeline_id` alone.** `ResultsManager.resolve_outputs(base_dir, pipeline_id, PipelineType.X)` and `resolve_latest_outputs(base_dir, PipelineType.X)` are the two lookups; downstream stages should resolve their inputs through them rather than accepting raw paths.
+- **Resumability is per-stage, not per-run.** Each stage's checkpoint lives next to its `run_metadata.json`, so re-running a stage on the same `pipeline_id` resumes that stage without disturbing siblings.
+- **The convention is uniform.** Only the stage name and the contents of `outputs/` vary between stages. The two metadata siblings are always present and always named the same way.
+
+### Extensions
+
+Phase C (RAG evaluation) plugs new stages (`chunk`, `retrieval_indexes`, `retrieval`, `answers`, `judge_answers`, `analysis`) into this same shape under each `results/<run-id>/`. See `docs/superpowers/specs/2026-05-08-phase-c-rag-evaluation-design.md` §11 for the binding spec, in particular §11.0 which restates this convention for Phase C.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds a new **Results Directory Layout** section to `docs/development/architecture.md`, prose only — no ASCII trees, since trees rot when files move and the convention is what's load-bearing. Names the per-stage shape (`<stage>_checkpoint.json` + `run_metadata.json` + `outputs/`), the run-root extras (`pipeline.json` + `index.json`), and the `resolve_outputs` / `resolve_latest_outputs` lookup path.
- Surfaces the convention to cold-start agents by adding a **Persistence** item to the `AGENTS.md` Quick Start checklist + the Key Standards Summary table.
- Expands the `README.md` "Results Versioning" Features bullet with a one-sentence convention statement.
- Cross-references the Phase C spec (§11.0) as the binding extension document for the new RAG-evaluation stages.

### Why now

The convention has lived in code (`ResultsManager`) and as a single line of schema metadata for some time, but is undocumented anywhere a fresh agent would discover it. The recent `arandu chunk` CLI (PR #95) shipped with a flat `Path(\"chunks\")` default — a concrete drift that the new docs explicitly call out as an antipattern.

### Scope

Docs-only. No `src/` changes. No spec changes (the Phase C spec under `docs/superpowers/` is untracked and stays that way).

## Test plan

- [ ] Render `docs/development/architecture.md` and confirm the new section appears between "Checkpoint System Pattern" and "Batch Processing Pattern" with a working ToC anchor.
- [ ] Confirm the cross-section links from `AGENTS.md` (Quick Start item 7 + Key Standards row) and `README.md` (Features bullet) all resolve to `docs/development/architecture.md#results-directory-layout`.
- [ ] Read the new section cold and verify a new contributor could correctly place a new pipeline stage's outputs without reading source.