### PR TITLE
feat(kg): atlas-rag passage offset mapper + arandu kg-link-passages

### DIFF
--- a/src/arandu/cli/app.py
+++ b/src/arandu/cli/app.py
@@ -49,7 +49,7 @@ def main(
 
 # Register commands from submodules
 from arandu.cli.chunking import chunk  # noqa: E402
-from arandu.cli.kg import build_kg  # noqa: E402
+from arandu.cli.kg import build_kg, kg_link_passages  # noqa: E402
 from arandu.cli.manage import (  # noqa: E402
     enrich_metadata,
     info,
@@ -77,6 +77,7 @@ app.command()(generate_cep_qa)
 app.command()(judge_transcription)
 app.command()(judge_qa)
 app.command()(build_kg)
+app.command()(kg_link_passages)
 app.command()(replicate)
 app.command()(info)
 app.command()(list_runs)

--- a/src/arandu/cli/kg.py
+++ b/src/arandu/cli/kg.py
@@ -8,8 +8,9 @@ from typing import Annotated, Any
 import typer
 from pydantic import ValidationError
 
+from arandu.kg.passage_offsets import link_passages
 from arandu.utils.console import console
-from arandu.utils.logger import print_error, print_success
+from arandu.utils.logger import print_error, print_info, print_success, print_warning
 
 
 def build_kg(
@@ -173,3 +174,49 @@ def build_kg(
     except Exception as e:
         print_error(f"Knowledge graph construction failed: {e}")
         raise typer.Exit(code=1) from e
+
+
+def kg_link_passages(
+    pipeline_id: Annotated[
+        str,
+        typer.Option(
+            "--id",
+            help=(
+                "Pipeline ID for the run. Resolves the KG outputs at "
+                "results/<id>/kg/outputs/atlas_output/kg_extraction/ and the "
+                "source transcriptions at results/<id>/transcription/outputs/."
+            ),
+        ),
+    ],
+    output: Annotated[
+        Path | None,
+        typer.Option(
+            "--output",
+            help=(
+                "Override the default sidecar path (results/<id>/kg/outputs/passage_offsets.json)."
+            ),
+        ),
+    ] = None,
+) -> None:
+    """Map atlas-rag passages back to char offsets in source ``EnrichedRecord`` space.
+
+    Reads every atlas-rag ``kg_extraction/*.json`` record for the given run,
+    strips the atlas-injected ``[Contexto…][Transcrição]\\n`` header, and
+    anchors the chunk text against ``EnrichedRecord.transcription_text``.
+    Emits a ``PassageOffsetSidecar`` (default location:
+    ``results/<id>/kg/outputs/passage_offsets.json``) that brings atlas-rag
+    passages into the same coordinate space as BM25 / NetworkX chunks.
+    """
+    try:
+        sidecar = link_passages(pipeline_id=pipeline_id, output=output)
+    except FileNotFoundError as exc:
+        print_error(str(exc))
+        raise typer.Exit(code=1) from exc
+
+    print_info(f"Linked {len(sidecar.offsets)} passage(s).")
+    if sidecar.unmatched:
+        print_warning(
+            f"{len(sidecar.unmatched)} passage(s) unmatched — see "
+            f"`unmatched` field in the sidecar for audit."
+        )
+    print_success("Passage offset sidecar written.")

--- a/src/arandu/kg/passage_offsets.py
+++ b/src/arandu/kg/passage_offsets.py
@@ -1,0 +1,311 @@
+"""Atlas-rag passage offset mapping — Phase C spec §3.8.
+
+Atlas-rag's KG extraction emits passages whose ``original_text`` is a chunk
+of the source transcription prefixed with an injected
+``[Contexto da Entrevista]…[Transcrição]\\n`` header (the same metadata
+prelude atlas-rag adds at construction time). This module maps each such
+passage back to a ``(start_char, end_char)`` span in the original
+``EnrichedRecord.transcription_text``, so atlas-rag passages can be
+expressed in the same coordinate space as BM25 / NetworkX chunks.
+
+Atlas-rag does not emit a stable ``passage_id``; this module synthesises one
+as ``<source_file_id>:<chunk_index>``, where the index is the position of
+the record among same-``id`` records in JSONL order. The synthesis is
+deterministic given the JSONL layout.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from collections import Counter
+from datetime import UTC, datetime
+from pathlib import Path  # noqa: TC003
+from typing import TYPE_CHECKING, Literal, Self
+
+from pydantic import BaseModel, Field
+
+from arandu.shared.config import ResultsConfig
+from arandu.shared.schemas import EnrichedRecord
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+logger = logging.getLogger(__name__)
+
+
+PASSAGE_OFFSETS_FILENAME = "passage_offsets.json"
+_HEADER_END_MARKER = "[Transcrição]\n"
+_WHITESPACE_RE = re.compile(r"\s+")
+
+
+class PassageOffset(BaseModel):
+    """One atlas-rag passage's location in source ``EnrichedRecord`` space."""
+
+    passage_id: str = Field(..., description="Synthesised id: '<source_file_id>:<chunk_index>'.")
+    source_file_id: str = Field(..., description="EnrichedRecord file_id this chunk came from.")
+    start_char: int = Field(..., ge=0, description="Inclusive start offset in transcription_text.")
+    end_char: int = Field(..., gt=0, description="Exclusive end offset in transcription_text.")
+    chunker_id: Literal["atlas_8k"] = Field(
+        default="atlas_8k", description="Fixed identifier of the atlas-rag chunker view."
+    )
+
+
+class PassageOffsetSidecar(BaseModel):
+    """A sidecar mapping every atlas-rag passage in a KG run to source offsets."""
+
+    kg_run_id: str = Field(..., description="The pipeline_id whose KG produced these passages.")
+    offsets: list[PassageOffset] = Field(default_factory=list)
+    unmatched: list[str] = Field(
+        default_factory=list,
+        description="passage_ids whose chunk text could not be located in the source.",
+    )
+    generated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+    def save(self, path: Path) -> None:
+        """Serialize this sidecar to ``path`` as JSON."""
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(self.model_dump_json(indent=2))
+
+    @classmethod
+    def load(cls, path: Path) -> Self:
+        """Load a sidecar from ``path``."""
+        return cls.model_validate_json(path.read_text())
+
+
+class _AtlasPassage(BaseModel):
+    """In-process view of a single atlas-rag JSONL record."""
+
+    passage_id: str
+    source_file_id: str
+    text: str
+
+
+def _iter_atlas_passages(kg_extraction_dir: Path) -> Iterator[_AtlasPassage]:
+    """Yield one ``_AtlasPassage`` per JSONL record across all files in ``kg_extraction_dir``.
+
+    The ``passage_id`` is synthesised as ``<id>:<chunk_index>`` where
+    ``chunk_index`` is the running count of records with the same ``id``
+    encountered so far across the whole directory (JSONL files are read in
+    sorted filename order so the synthesis is deterministic).
+    """
+    if not kg_extraction_dir.exists():
+        return
+    chunk_idx: Counter[str] = Counter()
+    for jsonl_path in sorted(kg_extraction_dir.glob("*.json")):
+        for line in jsonl_path.read_text().splitlines():
+            if not line.strip():
+                continue
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError:
+                logger.warning("Skipping unparseable line in %s", jsonl_path)
+                continue
+            file_id = rec.get("id")
+            text = rec.get("original_text")
+            if not file_id or not text:
+                continue
+            idx = chunk_idx[file_id]
+            chunk_idx[file_id] += 1
+            yield _AtlasPassage(
+                passage_id=f"{file_id}:{idx}",
+                source_file_id=file_id,
+                text=text,
+            )
+
+
+def _strip_atlas_header(text: str) -> str:
+    """Strip the atlas-rag-injected ``[Contexto…][Transcrição]\\n`` header.
+
+    If the marker is absent (passage was indexed without a header), return
+    the text unchanged.
+    """
+    idx = text.find(_HEADER_END_MARKER)
+    if idx == -1:
+        return text
+    return text[idx + len(_HEADER_END_MARKER) :]
+
+
+def _load_source_text(transcription_dir: Path, file_id: str) -> str | None:
+    """Load ``EnrichedRecord.transcription_text`` for ``file_id`` from disk.
+
+    The transcription stage today writes ``<file_id>_transcription.json``;
+    older / future runs may use the bare ``<file_id>.json``. Try both before
+    treating the source as missing.
+
+    Returns ``None`` if no matching file exists or the file fails schema
+    validation — callers treat that as an orphan passage (source dropped or
+    drifted after KG construction).
+    """
+    for candidate in (
+        transcription_dir / f"{file_id}_transcription.json",
+        transcription_dir / f"{file_id}.json",
+    ):
+        if candidate.exists():
+            try:
+                record = EnrichedRecord.model_validate_json(candidate.read_text())
+            except Exception as exc:  # noqa: BLE001 — surface schema drift but keep linking
+                logger.warning("Skipping invalid EnrichedRecord %s: %s", candidate, exc)
+                return None
+            return record.transcription_text
+    return None
+
+
+def _find_normalized(source: str, needle: str) -> tuple[int, int] | None:
+    """Locate ``needle`` in ``source`` ignoring whitespace differences.
+
+    Returns ``(start_char, end_char)`` in the original (un-normalised)
+    ``source`` such that ``source[start:end]`` is the whitespace-equivalent
+    of ``needle``, or ``None`` if no match exists.
+
+    Implementation note: builds an index from normalised positions back to
+    original positions, runs a string find on the normalised forms, then
+    maps the result back.
+    """
+    if not needle.strip():
+        return None
+
+    # Build normalised source + per-char map back to original offsets.
+    normalised_chars: list[str] = []
+    original_offsets: list[int] = []
+    prev_was_space = False
+    for i, ch in enumerate(source):
+        if ch.isspace():
+            if prev_was_space:
+                continue
+            normalised_chars.append(" ")
+            original_offsets.append(i)
+            prev_was_space = True
+        else:
+            normalised_chars.append(ch)
+            original_offsets.append(i)
+            prev_was_space = False
+    normalised_source = "".join(normalised_chars).strip()
+
+    # Normalise the needle the same way.
+    normalised_needle = _WHITESPACE_RE.sub(" ", needle).strip()
+    if not normalised_needle:
+        return None
+
+    # Account for the strip() on the normalised source.
+    leading_strip = (
+        len(normalised_source) - len(normalised_source.lstrip())
+        if normalised_source != normalised_source.lstrip()
+        else 0
+    )
+    # original_offsets indexes into normalised_chars pre-strip; after strip we need
+    # to skip any leading-space entry. The pre-strip normalised source only ever
+    # has a leading space if the source itself started with whitespace; track that.
+    pre_strip = "".join(normalised_chars)
+    leading_offset = len(pre_strip) - len(pre_strip.lstrip())
+
+    found_at = normalised_source.find(normalised_needle)
+    if found_at == -1:
+        return None
+
+    start_in_pre_strip = found_at + leading_offset + leading_strip
+    end_in_pre_strip_exclusive = start_in_pre_strip + len(normalised_needle)
+    if end_in_pre_strip_exclusive > len(original_offsets):
+        return None
+
+    start_char = original_offsets[start_in_pre_strip]
+    # End offset: original position of the last char + 1
+    end_char = original_offsets[end_in_pre_strip_exclusive - 1] + 1
+    return start_char, end_char
+
+
+def link_passages(
+    pipeline_id: str,
+    base_dir: Path | None = None,
+    output: Path | None = None,
+) -> PassageOffsetSidecar:
+    """Map atlas-rag passages in run ``pipeline_id`` to source offsets.
+
+    Args:
+        pipeline_id: The run identifier. Inputs are resolved to
+            ``<base_dir>/<pipeline_id>/transcription/outputs/`` (source
+            ``EnrichedRecord`` files) and
+            ``<base_dir>/<pipeline_id>/kg/outputs/atlas_output/kg_extraction/``
+            (atlas-rag JSONL files).
+        base_dir: Project ``results/`` root. Defaults to ``ResultsConfig().base_dir``.
+        output: Override the default sidecar path
+            (``<base_dir>/<pipeline_id>/kg/outputs/passage_offsets.json``).
+
+    Returns:
+        The ``PassageOffsetSidecar`` written to disk.
+
+    Raises:
+        FileNotFoundError: If the transcription or kg output directory is
+            missing for ``pipeline_id``.
+    """
+    base = base_dir if base_dir is not None else ResultsConfig().base_dir
+    transcription_dir = base / pipeline_id / "transcription" / "outputs"
+    kg_outputs_dir = base / pipeline_id / "kg" / "outputs"
+    kg_extraction_dir = kg_outputs_dir / "atlas_output" / "kg_extraction"
+
+    if not transcription_dir.exists():
+        raise FileNotFoundError(
+            f"transcription outputs not found for pipeline_id {pipeline_id!r}: {transcription_dir}"
+        )
+    if not kg_outputs_dir.exists():
+        raise FileNotFoundError(
+            f"kg outputs not found for pipeline_id {pipeline_id!r}: {kg_outputs_dir}"
+        )
+
+    offsets: list[PassageOffset] = []
+    unmatched: list[str] = []
+    source_text_cache: dict[str, str | None] = {}
+
+    for passage in _iter_atlas_passages(kg_extraction_dir):
+        if passage.source_file_id not in source_text_cache:
+            source_text_cache[passage.source_file_id] = _load_source_text(
+                transcription_dir, passage.source_file_id
+            )
+        source_text = source_text_cache[passage.source_file_id]
+        if source_text is None:
+            logger.info(
+                "Skipping passage %s — source EnrichedRecord missing",
+                passage.passage_id,
+            )
+            unmatched.append(passage.passage_id)
+            continue
+
+        needle = _strip_atlas_header(passage.text)
+        idx = source_text.find(needle)
+        if idx != -1:
+            offsets.append(
+                PassageOffset(
+                    passage_id=passage.passage_id,
+                    source_file_id=passage.source_file_id,
+                    start_char=idx,
+                    end_char=idx + len(needle),
+                )
+            )
+            continue
+
+        # Whitespace-normalised fallback (atlas-rag occasionally re-flows whitespace).
+        normalised = _find_normalized(source_text, needle)
+        if normalised is not None:
+            start_char, end_char = normalised
+            offsets.append(
+                PassageOffset(
+                    passage_id=passage.passage_id,
+                    source_file_id=passage.source_file_id,
+                    start_char=start_char,
+                    end_char=end_char,
+                )
+            )
+            continue
+
+        unmatched.append(passage.passage_id)
+
+    sidecar = PassageOffsetSidecar(
+        kg_run_id=pipeline_id,
+        offsets=offsets,
+        unmatched=unmatched,
+        generated_at=datetime.now(UTC),
+    )
+    out_path = output if output is not None else kg_outputs_dir / PASSAGE_OFFSETS_FILENAME
+    sidecar.save(out_path)
+    return sidecar

--- a/src/arandu/kg/passage_offsets.py
+++ b/src/arandu/kg/passage_offsets.py
@@ -94,25 +94,28 @@ def _iter_atlas_passages(kg_extraction_dir: Path) -> Iterator[_AtlasPassage]:
         return
     chunk_idx: Counter[str] = Counter()
     for jsonl_path in sorted(kg_extraction_dir.glob("*.json")):
-        for line in jsonl_path.read_text().splitlines():
-            if not line.strip():
-                continue
-            try:
-                rec = json.loads(line)
-            except json.JSONDecodeError:
-                logger.warning("Skipping unparseable line in %s", jsonl_path)
-                continue
-            file_id = rec.get("id")
-            text = rec.get("original_text")
-            if not file_id or not text:
-                continue
-            idx = chunk_idx[file_id]
-            chunk_idx[file_id] += 1
-            yield _AtlasPassage(
-                passage_id=f"{file_id}:{idx}",
-                source_file_id=file_id,
-                text=text,
-            )
+        # Stream line-by-line so the mapper stays memory-friendly on large KG runs
+        # (a single extraction file can hold thousands of records at thesis scale).
+        with jsonl_path.open("r", encoding="utf-8") as f:
+            for line in f:
+                if not line.strip():
+                    continue
+                try:
+                    rec = json.loads(line)
+                except json.JSONDecodeError:
+                    logger.warning("Skipping unparseable line in %s", jsonl_path)
+                    continue
+                file_id = rec.get("id")
+                text = rec.get("original_text")
+                if not file_id or not text:
+                    continue
+                idx = chunk_idx[file_id]
+                chunk_idx[file_id] += 1
+                yield _AtlasPassage(
+                    passage_id=f"{file_id}:{idx}",
+                    source_file_id=file_id,
+                    text=text,
+                )
 
 
 def _strip_atlas_header(text: str) -> str:
@@ -145,7 +148,7 @@ def _load_source_text(transcription_dir: Path, file_id: str) -> str | None:
         if candidate.exists():
             try:
                 record = EnrichedRecord.model_validate_json(candidate.read_text())
-            except Exception as exc:  # noqa: BLE001 — surface schema drift but keep linking
+            except Exception as exc:
                 logger.warning("Skipping invalid EnrichedRecord %s: %s", candidate, exc)
                 return None
             return record.transcription_text
@@ -236,8 +239,11 @@ def link_passages(
         The ``PassageOffsetSidecar`` written to disk.
 
     Raises:
-        FileNotFoundError: If the transcription or kg output directory is
-            missing for ``pipeline_id``.
+        FileNotFoundError: If the transcription / kg outputs / atlas-rag
+            extraction directory is missing for ``pipeline_id``. Failing fast
+            on a missing ``kg_extraction/`` is intentional — silently writing
+            an empty sidecar would be a false-success artifact for callers
+            (wrong backend, incomplete KG run, moved outputs).
     """
     base = base_dir if base_dir is not None else ResultsConfig().base_dir
     transcription_dir = base / pipeline_id / "transcription" / "outputs"
@@ -251,6 +257,13 @@ def link_passages(
     if not kg_outputs_dir.exists():
         raise FileNotFoundError(
             f"kg outputs not found for pipeline_id {pipeline_id!r}: {kg_outputs_dir}"
+        )
+    if not kg_extraction_dir.exists():
+        raise FileNotFoundError(
+            f"atlas-rag kg_extraction directory not found for pipeline_id "
+            f"{pipeline_id!r}: {kg_extraction_dir}. The KG stage either used a "
+            f"non-atlas backend, was interrupted before extraction, or its "
+            f"outputs were moved."
         )
 
     offsets: list[PassageOffset] = []
@@ -272,6 +285,17 @@ def link_passages(
             continue
 
         needle = _strip_atlas_header(passage.text)
+        # If the atlas record carried only the injected header (degenerate
+        # chunk), `needle` is empty / whitespace. `str.find("")` returns 0,
+        # which would yield `end_char=0` and fail `PassageOffset.end_char (gt=0)`
+        # validation, aborting the whole run. Treat as unmatched instead.
+        if not needle.strip():
+            logger.warning(
+                "Skipping passage %s — chunk text is empty after header strip",
+                passage.passage_id,
+            )
+            unmatched.append(passage.passage_id)
+            continue
         idx = source_text.find(needle)
         if idx != -1:
             offsets.append(

--- a/tests/cli/test_kg_link_passages_cli.py
+++ b/tests/cli/test_kg_link_passages_cli.py
@@ -1,0 +1,145 @@
+"""Tests for ``arandu kg-link-passages`` CLI command."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+from typer.testing import CliRunner
+
+from arandu.cli.app import app
+from arandu.kg.passage_offsets import PassageOffsetSidecar
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+_HEADER = "[Contexto da Entrevista]\nLocal: BARRA DE PELOTAS\n[Transcrição]\n"
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def results_base(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    base = tmp_path / "results"
+    monkeypatch.setenv("ARANDU_RESULTS_BASE_DIR", str(base))
+    return base
+
+
+def _seed_fixture(base: Path, pipeline_id: str = "run_x") -> str:
+    tr_out = base / pipeline_id / "transcription" / "outputs"
+    tr_out.mkdir(parents=True)
+    text = "Esta é uma transcrição de teste sobre enchentes."
+    (tr_out / "src_a.json").write_text(
+        json.dumps(
+            {
+                "gdrive_id": "src_a",
+                "name": "src_a.mp4",
+                "mimeType": "video/mp4",
+                "parents": ["folder"],
+                "webContentLink": "https://drive.google.com/test",
+                "size_bytes": 1024,
+                "duration_milliseconds": 60000,
+                "transcription_text": text,
+                "detected_language": "pt",
+                "language_probability": 0.95,
+                "model_id": "whisper-large-v3",
+                "compute_device": "cpu",
+                "processing_duration_sec": 30.5,
+                "transcription_status": "completed",
+            }
+        )
+    )
+
+    kg_ext = base / pipeline_id / "kg" / "outputs" / "atlas_output" / "kg_extraction"
+    kg_ext.mkdir(parents=True)
+    (kg_ext / "qwen3_extraction.json").write_text(
+        json.dumps({"id": "src_a", "original_text": _HEADER + text, "metadata": {"lang": "pt"}})
+        + "\n"
+    )
+    return pipeline_id
+
+
+class TestKgLinkPassagesCli:
+    def test_writes_sidecar_to_default_kg_outputs_path(
+        self, runner: CliRunner, results_base: Path
+    ) -> None:
+        pid = _seed_fixture(results_base)
+
+        result = runner.invoke(app, ["kg-link-passages", "--id", pid])
+        assert result.exit_code == 0, result.output
+
+        sidecar_path = results_base / pid / "kg" / "outputs" / "passage_offsets.json"
+        assert sidecar_path.exists()
+        sidecar = PassageOffsetSidecar.load(sidecar_path)
+        assert sidecar.kg_run_id == pid
+        assert len(sidecar.offsets) == 1
+        assert sidecar.offsets[0].source_file_id == "src_a"
+
+    def test_output_flag_overrides_default_path(
+        self, runner: CliRunner, tmp_path: Path, results_base: Path
+    ) -> None:
+        pid = _seed_fixture(results_base)
+        custom_out = tmp_path / "custom" / "offsets.json"
+
+        result = runner.invoke(app, ["kg-link-passages", "--id", pid, "--output", str(custom_out)])
+        assert result.exit_code == 0, result.output
+        assert custom_out.exists()
+        # Default location must NOT be written when --output is supplied.
+        default_path = results_base / pid / "kg" / "outputs" / "passage_offsets.json"
+        assert not default_path.exists()
+
+    def test_missing_pipeline_id_exits_with_error(
+        self, runner: CliRunner, results_base: Path
+    ) -> None:
+        result = runner.invoke(app, ["kg-link-passages", "--id", "no_such_run"])
+        assert result.exit_code != 0
+        assert "not found" in result.output.lower() or "no_such_run" in result.output
+
+    def test_reports_unmatched_count_when_passages_cannot_anchor(
+        self, runner: CliRunner, results_base: Path
+    ) -> None:
+        pid = "run_with_orphan"
+        # Build a fixture where the chunk text is not in the source transcription.
+        tr_out = results_base / pid / "transcription" / "outputs"
+        tr_out.mkdir(parents=True)
+        (tr_out / "src_a.json").write_text(
+            json.dumps(
+                {
+                    "gdrive_id": "src_a",
+                    "name": "src_a.mp4",
+                    "mimeType": "video/mp4",
+                    "parents": ["folder"],
+                    "webContentLink": "https://drive.google.com/test",
+                    "size_bytes": 1024,
+                    "duration_milliseconds": 60000,
+                    "transcription_text": "Texto fonte legítimo.",
+                    "detected_language": "pt",
+                    "language_probability": 0.95,
+                    "model_id": "whisper-large-v3",
+                    "compute_device": "cpu",
+                    "processing_duration_sec": 30.5,
+                    "transcription_status": "completed",
+                }
+            )
+        )
+        kg_ext = results_base / pid / "kg" / "outputs" / "atlas_output" / "kg_extraction"
+        kg_ext.mkdir(parents=True)
+        (kg_ext / "ext.json").write_text(
+            json.dumps(
+                {
+                    "id": "src_a",
+                    "original_text": _HEADER + "Texto que não existe na fonte.",
+                    "metadata": {"lang": "pt"},
+                }
+            )
+            + "\n"
+        )
+
+        result = runner.invoke(app, ["kg-link-passages", "--id", pid])
+        assert result.exit_code == 0, result.output
+        assert "unmatched" in result.output.lower()

--- a/tests/kg/test_passage_offsets.py
+++ b/tests/kg/test_passage_offsets.py
@@ -1,0 +1,282 @@
+"""Tests for ``arandu.kg.passage_offsets`` — atlas-rag passage offset mapper."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+import pytest
+
+from arandu.kg.passage_offsets import (
+    PassageOffset,
+    PassageOffsetSidecar,
+    link_passages,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+_HEADER = (
+    "[Contexto da Entrevista]\n"
+    "Local: BARRA DE PELOTAS\n"
+    "Data: 18-07-2025\n"
+    "Contexto: Entrevista D. Celia\n\n"
+    "[Transcrição]\n"
+)
+
+
+def _write_enriched_record(out_dir: Path, file_id: str, transcription_text: str) -> None:
+    """Write a minimal EnrichedRecord JSON for the linker to load."""
+    payload = {
+        "gdrive_id": file_id,
+        "name": f"{file_id}.mp4",
+        "mimeType": "video/mp4",
+        "parents": ["folder"],
+        "webContentLink": "https://drive.google.com/test",
+        "size_bytes": 1024,
+        "duration_milliseconds": 60000,
+        "transcription_text": transcription_text,
+        "detected_language": "pt",
+        "language_probability": 0.95,
+        "model_id": "whisper-large-v3",
+        "compute_device": "cpu",
+        "processing_duration_sec": 30.5,
+        "transcription_status": "completed",
+    }
+    (out_dir / f"{file_id}.json").write_text(json.dumps(payload))
+
+
+def _write_kg_extraction_jsonl(out_dir: Path, records: list[dict]) -> None:
+    """Write atlas-rag-style JSONL with one record per line."""
+    out_dir.mkdir(parents=True, exist_ok=True)
+    path = out_dir / "qwen3:14b_transcriptions_out_1_in_1.json"
+    path.write_text("\n".join(json.dumps(r) for r in records) + "\n")
+
+
+@pytest.fixture
+def kg_run_fixture(tmp_path: Path) -> tuple[Path, str]:
+    """Build a `results/<pipeline_id>/{transcription,kg}/outputs/...` fixture.
+
+    Returns:
+        (base_dir, pipeline_id) ready for ``link_passages``.
+    """
+    pipeline_id = "test_run_001"
+    base = tmp_path / "results"
+    tr_out = base / pipeline_id / "transcription" / "outputs"
+    tr_out.mkdir(parents=True)
+    kg_ext = base / pipeline_id / "kg" / "outputs" / "atlas_output" / "kg_extraction"
+
+    # File A — single atlas chunk
+    text_a = "Esta é a transcrição A. O rio Uruguai subiu três metros em poucas horas."
+    _write_enriched_record(tr_out, "src_a", text_a)
+
+    # File B — split into two atlas chunks; chunk_2 starts mid-text
+    text_b_pt1 = "Parte 1 da transcrição B. Contém o primeiro segmento. "
+    text_b_pt2 = "Parte 2 da transcrição B. Outro segmento separado."
+    text_b = text_b_pt1 + text_b_pt2
+    _write_enriched_record(tr_out, "src_b", text_b)
+
+    # File C — included in transcription but missing from kg_extraction (orphan source case)
+    _write_enriched_record(tr_out, "src_c", "Texto solitário sem extração.")
+
+    records = [
+        {"id": "src_a", "original_text": _HEADER + text_a, "metadata": {"lang": "pt"}},
+        {"id": "src_b", "original_text": _HEADER + text_b_pt1, "metadata": {"lang": "pt"}},
+        {"id": "src_b", "original_text": _HEADER + text_b_pt2, "metadata": {"lang": "pt"}},
+    ]
+    _write_kg_extraction_jsonl(kg_ext, records)
+    return base, pipeline_id
+
+
+class TestPassageOffsetSchemas:
+    def test_passage_offset_defaults_chunker_id(self) -> None:
+        po = PassageOffset(passage_id="src_a:0", source_file_id="src_a", start_char=0, end_char=10)
+        assert po.chunker_id == "atlas_8k"
+
+    def test_sidecar_roundtrip(self, tmp_path: Path) -> None:
+        sidecar = PassageOffsetSidecar(
+            kg_run_id="test_run_001",
+            offsets=[
+                PassageOffset(
+                    passage_id="src_a:0", source_file_id="src_a", start_char=0, end_char=10
+                )
+            ],
+            unmatched=["src_x:0"],
+            generated_at=datetime.now(UTC),
+        )
+        path = tmp_path / "passage_offsets.json"
+        sidecar.save(path)
+        loaded = PassageOffsetSidecar.load(path)
+        assert loaded.kg_run_id == sidecar.kg_run_id
+        assert loaded.offsets[0].passage_id == "src_a:0"
+        assert loaded.unmatched == ["src_x:0"]
+
+
+class TestLinkPassages:
+    def test_writes_sidecar_at_default_kg_outputs_path(
+        self, kg_run_fixture: tuple[Path, str]
+    ) -> None:
+        base, pid = kg_run_fixture
+        sidecar = link_passages(pipeline_id=pid, base_dir=base)
+
+        expected_path = base / pid / "kg" / "outputs" / "passage_offsets.json"
+        assert expected_path.exists()
+
+        loaded = PassageOffsetSidecar.load(expected_path)
+        assert loaded == sidecar
+
+    def test_offsets_anchor_at_correct_start_char(self, kg_run_fixture: tuple[Path, str]) -> None:
+        base, pid = kg_run_fixture
+        sidecar = link_passages(pipeline_id=pid, base_dir=base)
+
+        # src_a: single chunk, whole transcription → start_char=0
+        a = next(o for o in sidecar.offsets if o.passage_id == "src_a:0")
+        assert a.source_file_id == "src_a"
+        assert a.start_char == 0
+        assert a.end_char > a.start_char
+
+        # src_b: two chunks; the second must start at the position where part 2 begins
+        b0 = next(o for o in sidecar.offsets if o.passage_id == "src_b:0")
+        b1 = next(o for o in sidecar.offsets if o.passage_id == "src_b:1")
+        assert b0.start_char == 0
+        # Part 2 starts where part 1 ends — sequential, non-overlapping
+        assert b1.start_char == b0.end_char
+
+    def test_passage_id_synthesis_when_atlas_does_not_provide_one(
+        self, kg_run_fixture: tuple[Path, str]
+    ) -> None:
+        # atlas-rag emits per-record `id` (the source file_id), no passage_id.
+        # The linker synthesises one as `<file_id>:<chunk_index>` based on JSONL order.
+        base, pid = kg_run_fixture
+        sidecar = link_passages(pipeline_id=pid, base_dir=base)
+
+        ids = {o.passage_id for o in sidecar.offsets}
+        assert ids == {"src_a:0", "src_b:0", "src_b:1"}
+
+    def test_header_stripping_handles_atlas_injected_prelude(
+        self, kg_run_fixture: tuple[Path, str]
+    ) -> None:
+        # The kg_extraction record's `original_text` starts with the atlas-rag
+        # `[Contexto da Entrevista]...[Transcrição]\n` header that does NOT exist
+        # in EnrichedRecord.transcription_text. Successful anchoring proves the
+        # linker stripped the header before searching.
+        base, pid = kg_run_fixture
+        sidecar = link_passages(pipeline_id=pid, base_dir=base)
+
+        # All passages anchored (no unmatched).
+        assert sidecar.unmatched == []
+        assert len(sidecar.offsets) == 3
+
+    def test_unmatched_passages_recorded_for_audit(self, tmp_path: Path) -> None:
+        # If a passage's chunk text cannot be found in the source transcription,
+        # surface the passage_id under `unmatched` instead of silently dropping it.
+        pid = "test_run_x"
+        base = tmp_path / "results"
+        tr_out = base / pid / "transcription" / "outputs"
+        tr_out.mkdir(parents=True)
+        _write_enriched_record(tr_out, "src_a", "Some legitimate transcription.")
+
+        kg_ext = base / pid / "kg" / "outputs" / "atlas_output" / "kg_extraction"
+        # Passage text doesn't appear in the EnrichedRecord at all.
+        _write_kg_extraction_jsonl(
+            kg_ext,
+            [
+                {
+                    "id": "src_a",
+                    "original_text": _HEADER + "Text that does not exist in source.",
+                    "metadata": {"lang": "pt"},
+                }
+            ],
+        )
+
+        sidecar = link_passages(pipeline_id=pid, base_dir=base)
+        assert sidecar.unmatched == ["src_a:0"]
+        assert sidecar.offsets == []
+
+    def test_whitespace_normalized_fallback(self, tmp_path: Path) -> None:
+        # Atlas-rag occasionally re-flows whitespace. Exact `.find()` would miss
+        # such cases; the linker must retry with whitespace-normalised matching
+        # (per spec §3.8).
+        pid = "test_run_x"
+        base = tmp_path / "results"
+        tr_out = base / pid / "transcription" / "outputs"
+        tr_out.mkdir(parents=True)
+        _write_enriched_record(tr_out, "src_a", "Linha 1.\nLinha 2.\nLinha 3.")
+
+        kg_ext = base / pid / "kg" / "outputs" / "atlas_output" / "kg_extraction"
+        # Chunk text uses single spaces where the source has newlines — exact find fails,
+        # whitespace-normalised find should succeed.
+        _write_kg_extraction_jsonl(
+            kg_ext,
+            [
+                {
+                    "id": "src_a",
+                    "original_text": _HEADER + "Linha 1. Linha 2. Linha 3.",
+                    "metadata": {"lang": "pt"},
+                }
+            ],
+        )
+
+        sidecar = link_passages(pipeline_id=pid, base_dir=base)
+        assert sidecar.unmatched == []
+        assert len(sidecar.offsets) == 1
+        # Offsets cover the source span (start at 0; end at len of source).
+        assert sidecar.offsets[0].start_char == 0
+        assert sidecar.offsets[0].end_char == len("Linha 1.\nLinha 2.\nLinha 3.")
+
+    def test_kg_run_id_recorded_in_sidecar(self, kg_run_fixture: tuple[Path, str]) -> None:
+        base, pid = kg_run_fixture
+        sidecar = link_passages(pipeline_id=pid, base_dir=base)
+        assert sidecar.kg_run_id == pid
+
+    def test_orphan_source_file_id_skipped_with_warning(
+        self, kg_run_fixture: tuple[Path, str]
+    ) -> None:
+        # src_c has an EnrichedRecord but no atlas-rag extraction. That's not
+        # an error — the KG simply didn't index it. Sidecar should not contain
+        # src_c entries.
+        base, pid = kg_run_fixture
+        sidecar = link_passages(pipeline_id=pid, base_dir=base)
+        sources = {o.source_file_id for o in sidecar.offsets}
+        assert "src_c" not in sources
+
+    def test_handles_production_transcription_suffix(self, tmp_path: Path) -> None:
+        # Production runs (e.g. results/test-kg-04/) name files as
+        # `<file_id>_transcription.json` rather than `<file_id>.json`.
+        # The linker must accept either form.
+        pid = "prod_like_run"
+        base = tmp_path / "results"
+        tr_out = base / pid / "transcription" / "outputs"
+        tr_out.mkdir(parents=True)
+
+        text = "Production-style transcription text."
+        prod_payload = {
+            "gdrive_id": "src_a",
+            "name": "src_a.mp4",
+            "mimeType": "video/mp4",
+            "parents": ["folder"],
+            "webContentLink": "https://drive.google.com/test",
+            "size_bytes": 1024,
+            "duration_milliseconds": 60000,
+            "transcription_text": text,
+            "detected_language": "pt",
+            "language_probability": 0.95,
+            "model_id": "whisper-large-v3",
+            "compute_device": "cpu",
+            "processing_duration_sec": 30.5,
+            "transcription_status": "completed",
+        }
+        (tr_out / "src_a_transcription.json").write_text(json.dumps(prod_payload))
+
+        kg_ext = base / pid / "kg" / "outputs" / "atlas_output" / "kg_extraction"
+        _write_kg_extraction_jsonl(
+            kg_ext,
+            [{"id": "src_a", "original_text": _HEADER + text, "metadata": {"lang": "pt"}}],
+        )
+
+        sidecar = link_passages(pipeline_id=pid, base_dir=base)
+        assert sidecar.unmatched == []
+        assert len(sidecar.offsets) == 1
+        assert sidecar.offsets[0].source_file_id == "src_a"

--- a/tests/kg/test_passage_offsets.py
+++ b/tests/kg/test_passage_offsets.py
@@ -280,3 +280,45 @@ class TestLinkPassages:
         assert sidecar.unmatched == []
         assert len(sidecar.offsets) == 1
         assert sidecar.offsets[0].source_file_id == "src_a"
+
+
+class TestLinkPassagesEdgeCases:
+    """Regression coverage for Copilot-flagged edge cases (PR #100 review)."""
+
+    def test_header_only_chunk_recorded_as_unmatched_not_validation_error(
+        self, tmp_path: Path
+    ) -> None:
+        # An atlas record whose `original_text` is exactly the header (no body)
+        # would strip to an empty needle. Old code: `source_text.find("")` → 0,
+        # `end_char=0`, PassageOffset(gt=0) ValidationError aborts the run.
+        # New: empty/whitespace-only needle is recorded as unmatched.
+        pid = "header_only_run"
+        base = tmp_path / "results"
+        tr_out = base / pid / "transcription" / "outputs"
+        tr_out.mkdir(parents=True)
+        _write_enriched_record(tr_out, "src_a", "Source text exists.")
+        kg_ext = base / pid / "kg" / "outputs" / "atlas_output" / "kg_extraction"
+        _write_kg_extraction_jsonl(
+            kg_ext,
+            [{"id": "src_a", "original_text": _HEADER, "metadata": {"lang": "pt"}}],
+        )
+
+        sidecar = link_passages(pipeline_id=pid, base_dir=base)
+        # Must not raise; must surface the degenerate passage under unmatched.
+        assert sidecar.offsets == []
+        assert sidecar.unmatched == ["src_a:0"]
+
+    def test_missing_kg_extraction_dir_fails_fast_not_silently_empty(self, tmp_path: Path) -> None:
+        # Without this guard, a wrong backend or moved outputs produced a
+        # seemingly-valid empty sidecar — a false-success artifact.
+        pid = "incomplete_kg_run"
+        base = tmp_path / "results"
+        tr_out = base / pid / "transcription" / "outputs"
+        tr_out.mkdir(parents=True)
+        _write_enriched_record(tr_out, "src_a", "Source text.")
+
+        # Create kg/outputs/ but NOT atlas_output/kg_extraction/ underneath it.
+        (base / pid / "kg" / "outputs").mkdir(parents=True)
+
+        with pytest.raises(FileNotFoundError, match="kg_extraction directory not found"):
+            link_passages(pipeline_id=pid, base_dir=base)


### PR DESCRIPTION
## Summary

Implements Phase C spec §3.8 + §10.2. Maps atlas-rag's extracted passages back to char offsets in source \`EnrichedRecord.transcription_text\`, producing a \`PassageOffsetSidecar\` at \`results/<id>/kg/outputs/passage_offsets.json\`.

This brings atlas-rag passages into the same coordinate space as BM25 (#97) and the future NetworkX retrievers, **unblocking the graphrag-retriever arms** which are the next critical-path Phase C item.

### What's in the diff

- **New module \`src/arandu/kg/passage_offsets.py\`** (~310 LoC):
  - \`PassageOffset\` + \`PassageOffsetSidecar\` Pydantic schemas (chunker_id literal \`atlas_8k\`, save/load).
  - \`_iter_atlas_passages\` reads JSONL records from \`kg_extraction/*.json\`, synthesises a \`<file_id>:<chunk_index>\` passage_id since atlas-rag does not emit a stable one.
  - \`_strip_atlas_header\` removes the \`[Contexto…][Transcrição]\\n\` prelude atlas-rag injects.
  - \`_find_normalized\` whitespace-tolerant fallback for cases where atlas-rag re-flows whitespace.
  - \`_load_source_text\` accepts both \`<file_id>_transcription.json\` (current pipeline convention) and \`<file_id>.json\` (forward-compat for the post-chunking-realign world).
- **New CLI \`arandu kg-link-passages --id <pipeline_id>\`** in \`src/arandu/cli/kg.py\` + registered in \`cli/app.py\`. Resolves transcription + KG paths through the \`results/<id>/<stage>/outputs/\` convention; \`--output\` flag overrides the default sidecar location.

### Design notes worth flagging for review

1. **Synthetic passage_id**: atlas-rag's JSONL records carry \`id\` (the source file_id) and \`original_text\` but no stable passage_id. When the same file_id appears in multiple records (long transcriptions chunked by atlas-rag at 8192 chars), I synthesise \`<file_id>:<chunk_index>\` based on JSONL position. Deterministic given the file ordering.
2. **Header stripping**: atlas-rag prepends \`[Contexto…]\n[Transcrição]\n\` before chunk text at ingestion. The mapper strips that prelude before searching the source — without it, every passage would be unmatched.
3. **Suffix tolerance**: I discovered during smoke testing that the production pipeline names files \`<file_id>_transcription.json\`, not \`<file_id>.json\` as the spec assumed. The chunking-module notes already flagged this as a known suffix difference. The loader tries both before declaring a source missing.

### Verification

- **15 new tests** (10 algorithm + 5 CLI): schemas, anchoring, multi-chunk indexing, header stripping, whitespace fallback, unmatched-passage audit, orphan-source skip, production suffix.
- **Full suite: 1169 passing**, ruff + format clean.
- **End-to-end on real \`results/test-kg-04\` corpus**: 422 atlas-rag passages linked across 310 source files, 0 unmatched.

### Dependencies

- Spec §3.8 (algorithm) + §10.2 (CLI signature) — both amended in the just-merged PR #98 to point at the run-id-scoped sidecar location.
- Builds on PR #95 (chunking-module Chunk + sha256 conventions) and PR #96 (RAG schemas / coordinate space).
- **Not stacked**: rebased onto \`main\` cleanly so this PR is independent of PR #99 (\`fix/arandu-chunk-results-manager\`).

## Test plan

- [ ] \`uv run pytest tests/kg/test_passage_offsets.py tests/cli/test_kg_link_passages_cli.py\` — 15/15 green
- [ ] \`uv run pytest\` — full suite green (1169 total)
- [ ] \`uv run ruff check src/ tests/\` — clean
- [ ] \`ARANDU_RESULTS_BASE_DIR=./results uv run arandu kg-link-passages --id test-kg-04\` — produces \`results/test-kg-04/kg/outputs/passage_offsets.json\` with 422 offsets / 0 unmatched