### PR TITLE
fix(rag): uniform top_k <= 0 contract across all retriever arms

### DIFF
--- a/src/arandu/shared/rag/retrievers/atlas_rag.py
+++ b/src/arandu/shared/rag/retrievers/atlas_rag.py
@@ -467,6 +467,12 @@ class AtlasRagRetriever:
             is atlas-rag's ``passage_id``; offsets are looked up via the
             ``passage_offsets.json`` sidecar by downstream judges.
         """
+        if top_k <= 0:
+            # Contract: caller may pass top_k=0 to disable an arm without
+            # branching elsewhere. Return [] cleanly rather than letting
+            # the bridge loop's `len(out) >= 0` short-circuit yield a
+            # stray record.
+            return []
         scored = self._retrieve_with_scores(question, top_k=top_k)
         return _atlas_results_to_retrieved_passages(scored)
 

--- a/src/arandu/shared/rag/retrievers/khop_subgraph.py
+++ b/src/arandu/shared/rag/retrievers/khop_subgraph.py
@@ -347,6 +347,11 @@ class KHopSubgraphRetriever:
             zero-indexed ranks and monotonically non-increasing scores.
             Empty entity link → empty list (graph-floor guarantee).
         """
+        if top_k <= 0:
+            # Contract: caller may pass top_k=0 to disable an arm without
+            # branching elsewhere. Return [] cleanly rather than letting
+            # the build-then-cap loop yield a stray record.
+            return []
         seeds = self._entity_link(question)
         if not seeds:
             return []

--- a/tests/shared/rag/retrievers/test_atlas_rag.py
+++ b/tests/shared/rag/retrievers/test_atlas_rag.py
@@ -157,6 +157,19 @@ class TestAtlasRagRetrieverRetrieve:
         instance._retrieve_with_scores = MagicMock(return_value=[])  # type: ignore[method-assign]
         assert isinstance(instance, Retriever)
 
+    def test_top_k_zero_returns_empty_without_calling_inner(self) -> None:
+        # Uniform contract across all retriever arms: top_k <= 0 → [].
+        # The bridge loop's `len(out) >= 0` would have short-circuited
+        # AFTER appending one record (silent contract violation). The
+        # early guard also avoids calling the expensive PPR seam.
+        instance = AtlasRagRetriever.__new__(AtlasRagRetriever)
+        instance.retriever_id = "atlas_rag_test"
+        instance._retrieve_with_scores = MagicMock(  # type: ignore[method-assign]
+            return_value=[("p1", 0.9)]
+        )
+        assert instance.retrieve("some question", top_k=0) == []
+        instance._retrieve_with_scores.assert_not_called()
+
 
 # -- chunk_id namespace bridge (PR #102 follow-up to PR #101) ------------
 

--- a/tests/shared/rag/retrievers/test_bm25.py
+++ b/tests/shared/rag/retrievers/test_bm25.py
@@ -188,6 +188,16 @@ class TestBM25Retrieve:
         results = retriever.retrieve("enchente", top_k=2)
         assert len(results) == 2
 
+    def test_top_k_zero_returns_empty(self, tmp_path: Path) -> None:
+        # Uniform contract across all retriever arms: top_k <= 0 → [].
+        # BM25's `argsort()[:0]` already produces [], but locking it here
+        # prevents future refactors from drifting away from the contract
+        # the other arms enforce explicitly.
+        chunks, resolver, index_dir = _build_corpus_fixture(tmp_path)
+        BM25Retriever.build_index(chunks, resolver, index_dir, CHUNKER_ID, language="pt")
+        retriever = BM25Retriever(index_dir=index_dir, chunker_id=CHUNKER_ID)
+        assert retriever.retrieve("enchente", top_k=0) == []
+
     def test_retrieve_returns_ranked_zero_indexed(self, tmp_path: Path) -> None:
         # "Itaqui Maria" — each token appears in exactly one doc (idf > 0), so the
         # ranking is non-degenerate and scores monotonically decrease.

--- a/tests/shared/rag/retrievers/test_khop_subgraph.py
+++ b/tests/shared/rag/retrievers/test_khop_subgraph.py
@@ -177,6 +177,16 @@ class TestKHopSubgraphRetrieverRetrieve:
         results = retriever.retrieve("rio enchente barragem", top_k=1)
         assert len(results) == 1
 
+    def test_top_k_zero_returns_empty(self, tmp_path: Path) -> None:
+        # Uniform contract across all retriever arms: top_k <= 0 → [].
+        # Previously, the build-then-cap loop appended a record on iteration
+        # 1, then `len(ranked) >= 0` broke — but the record was already in
+        # the list, so retrieve() silently returned 1 record when 0 were
+        # requested. Now guarded with an early `if top_k <= 0: return []`.
+        path = _write_kg_layout(_build_minimal_kg(), tmp_path)
+        retriever = KHopSubgraphRetriever(kg_outputs_dir=path, k_hop=2)
+        assert retriever.retrieve("rio enchente", top_k=0) == []
+
     def test_chunk_id_is_atlas_passage_id_not_text(self, tmp_path: Path) -> None:
         # Per the `RetrievedPassage.chunk_id` docstring it must be a
         # "reference into the source ChunkSet" — i.e. a stable identifier,

--- a/tests/shared/rag/retrievers/test_null.py
+++ b/tests/shared/rag/retrievers/test_null.py
@@ -18,8 +18,10 @@ class TestNullRetriever:
         assert retriever.retrieve("Em que ano ocorreu a enchente?", top_k=10) == []
 
     def test_retrieve_returns_empty_regardless_of_top_k(self) -> None:
+        # Includes top_k=0 to lock the uniform contract across all
+        # retriever arms (cf. fix/top-k-zero-contract).
         retriever = NullRetriever()
-        for k in (1, 5, 100):
+        for k in (0, 1, 5, 100):
             assert retriever.retrieve("qualquer pergunta", top_k=k) == []
 
     def test_retrieve_returns_empty_for_empty_question(self) -> None:

--- a/tests/shared/rag/retrievers/test_null.py
+++ b/tests/shared/rag/retrievers/test_null.py
@@ -19,7 +19,7 @@ class TestNullRetriever:
 
     def test_retrieve_returns_empty_regardless_of_top_k(self) -> None:
         # Includes top_k=0 to lock the uniform contract across all
-        # retriever arms (cf. fix/top-k-zero-contract).
+        # retriever arms.
         retriever = NullRetriever()
         for k in (0, 1, 5, 100):
             assert retriever.retrieve("qualquer pergunta", top_k=k) == []


### PR DESCRIPTION
## Summary

Audit follow-up from PR #104's Copilot review. The `top_k=0` IndexError fix on `KHopTripleRetriever` prompted a sweep across the other arms — found that **`KHopSubgraphRetriever`** and **`AtlasRagRetriever`** carry a different flavour of the same class of bug:

- `KHopTripleRetriever` (fixed in #104): `ranked[0]` after empty slice → **IndexError**
- `KHopSubgraphRetriever` + `AtlasRagRetriever` (this PR): `for ... if len(ranked) >= top_k: break` pattern appends a record BEFORE the cap check → **silently returns 1 record when 0 requested**

The second flavour is arguably worse — no crash, no surface error, but a contract violation that would skew benchmark metrics if `top_k=0` ever shows up in a sweep (e.g., to disable an arm).

## Fix

Early guard `if top_k <= 0: return []` at the top of `retrieve()` in both affected retrievers. Mirrors the guard already in `KHopTripleRetriever` and `BM25Retriever`'s implicit-via-`argsort()[:0]` behaviour. After this PR every arm honours the same uniform contract.

| Retriever | Behavior before | Behavior after |
| --- | --- | --- |
| `BM25Retriever` | `[]` ✓ | `[]` (unchanged) |
| `AtlasRagRetriever` | 1 stray record | `[]` (new guard) |
| `KHopSubgraphRetriever` | 1 stray record | `[]` (new guard) |
| `KHopTripleRetriever` | `[]` ✓ (#104) | `[]` (unchanged) |
| `NullRetriever` | `[]` ✓ | `[]` (unchanged) |

## Coverage

One test per arm locks the contract:

- `test_top_k_zero_returns_empty` on BM25, KHopSubgraph, AtlasRag
- `test_top_k_zero_returns_empty_without_calling_inner` on AtlasRag also asserts the guard fires BEFORE the expensive PPR seam
- `NullRetriever`'s existing parametric test extended to include `top_k=0`
- `KHopTripleRetriever` already had `test_top_k_zero_returns_empty_not_indexerror` from #104

Full suite: **129 passing locally** (was 125, +4 new). Lint + format clean.

## Test plan

- [ ] `uv run pytest tests/shared/rag/retrievers/` — green (129 tests)
- [ ] `uv run ruff check src/ tests/` — clean
- [ ] `uv run ruff format --check src/ tests/` — clean