### PR TITLE
feat(kg): arandu kg-build-retriever-index — split atlas-rag precompute from retrieve

### DIFF
--- a/scripts/test_atlas_rag_retriever.py
+++ b/scripts/test_atlas_rag_retriever.py
@@ -39,12 +39,12 @@ import os
 import time
 from pathlib import Path
 
-import numpy as np
 from openai import OpenAI
 from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
 
+from arandu.shared.embeddings import GeminiEmbedder
 from arandu.shared.rag.retrievers.atlas_rag import (
     PRECOMPUTE_DIR_NAME,
     AtlasRagRetriever,
@@ -58,68 +58,6 @@ SMOKE_QUESTIONS: list[str] = [
     "Como o rio Uruguai se comportou durante a enchente de 2024?",
     "Onde fica a estrada que foi reconstruída segundo D. Silvia?",
 ]
-
-
-# ----------------------------------------------------------------------
-# Gemini embedding shim (duck-typed against atlas-rag's BaseEmbeddingModel).
-# ----------------------------------------------------------------------
-
-
-class GeminiEmbedder:
-    """Adapter exposing Gemini embeddings via atlas-rag's encoder interface.
-
-    atlas-rag only calls `sentence_encoder.encode(batch, normalize_embeddings=bool)`
-    so we duck-type rather than subclass `BaseEmbeddingModel` (which would force
-    a heavier dependency on the atlas-rag class hierarchy).
-
-    Uses Gemini's OpenAI-compatible endpoint, so the same `OpenAI` client works
-    for both LLM completions and embeddings — no new SDK in the dependency tree.
-
-    Two layers of throttle handling for Gemini's quotas:
-
-    - **Batch size cap.** Gemini's BatchEmbedContentsRequest limits each call
-      to 100 inputs, but atlas-rag hands us batches of 256. We fan each call
-      out into Gemini-sized sub-requests.
-    - **Per-minute pacing + retry.** Gemini's paid-tier embed quota is
-      ~3000 RPM. We sleep `_PACING_SLEEP_S` between sub-requests to stay
-      well under, and rely on the openai SDK's built-in `Retry-After`
-      honouring (raised via `max_retries`) for any stragglers.
-    """
-
-    _GEMINI_BATCH_MAX = 100
-    _PACING_SLEEP_S = 0.05  # 20 RPS ≪ 50 RPS (the 3000 RPM ceiling)
-
-    def __init__(self, client: OpenAI, model: str) -> None:
-        self._client = client
-        self._model = model
-
-    def encode(
-        self,
-        sentences: list[str],
-        normalize_embeddings: bool = False,
-        **_kwargs: object,  # atlas-rag passes `query_type` etc.; ignore.
-    ) -> np.ndarray:
-        """Encode sentences into a 2D `(batch, dim)` numpy array.
-
-        Upstream's `HippoRAGRetriever.query2edge` calls
-        `np.linalg.norm(query_emb, axis=1, keepdims=True)` and
-        `edge_embeddings @ query_emb[0].T`, both of which require a 2D
-        ndarray. `list[ndarray]` works for the build-time `.extend()`
-        pattern but breaks query-time math — so we always return 2D.
-        """
-        if not sentences:
-            return np.zeros((0, 0), dtype=np.float32)
-        vectors: list[np.ndarray] = []
-        for start in range(0, len(sentences), self._GEMINI_BATCH_MAX):
-            sub = sentences[start : start + self._GEMINI_BATCH_MAX]
-            resp = self._client.embeddings.create(model=self._model, input=sub)
-            vectors.extend(np.array(d.embedding, dtype=np.float32) for d in resp.data)
-            if start + self._GEMINI_BATCH_MAX < len(sentences):
-                time.sleep(self._PACING_SLEEP_S)
-        arr = np.stack(vectors).astype(np.float32)
-        if normalize_embeddings:
-            arr = arr / np.linalg.norm(arr, axis=1, keepdims=True)
-        return arr
 
 
 def make_sentence_transformers_encoder(model_name: str) -> object:

--- a/src/arandu/cli/app.py
+++ b/src/arandu/cli/app.py
@@ -49,7 +49,7 @@ def main(
 
 # Register commands from submodules
 from arandu.cli.chunking import chunk  # noqa: E402
-from arandu.cli.kg import build_kg, kg_link_passages  # noqa: E402
+from arandu.cli.kg import build_kg, kg_build_retriever_index, kg_link_passages  # noqa: E402
 from arandu.cli.manage import (  # noqa: E402
     enrich_metadata,
     info,
@@ -78,6 +78,7 @@ app.command()(judge_transcription)
 app.command()(judge_qa)
 app.command()(build_kg)
 app.command()(kg_link_passages)
+app.command()(kg_build_retriever_index)
 app.command()(replicate)
 app.command()(info)
 app.command()(list_runs)

--- a/src/arandu/cli/kg.py
+++ b/src/arandu/cli/kg.py
@@ -9,6 +9,8 @@ import typer
 from pydantic import ValidationError
 
 from arandu.kg.passage_offsets import link_passages
+from arandu.kg.retriever_index import build_retriever_index
+from arandu.shared.embeddings import EmbedderSettings
 from arandu.utils.console import console
 from arandu.utils.logger import print_error, print_info, print_success, print_warning
 
@@ -220,3 +222,91 @@ def kg_link_passages(
             f"`unmatched` field in the sidecar for audit."
         )
     print_success("Passage offset sidecar written.")
+
+
+def kg_build_retriever_index(
+    pipeline_id: Annotated[
+        str,
+        typer.Option(
+            "--id",
+            help=(
+                "Pipeline ID for the run. Resolves the atlas-rag KG outputs at "
+                "results/<id>/kg/outputs/atlas_output/ and writes the precompute "
+                "under .../precompute/."
+            ),
+        ),
+    ],
+    keyword: Annotated[
+        str,
+        typer.Option(
+            "--keyword",
+            help="atlas-rag filename pattern (defaults to project convention).",
+        ),
+    ] = "transcriptions.json",
+    include_events: Annotated[
+        bool,
+        typer.Option(
+            "--include-events/--no-include-events",
+            help="Include event nodes in the embedded set. Defaults to True.",
+        ),
+    ] = True,
+    include_concept: Annotated[
+        bool,
+        typer.Option(
+            "--include-concept/--no-include-concept",
+            help="Include concept nodes in the embedded set. Defaults to True.",
+        ),
+    ] = True,
+    rebuild: Annotated[
+        bool,
+        typer.Option(
+            "--rebuild",
+            help=(
+                "Force a fresh build even if `precompute/manifest.json` already "
+                "exists. Without this flag, an existing precompute is reused."
+            ),
+        ),
+    ] = False,
+) -> None:
+    """Build the atlas-rag retriever's precomputed index for a run.
+
+    The precompute (node/edge/text pickles + integrity manifest) lives under
+    ``results/<id>/kg/outputs/atlas_output/precompute/`` and is consumed by
+    ``arandu retrieve --arm atlas_rag``. The build cost is non-trivial —
+    ~75k embeddings on test-kg-04 take ~5 minutes via Gemini and cost
+    ~$0.05 — so this is a dedicated step kept out of ``arandu retrieve``'s
+    hot path.
+
+    Embedder provider + model are read from ``ARANDU_EMBEDDER_*`` env
+    vars (see :class:`arandu.shared.embeddings.EmbedderSettings`).
+    Defaults to Gemini with ``gemini-embedding-001``; switch to
+    ``ARANDU_EMBEDDER_PROVIDER=sentence_transformers`` for local GPU.
+    """
+    try:
+        settings = EmbedderSettings()
+    except ValidationError as exc:
+        print_error(f"Invalid embedder settings: {exc}")
+        raise typer.Exit(code=1) from exc
+
+    print_info(f"Embedder: provider={settings.provider!r}, model={settings.model!r}")
+
+    try:
+        precompute_dir = build_retriever_index(
+            pipeline_id=pipeline_id,
+            embedder_settings=settings,
+            keyword=keyword,
+            include_events=include_events,
+            include_concept=include_concept,
+            rebuild=rebuild,
+        )
+    except FileNotFoundError as exc:
+        print_error(str(exc))
+        raise typer.Exit(code=1) from exc
+    except RuntimeError as exc:
+        print_error(str(exc))
+        raise typer.Exit(code=1) from exc
+    except ValueError as exc:
+        print_error(f"Invalid build configuration: {exc}")
+        raise typer.Exit(code=1) from exc
+
+    print_success(f"Retriever index ready at {precompute_dir}/")

--- a/src/arandu/kg/retriever_index.py
+++ b/src/arandu/kg/retriever_index.py
@@ -14,6 +14,7 @@ precompute lands on disk: ``results/<id>/kg/outputs/atlas_output/precompute/``.
 
 from __future__ import annotations
 
+import json
 from typing import TYPE_CHECKING
 
 from arandu.shared.config import ResultsConfig
@@ -26,6 +27,50 @@ from arandu.shared.rag.retrievers.atlas_rag import (
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+
+def _check_manifest_compatible(
+    manifest_path: Path,
+    *,
+    keyword: str,
+    include_events: bool,
+    include_concept: bool,
+    sentence_encoder_model: str,
+) -> None:
+    """Raise ValueError if the on-disk manifest disagrees with the requested params.
+
+    Without this check, a precompute built with one set of flags would be
+    silently reused when ``arandu kg-build-retriever-index`` is invoked
+    with different ones. ``AtlasRagRetriever.__init__`` would later catch
+    the mismatch, but the operator's mental model "I just rebuilt this"
+    would be wrong — surface it here instead, pointing them at ``--rebuild``.
+    """
+    try:
+        manifest = json.loads(manifest_path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(
+            f"Existing manifest at {manifest_path} is unreadable: {exc}. "
+            f"Pass --rebuild to regenerate."
+        ) from exc
+
+    mismatches: list[str] = []
+    for field, expected in (
+        ("keyword", keyword),
+        ("include_events", include_events),
+        ("include_concept", include_concept),
+        ("sentence_encoder_model", sentence_encoder_model),
+    ):
+        if manifest.get(field) != expected:
+            mismatches.append(
+                f"  {field}: manifest={manifest.get(field)!r}, requested={expected!r}"
+            )
+    if mismatches:
+        joined = "\n".join(mismatches)
+        raise ValueError(
+            f"Existing precompute at {manifest_path.parent}/ was built with different "
+            f"parameters than requested:\n{joined}\n"
+            f"Pass --rebuild to regenerate, or invoke with matching parameters."
+        )
 
 
 def build_retriever_index(
@@ -62,8 +107,12 @@ def build_retriever_index(
             :meth:`AtlasRagRetriever.build_index` defends that with a
             clearer error before invoking upstream.
         rebuild: If False (default), skip the build when a manifest already
-            exists at the target precompute path. If True, force a fresh
-            build (atlas-rag will overwrite the existing pickles).
+            exists at the target precompute path AND its recorded
+            parameters match the requested ones. If the existing manifest
+            disagrees with the request, raise :class:`ValueError` rather
+            than silently reusing an incompatible precompute. If True,
+            force a fresh build regardless (atlas-rag overwrites the
+            existing pickles).
 
     Returns:
         The precompute directory path (``.../atlas_output/precompute/``).
@@ -73,6 +122,10 @@ def build_retriever_index(
             for ``pipeline_id`` are missing.
         RuntimeError: From :func:`build_embedder` if a cloud embedder is
             requested without its API key env var set.
+        ValueError: If an existing manifest at the target path was built
+            with different ``keyword`` / ``include_events`` /
+            ``include_concept`` / ``sentence_encoder_model`` than
+            requested. Pass ``rebuild=True`` to regenerate.
     """
     base = base_dir if base_dir is not None else ResultsConfig().base_dir
     kg_outputs_dir = base / pipeline_id / "kg" / "outputs"
@@ -91,12 +144,24 @@ def build_retriever_index(
             f"before graphml emission."
         )
 
+    settings = embedder_settings if embedder_settings is not None else EmbedderSettings()
+
     precompute_dir = atlas_output_dir / PRECOMPUTE_DIR_NAME
     manifest_path = precompute_dir / MANIFEST_FILENAME
     if manifest_path.exists() and not rebuild:
+        # Validate the on-disk manifest matches what was requested. Silent
+        # reuse on mismatch would defer the error to retrieve-time when
+        # AtlasRagRetriever.__init__ runs its own validation — surface it
+        # now so the operator's "I just rebuilt this" mental model is right.
+        _check_manifest_compatible(
+            manifest_path,
+            keyword=keyword,
+            include_events=include_events,
+            include_concept=include_concept,
+            sentence_encoder_model=settings.model,
+        )
         return precompute_dir
 
-    settings = embedder_settings if embedder_settings is not None else EmbedderSettings()
     encoder = build_embedder(settings)
 
     AtlasRagRetriever.build_index(

--- a/src/arandu/kg/retriever_index.py
+++ b/src/arandu/kg/retriever_index.py
@@ -1,0 +1,110 @@
+"""Build the atlas-rag retriever's precomputed index for a given pipeline run.
+
+Thin domain-layer wrapper around :meth:`AtlasRagRetriever.build_index`. The
+heavy embedding work lives in atlas-rag's ``create_embeddings_and_index``;
+this module just resolves paths via ``ResultsConfig`` (matching
+:func:`arandu.kg.passage_offsets.link_passages`'s style) and dispatches.
+
+Lives next to ``passage_offsets.py`` rather than under
+``arandu.shared.rag.retrievers/`` because the precompute is intrinsic to
+the *KG* (depends on the graphml's sha), not to the benchmark run that
+consumes it. Co-locating with the KG-stage helpers matches where the
+precompute lands on disk: ``results/<id>/kg/outputs/atlas_output/precompute/``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from arandu.shared.config import ResultsConfig
+from arandu.shared.embeddings import EmbedderSettings, build_embedder
+from arandu.shared.rag.retrievers.atlas_rag import (
+    MANIFEST_FILENAME,
+    PRECOMPUTE_DIR_NAME,
+    AtlasRagRetriever,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def build_retriever_index(
+    pipeline_id: str,
+    *,
+    base_dir: Path | None = None,
+    embedder_settings: EmbedderSettings | None = None,
+    keyword: str = "transcriptions.json",
+    include_events: bool = True,
+    include_concept: bool = True,
+    rebuild: bool = False,
+) -> Path:
+    """Build (or refresh) the atlas-rag precompute for run ``pipeline_id``.
+
+    Resolves the KG output directory under ``<base_dir>/<pipeline_id>/kg/
+    outputs/atlas_output/``, then invokes
+    :meth:`AtlasRagRetriever.build_index` with an embedder built from
+    ``embedder_settings``.
+
+    Args:
+        pipeline_id: The run identifier. Inputs are resolved relative to
+            ``<base_dir>/<pipeline_id>/kg/outputs/atlas_output/``.
+        base_dir: Project ``results/`` root. Defaults to
+            ``ResultsConfig().base_dir``.
+        embedder_settings: Provider + model choice for the encoder.
+            Defaults to ``EmbedderSettings()`` (reads ``ARANDU_EMBEDDER_*``
+            env vars).
+        keyword: atlas-rag's filename pattern. Defaults to project
+            convention ``"transcriptions.json"``.
+        include_events: Whether to include event nodes in the embedded
+            node set. Defaults to True (matches project KG construction).
+        include_concept: Whether to include concept nodes. Defaults to
+            True. atlas-rag rejects the ``(False, True)`` combination;
+            :meth:`AtlasRagRetriever.build_index` defends that with a
+            clearer error before invoking upstream.
+        rebuild: If False (default), skip the build when a manifest already
+            exists at the target precompute path. If True, force a fresh
+            build (atlas-rag will overwrite the existing pickles).
+
+    Returns:
+        The precompute directory path (``.../atlas_output/precompute/``).
+
+    Raises:
+        FileNotFoundError: If the KG outputs or the atlas-rag GraphML
+            for ``pipeline_id`` are missing.
+        RuntimeError: From :func:`build_embedder` if a cloud embedder is
+            requested without its API key env var set.
+    """
+    base = base_dir if base_dir is not None else ResultsConfig().base_dir
+    kg_outputs_dir = base / pipeline_id / "kg" / "outputs"
+    atlas_output_dir = kg_outputs_dir / "atlas_output"
+    graphml_path = atlas_output_dir / "kg_graphml" / f"{keyword}_graph.graphml"
+
+    if not kg_outputs_dir.exists():
+        raise FileNotFoundError(
+            f"kg outputs not found for pipeline_id {pipeline_id!r}: {kg_outputs_dir}. "
+            f"Run `arandu build-kg --id {pipeline_id} ...` first."
+        )
+    if not graphml_path.exists():
+        raise FileNotFoundError(
+            f"atlas-rag GraphML not found for pipeline_id {pipeline_id!r}: {graphml_path}. "
+            f"The KG stage either used a non-atlas backend or was interrupted "
+            f"before graphml emission."
+        )
+
+    precompute_dir = atlas_output_dir / PRECOMPUTE_DIR_NAME
+    manifest_path = precompute_dir / MANIFEST_FILENAME
+    if manifest_path.exists() and not rebuild:
+        return precompute_dir
+
+    settings = embedder_settings if embedder_settings is not None else EmbedderSettings()
+    encoder = build_embedder(settings)
+
+    AtlasRagRetriever.build_index(
+        kg_outputs_dir=atlas_output_dir,
+        sentence_encoder=encoder,
+        sentence_encoder_model=settings.model,
+        keyword=keyword,
+        include_events=include_events,
+        include_concept=include_concept,
+    )
+    return precompute_dir

--- a/src/arandu/shared/embeddings/__init__.py
+++ b/src/arandu/shared/embeddings/__init__.py
@@ -1,0 +1,15 @@
+"""Embedding providers for atlas-rag retriever precompute (and beyond).
+
+Two providers ship today: Gemini (cloud, default for thesis runs) and
+sentence-transformers (local GPU, used on PCAD). See
+:mod:`arandu.shared.embeddings.factory` for the selection mechanism.
+"""
+
+from arandu.shared.embeddings.factory import (
+    EmbedderProvider,
+    EmbedderSettings,
+    build_embedder,
+)
+from arandu.shared.embeddings.gemini import GeminiEmbedder
+
+__all__ = ["EmbedderProvider", "EmbedderSettings", "GeminiEmbedder", "build_embedder"]

--- a/src/arandu/shared/embeddings/factory.py
+++ b/src/arandu/shared/embeddings/factory.py
@@ -43,6 +43,12 @@ class EmbedderSettings(BaseSettings):
         api_key_env: Name of the env var holding the Gemini API key.
             Defaults to ``GEMINI_API_KEY`` — matching the smoke script's
             convention. Ignored for sentence-transformers.
+        max_retries: ``openai.OpenAI(max_retries=...)`` value used for the
+            Gemini client. Default 8 because a 75k-embedding build (the
+            ``test-kg-04`` smoke) hits Gemini's 429s often enough that
+            the OpenAI SDK's default of 2 retries causes partial failures.
+            The smoke script ran clean with 8. Ignored for
+            sentence-transformers.
     """
 
     provider: EmbedderProvider = Field(
@@ -56,6 +62,14 @@ class EmbedderSettings(BaseSettings):
     api_key_env: str = Field(
         default="GEMINI_API_KEY",
         description="Env var name holding the Gemini API key (ignored for local providers).",
+    )
+    max_retries: int = Field(
+        default=8,
+        ge=0,
+        description=(
+            "OpenAI SDK max_retries for the Gemini client. Higher than the SDK "
+            "default (2) because large embedding builds hit 429s under quota."
+        ),
     )
 
     model_config = SettingsConfigDict(env_prefix="ARANDU_EMBEDDER_", extra="ignore")
@@ -95,7 +109,11 @@ def build_embedder(settings: EmbedderSettings) -> Any:
         # works in envs without `openai` installed.
         from openai import OpenAI
 
-        client = OpenAI(api_key=api_key, base_url=_GEMINI_OPENAI_BASE_URL)
+        client = OpenAI(
+            api_key=api_key,
+            base_url=_GEMINI_OPENAI_BASE_URL,
+            max_retries=settings.max_retries,
+        )
         return GeminiEmbedder(client=client, model=settings.model)
 
     if settings.provider == "sentence_transformers":

--- a/src/arandu/shared/embeddings/factory.py
+++ b/src/arandu/shared/embeddings/factory.py
@@ -1,0 +1,110 @@
+"""Embedder settings + factory dispatch.
+
+Two providers supported today:
+
+- ``gemini``: cloud, OpenAI-compatible endpoint, sized for thesis runs.
+  See :class:`arandu.shared.embeddings.gemini.GeminiEmbedder`.
+- ``sentence_transformers``: local, GPU-backed; used on PCAD / when
+  cloud quotas are tight. atlas-rag's
+  :class:`SentenceTransformerEmbeddingModel` is used as-is.
+
+The choice is exposed through :class:`EmbedderSettings` (env prefix
+``ARANDU_EMBEDDER_``) and resolved by :func:`build_embedder`.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Literal
+
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+from arandu.shared.embeddings.gemini import GeminiEmbedder
+
+EmbedderProvider = Literal["gemini", "sentence_transformers"]
+
+
+_GEMINI_OPENAI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai/"
+
+
+class EmbedderSettings(BaseSettings):
+    """Provider + model selection for atlas-rag's sentence encoder.
+
+    Attributes:
+        provider: Embedding backend. Defaults to ``"gemini"`` because the
+            thesis runs are cloud-driven; switch to
+            ``"sentence_transformers"`` for PCAD or other GPU-local paths.
+        model: Provider-specific model identifier. For Gemini, defaults to
+            ``"gemini-embedding-001"`` (the 004 series was removed by
+            Google in 2025-Q1). For sentence-transformers, any
+            ``sentence_transformers``-resolvable name works
+            (e.g. ``"intfloat/multilingual-e5-large-instruct"``).
+        api_key_env: Name of the env var holding the Gemini API key.
+            Defaults to ``GEMINI_API_KEY`` — matching the smoke script's
+            convention. Ignored for sentence-transformers.
+    """
+
+    provider: EmbedderProvider = Field(
+        default="gemini",
+        description="Embedding backend: 'gemini' (cloud) or 'sentence_transformers' (local).",
+    )
+    model: str = Field(
+        default="gemini-embedding-001",
+        description="Model identifier passed to the chosen provider.",
+    )
+    api_key_env: str = Field(
+        default="GEMINI_API_KEY",
+        description="Env var name holding the Gemini API key (ignored for local providers).",
+    )
+
+    model_config = SettingsConfigDict(env_prefix="ARANDU_EMBEDDER_", extra="ignore")
+
+
+def build_embedder(settings: EmbedderSettings) -> Any:
+    """Return a duck-typed embedder for the configured provider.
+
+    Both return types satisfy atlas-rag's encoder contract
+    (``encode(list[str], normalize_embeddings=bool) -> ndarray``); the
+    return is typed as ``Any`` because atlas-rag's
+    :class:`BaseEmbeddingModel` is a heavy class hierarchy we don't want
+    to import at module-load time.
+
+    Args:
+        settings: Resolved settings (typically built via
+            ``EmbedderSettings()`` so env vars are read).
+
+    Returns:
+        An embedder satisfying atlas-rag's encoder contract.
+
+    Raises:
+        RuntimeError: If ``provider`` is ``"gemini"`` and the API key
+            env var (default ``GEMINI_API_KEY``) is unset.
+        ValueError: If ``provider`` is not a recognized value (defensive;
+            ``EmbedderProvider`` is a Literal, but env-var paths can
+            still feed an arbitrary string).
+    """
+    if settings.provider == "gemini":
+        api_key = os.environ.get(settings.api_key_env)
+        if not api_key:
+            raise RuntimeError(
+                f"Gemini embedder requested but {settings.api_key_env} is unset. "
+                f"Set it or switch ARANDU_EMBEDDER_PROVIDER to 'sentence_transformers'."
+            )
+        # Import the OpenAI client lazily so the sentence-transformers path
+        # works in envs without `openai` installed.
+        from openai import OpenAI
+
+        client = OpenAI(api_key=api_key, base_url=_GEMINI_OPENAI_BASE_URL)
+        return GeminiEmbedder(client=client, model=settings.model)
+
+    if settings.provider == "sentence_transformers":
+        # Defer atlas-rag import; only the local-GPU path needs it.
+        from atlas_rag.vectorstore.embedding_model import SentenceTransformerEmbeddingModel
+
+        return SentenceTransformerEmbeddingModel(settings.model)
+
+    raise ValueError(
+        f"Unknown embedder provider {settings.provider!r}. "
+        f"Valid values: 'gemini', 'sentence_transformers'."
+    )

--- a/src/arandu/shared/embeddings/gemini.py
+++ b/src/arandu/shared/embeddings/gemini.py
@@ -1,0 +1,109 @@
+"""Gemini-backed embedder for atlas-rag's encoder interface.
+
+Promoted from ``scripts/test_atlas_rag_retriever.py`` after the smoke run
+on ``test-kg-04`` (2026-05-22) confirmed the throttling + batch shape
+hold up under a real KG build (~75k embeddings, ~5 min wall time, ~$0.05).
+
+atlas-rag's ``HippoRAGRetriever`` calls ``sentence_encoder.encode(batch,
+normalize_embeddings=bool)`` and nothing else from the encoder, so this
+adapter duck-types against atlas-rag's :class:`BaseEmbeddingModel`
+rather than subclassing it — avoids a hard import dependency on the
+atlas-rag class hierarchy at module-load time.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from openai import OpenAI
+
+
+# Gemini's BatchEmbedContentsRequest caps each call at 100 inputs. atlas-rag
+# hands us batches of up to 256, so we fan each call out into Gemini-sized
+# sub-requests.
+_GEMINI_BATCH_MAX = 100
+
+# Gemini's paid-tier embed quota is ~3000 RPM. 50ms between sub-requests
+# = 20 RPS = 1200 RPM, well under the ceiling with headroom for retries.
+_PACING_SLEEP_S = 0.05
+
+
+class GeminiEmbedder:
+    """Adapter exposing Gemini embeddings via atlas-rag's encoder interface.
+
+    Uses Gemini's OpenAI-compatible endpoint so the same ``OpenAI`` client
+    works for both LLM completions and embeddings — no new SDK in the
+    dependency tree.
+
+    Two layers of throttle handling for Gemini's quotas:
+
+    - **Batch size cap.** Gemini's BatchEmbedContentsRequest limits each call
+      to 100 inputs; atlas-rag hands us batches of 256. We fan each call out
+      into Gemini-sized sub-requests.
+    - **Per-minute pacing + retry.** Pacing constant (``_PACING_SLEEP_S``)
+      keeps RPS well under the 3000 RPM ceiling; the ``openai`` SDK's
+      built-in ``Retry-After`` honouring (via ``max_retries``) handles
+      stragglers.
+
+    Attributes:
+        model: The Gemini embedding model identifier (e.g.
+            ``"gemini-embedding-001"``).
+    """
+
+    def __init__(self, client: OpenAI, model: str) -> None:
+        """Construct from an existing OpenAI-shaped client + model id.
+
+        Args:
+            client: An ``openai.OpenAI`` instance pointed at Gemini's
+                ``/v1beta/openai/`` base URL.
+            model: Embedding model identifier (e.g. ``gemini-embedding-001``).
+                The 004 series was removed by Google in 2025-Q1; current code
+                uses 001 unless overridden.
+        """
+        self._client = client
+        self.model = model
+
+    def encode(
+        self,
+        sentences: list[str],
+        normalize_embeddings: bool = False,
+        **_kwargs: object,  # atlas-rag passes `query_type` etc.; ignore.
+    ) -> np.ndarray:
+        """Encode sentences into a 2D ``(batch, dim)`` numpy array.
+
+        atlas-rag's ``HippoRAGRetriever.query2edge`` calls
+        ``np.linalg.norm(query_emb, axis=1, keepdims=True)`` and
+        ``edge_embeddings @ query_emb[0].T``, both of which require a 2D
+        ndarray. ``list[ndarray]`` works for the build-time ``.extend()``
+        pattern but breaks query-time math — so we always return 2D.
+
+        Args:
+            sentences: Strings to embed.
+            normalize_embeddings: If true, L2-normalize each row of the
+                result (atlas-rag uses this for cosine similarity).
+            **_kwargs: Swallowed. atlas-rag's runtime path passes
+                ``query_type`` and possibly other forward-compatible
+                kwargs that aren't part of our minimal contract.
+
+        Returns:
+            A ``(len(sentences), embedding_dim)`` float32 ndarray. An
+            empty input returns a ``(0, 0)`` ndarray (atlas-rag's
+            callers handle the empty case via shape checks).
+        """
+        if not sentences:
+            return np.zeros((0, 0), dtype=np.float32)
+        vectors: list[np.ndarray] = []
+        for start in range(0, len(sentences), _GEMINI_BATCH_MAX):
+            sub = sentences[start : start + _GEMINI_BATCH_MAX]
+            resp = self._client.embeddings.create(model=self.model, input=sub)
+            vectors.extend(np.array(d.embedding, dtype=np.float32) for d in resp.data)
+            if start + _GEMINI_BATCH_MAX < len(sentences):
+                time.sleep(_PACING_SLEEP_S)
+        arr = np.stack(vectors).astype(np.float32)
+        if normalize_embeddings:
+            arr = arr / np.linalg.norm(arr, axis=1, keepdims=True)
+        return arr

--- a/tests/cli/test_kg_build_retriever_index_cli.py
+++ b/tests/cli/test_kg_build_retriever_index_cli.py
@@ -91,12 +91,19 @@ class TestKgBuildRetrieverIndexCli:
         results_base: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        # If precompute/manifest.json already exists, the helper returns
-        # early without calling atlas-rag's expensive build.
+        # If precompute/manifest.json already exists AND matches the
+        # requested params, the helper returns early without calling
+        # atlas-rag's expensive build.
         atlas_dir = _seed_atlas_kg(results_base)
         precompute = atlas_dir / "precompute"
         precompute.mkdir()
-        (precompute / "manifest.json").write_text(json.dumps({"sentinel": True}))
+        compatible_manifest = {
+            "keyword": "transcriptions.json",
+            "include_events": True,
+            "include_concept": True,
+            "sentence_encoder_model": "gemini-embedding-001",
+        }
+        (precompute / "manifest.json").write_text(json.dumps(compatible_manifest))
         monkeypatch.setenv("GEMINI_API_KEY", "test-key")
 
         with patch("arandu.kg.retriever_index.AtlasRagRetriever.build_index") as mock_build:
@@ -105,7 +112,39 @@ class TestKgBuildRetrieverIndexCli:
         assert result.exit_code == 0, result.output
         mock_build.assert_not_called()
         # Existing manifest is preserved untouched.
-        assert json.loads((precompute / "manifest.json").read_text()) == {"sentinel": True}
+        assert json.loads((precompute / "manifest.json").read_text()) == compatible_manifest
+
+    def test_existing_manifest_mismatch_raises_with_rebuild_hint(
+        self,
+        runner: CliRunner,
+        results_base: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Manifest was built with include_events=True but the user invokes
+        # with --no-include-events. Silent reuse would defer the error to
+        # retrieve-time; surface it here with a --rebuild hint.
+        atlas_dir = _seed_atlas_kg(results_base)
+        precompute = atlas_dir / "precompute"
+        precompute.mkdir()
+        stale_manifest = {
+            "keyword": "transcriptions.json",
+            "include_events": True,
+            "include_concept": True,
+            "sentence_encoder_model": "gemini-embedding-001",
+        }
+        (precompute / "manifest.json").write_text(json.dumps(stale_manifest))
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+
+        with patch("arandu.kg.retriever_index.AtlasRagRetriever.build_index") as mock_build:
+            result = runner.invoke(
+                app,
+                ["kg-build-retriever-index", "--id", "run_x", "--no-include-events"],
+            )
+
+        assert result.exit_code == 1
+        assert "include_events" in result.output
+        assert "--rebuild" in result.output
+        mock_build.assert_not_called()
 
     def test_rebuild_flag_forces_call_even_with_existing_manifest(
         self,

--- a/tests/cli/test_kg_build_retriever_index_cli.py
+++ b/tests/cli/test_kg_build_retriever_index_cli.py
@@ -1,0 +1,156 @@
+"""Tests for ``arandu kg-build-retriever-index`` CLI command.
+
+Locks the failure-mode surface (missing KG outputs, missing graphml,
+missing API key, skip-on-existing-manifest) without paying the
+embedding compute cost. The actual atlas-rag build is exercised by
+``scripts/test_atlas_rag_retriever.py`` against the real test-kg-04 KG.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+from typer.testing import CliRunner
+
+from arandu.cli.app import app
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def results_base(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    base = tmp_path / "results"
+    monkeypatch.setenv("ARANDU_RESULTS_BASE_DIR", str(base))
+    return base
+
+
+def _seed_atlas_kg(
+    base: Path, pipeline_id: str = "run_x", keyword: str = "transcriptions.json"
+) -> Path:
+    """Lay out a minimal ``results/<id>/kg/outputs/atlas_output/`` tree.
+
+    The graphml is a stub — atlas-rag's ``build_index`` is mocked away in
+    these tests, so the bytes never matter. Returns the path so tests can
+    optionally write more under it.
+    """
+    graphml_dir = base / pipeline_id / "kg" / "outputs" / "atlas_output" / "kg_graphml"
+    graphml_dir.mkdir(parents=True)
+    (graphml_dir / f"{keyword}_graph.graphml").write_bytes(b'<?xml version="1.0"?><graphml/>')
+    return base / pipeline_id / "kg" / "outputs" / "atlas_output"
+
+
+class TestKgBuildRetrieverIndexCli:
+    def test_missing_kg_outputs_fails_with_clear_error(
+        self, runner: CliRunner, results_base: Path
+    ) -> None:
+        # No `results/<id>/kg/outputs/` for the pipeline_id at all.
+        result = runner.invoke(app, ["kg-build-retriever-index", "--id", "nonexistent"])
+
+        assert result.exit_code == 1
+        assert "kg outputs not found" in result.output
+
+    def test_missing_graphml_fails_with_clear_error(
+        self, runner: CliRunner, results_base: Path
+    ) -> None:
+        # kg/outputs/ exists but the atlas-rag graphml does not — KG was
+        # built with a different backend or interrupted before emission.
+        (results_base / "run_x" / "kg" / "outputs").mkdir(parents=True)
+        result = runner.invoke(app, ["kg-build-retriever-index", "--id", "run_x"])
+
+        assert result.exit_code == 1
+        assert "GraphML not found" in result.output
+
+    def test_missing_gemini_api_key_fails_fast(
+        self,
+        runner: CliRunner,
+        results_base: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Gemini is the default provider; without GEMINI_API_KEY the build
+        # must refuse before invoking the (expensive) atlas-rag path.
+        _seed_atlas_kg(results_base)
+        monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+
+        result = runner.invoke(app, ["kg-build-retriever-index", "--id", "run_x"])
+
+        assert result.exit_code == 1
+        assert "GEMINI_API_KEY" in result.output
+
+    def test_existing_manifest_skipped_without_rebuild(
+        self,
+        runner: CliRunner,
+        results_base: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # If precompute/manifest.json already exists, the helper returns
+        # early without calling atlas-rag's expensive build.
+        atlas_dir = _seed_atlas_kg(results_base)
+        precompute = atlas_dir / "precompute"
+        precompute.mkdir()
+        (precompute / "manifest.json").write_text(json.dumps({"sentinel": True}))
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+
+        with patch("arandu.kg.retriever_index.AtlasRagRetriever.build_index") as mock_build:
+            result = runner.invoke(app, ["kg-build-retriever-index", "--id", "run_x"])
+
+        assert result.exit_code == 0, result.output
+        mock_build.assert_not_called()
+        # Existing manifest is preserved untouched.
+        assert json.loads((precompute / "manifest.json").read_text()) == {"sentinel": True}
+
+    def test_rebuild_flag_forces_call_even_with_existing_manifest(
+        self,
+        runner: CliRunner,
+        results_base: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        atlas_dir = _seed_atlas_kg(results_base)
+        precompute = atlas_dir / "precompute"
+        precompute.mkdir()
+        (precompute / "manifest.json").write_text(json.dumps({"sentinel": True}))
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+
+        with (
+            patch("arandu.kg.retriever_index.build_embedder") as mock_build_embedder,
+            patch("arandu.kg.retriever_index.AtlasRagRetriever.build_index") as mock_build,
+        ):
+            mock_build_embedder.return_value = object()
+            result = runner.invoke(app, ["kg-build-retriever-index", "--id", "run_x", "--rebuild"])
+
+        assert result.exit_code == 0, result.output
+        mock_build.assert_called_once()
+        _, kwargs = mock_build.call_args
+        assert kwargs["kg_outputs_dir"] == atlas_dir
+        assert kwargs["keyword"] == "transcriptions.json"
+        assert kwargs["include_events"] is True
+        assert kwargs["include_concept"] is True
+
+    def test_first_build_calls_atlas_rag(
+        self,
+        runner: CliRunner,
+        results_base: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # No precompute/manifest yet → must invoke the build path.
+        atlas_dir = _seed_atlas_kg(results_base)
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+
+        with (
+            patch("arandu.kg.retriever_index.build_embedder") as mock_build_embedder,
+            patch("arandu.kg.retriever_index.AtlasRagRetriever.build_index") as mock_build,
+        ):
+            mock_build_embedder.return_value = object()
+            result = runner.invoke(app, ["kg-build-retriever-index", "--id", "run_x"])
+
+        assert result.exit_code == 0, result.output
+        mock_build.assert_called_once()
+        assert atlas_dir == mock_build.call_args.kwargs["kg_outputs_dir"]

--- a/tests/shared/embeddings/test_factory.py
+++ b/tests/shared/embeddings/test_factory.py
@@ -1,0 +1,83 @@
+"""Tests for ``shared/embeddings/factory.py`` — settings + provider dispatch."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from arandu.shared.embeddings import EmbedderSettings, GeminiEmbedder, build_embedder
+
+
+class TestEmbedderSettings:
+    def test_defaults(self) -> None:
+        # Thesis runs are Gemini-driven by default. The 001 model is the
+        # one Google currently supports (004 was removed in 2025-Q1).
+        s = EmbedderSettings(_env_file=None)
+        assert s.provider == "gemini"
+        assert s.model == "gemini-embedding-001"
+        assert s.api_key_env == "GEMINI_API_KEY"
+
+    def test_provider_via_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ARANDU_EMBEDDER_PROVIDER", "sentence_transformers")
+        monkeypatch.setenv("ARANDU_EMBEDDER_MODEL", "intfloat/multilingual-e5-large-instruct")
+        s = EmbedderSettings()
+        assert s.provider == "sentence_transformers"
+        assert s.model == "intfloat/multilingual-e5-large-instruct"
+
+
+class TestBuildEmbedder:
+    def test_gemini_requires_api_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+        settings = EmbedderSettings(provider="gemini", model="m", api_key_env="GEMINI_API_KEY")
+
+        with pytest.raises(RuntimeError, match="GEMINI_API_KEY"):
+            build_embedder(settings)
+
+    def test_gemini_returns_gemini_embedder(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+        settings = EmbedderSettings(provider="gemini", model="gemini-embedding-001")
+
+        with patch("openai.OpenAI") as mock_openai:
+            embedder = build_embedder(settings)
+
+        assert isinstance(embedder, GeminiEmbedder)
+        assert embedder.model == "gemini-embedding-001"
+        # The OpenAI client must be pointed at Gemini's compatibility URL,
+        # not OpenAI proper. Locking the URL prevents accidental drift to
+        # the wrong backend.
+        mock_openai.assert_called_once()
+        _, kwargs = mock_openai.call_args
+        assert kwargs["api_key"] == "test-key"
+        assert "generativelanguage.googleapis.com" in kwargs["base_url"]
+
+    def test_sentence_transformers_dispatches_to_atlas_rag_model(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The atlas-rag SentenceTransformerEmbeddingModel constructor pulls
+        # weights; patch the class so the test stays import-only.
+        # Skip if atlas_rag isn't installed (CI runs without --extra kg).
+        pytest.importorskip("atlas_rag.vectorstore.embedding_model")
+        settings = EmbedderSettings(provider="sentence_transformers", model="some/local-model")
+
+        with patch(
+            "atlas_rag.vectorstore.embedding_model.SentenceTransformerEmbeddingModel"
+        ) as mock_cls:
+            mock_cls.return_value = "embedder-instance"
+            result = build_embedder(settings)
+
+        mock_cls.assert_called_once_with("some/local-model")
+        assert result == "embedder-instance"
+
+    def test_unknown_provider_raises_valueerror(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Defensive: provider is a Literal, but env-var-driven configs
+        # can still feed an arbitrary string into the field. Pydantic
+        # validation catches this at construction; our factory's else
+        # branch is a belt-and-braces guard.
+        settings = EmbedderSettings.model_construct(
+            provider="nonexistent",  # type: ignore[arg-type]
+            model="m",
+            api_key_env="GEMINI_API_KEY",
+        )
+        with pytest.raises(ValueError, match="Unknown embedder provider"):
+            build_embedder(settings)

--- a/tests/shared/embeddings/test_factory.py
+++ b/tests/shared/embeddings/test_factory.py
@@ -17,6 +17,9 @@ class TestEmbedderSettings:
         assert s.provider == "gemini"
         assert s.model == "gemini-embedding-001"
         assert s.api_key_env == "GEMINI_API_KEY"
+        # max_retries=8 is calibrated against the test-kg-04 smoke; the SDK
+        # default (2) is too low for 75k-embedding builds under Gemini's quota.
+        assert s.max_retries == 8
 
     def test_provider_via_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("ARANDU_EMBEDDER_PROVIDER", "sentence_transformers")
@@ -50,6 +53,19 @@ class TestBuildEmbedder:
         _, kwargs = mock_openai.call_args
         assert kwargs["api_key"] == "test-key"
         assert "generativelanguage.googleapis.com" in kwargs["base_url"]
+        # max_retries is forwarded so large embedding builds survive 429s
+        # under Gemini's quota (the SDK's default of 2 is too low for
+        # 75k-embedding runs — the smoke script uses 8).
+        assert kwargs["max_retries"] == 8
+
+    def test_max_retries_override_via_settings(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+        settings = EmbedderSettings(provider="gemini", model="m", max_retries=15)
+
+        with patch("openai.OpenAI") as mock_openai:
+            build_embedder(settings)
+
+        assert mock_openai.call_args.kwargs["max_retries"] == 15
 
     def test_sentence_transformers_dispatches_to_atlas_rag_model(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/shared/embeddings/test_gemini.py
+++ b/tests/shared/embeddings/test_gemini.py
@@ -1,0 +1,143 @@
+"""Tests for ``shared/embeddings/gemini.py`` — the Gemini-backed embedder.
+
+Locks the encoder contract atlas-rag's ``HippoRAGRetriever`` calls into:
+
+- ``encode(list[str], normalize_embeddings=bool) -> 2D ndarray``
+- Empty input → ``(0, 0)`` shape without making an API call
+- Batches over 100 inputs fan out into Gemini-sized sub-requests
+- Extra kwargs (``query_type=...``) are swallowed without error
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import numpy as np
+
+from arandu.shared.embeddings import GeminiEmbedder
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+
+def _fake_embedding_response(dim: int, count: int) -> object:
+    """Construct an object shaped like ``client.embeddings.create(...)``'s return.
+
+    The real ``CreateEmbeddingResponse`` exposes ``.data`` as a list of
+    ``Embedding`` objects, each carrying an ``.embedding`` list[float].
+    """
+
+    def make_emb(seed: int) -> object:
+        e = MagicMock()
+        # Deterministic vectors so tests can assert ordering downstream.
+        e.embedding = [float(seed + i * 0.001) for i in range(dim)]
+        return e
+
+    resp = MagicMock()
+    resp.data = [make_emb(seed=i) for i in range(count)]
+    return resp
+
+
+class TestGeminiEmbedderEncode:
+    """The minimal contract atlas-rag relies on."""
+
+    def test_empty_input_returns_zero_shape_without_calling_client(self) -> None:
+        # Empty sentence list must short-circuit; atlas-rag's callers do
+        # shape checks on the result, but we save a free API call regardless.
+        client = MagicMock()
+        embedder = GeminiEmbedder(client=client, model="gemini-embedding-001")
+
+        result = embedder.encode([])
+
+        assert result.shape == (0, 0)
+        assert result.dtype == np.float32
+        client.embeddings.create.assert_not_called()
+
+    def test_single_batch_returns_2d_ndarray(self) -> None:
+        # atlas-rag's query2edge calls `np.linalg.norm(query_emb, axis=1)`
+        # so we MUST return 2D, even when input is one sentence.
+        client = MagicMock()
+        client.embeddings.create.return_value = _fake_embedding_response(dim=4, count=1)
+        embedder = GeminiEmbedder(client=client, model="gemini-embedding-001")
+
+        result = embedder.encode(["one sentence"])
+
+        assert result.ndim == 2
+        assert result.shape == (1, 4)
+
+    def test_batch_chunking_fans_out_into_100_sized_subrequests(self) -> None:
+        # Gemini caps each call at 100 inputs; atlas-rag hands us 256.
+        # 250 inputs → 3 sub-requests (100 + 100 + 50).
+        client = MagicMock()
+        # Each call returns embeddings sized for what was passed in.
+        client.embeddings.create.side_effect = [
+            _fake_embedding_response(dim=4, count=100),
+            _fake_embedding_response(dim=4, count=100),
+            _fake_embedding_response(dim=4, count=50),
+        ]
+        embedder = GeminiEmbedder(client=client, model="gemini-embedding-001")
+
+        sentences = [f"sentence-{i}" for i in range(250)]
+        result = embedder.encode(sentences)
+
+        assert client.embeddings.create.call_count == 3
+        assert result.shape == (250, 4)
+
+    def test_normalize_embeddings_produces_unit_rows(self) -> None:
+        client = MagicMock()
+        client.embeddings.create.return_value = _fake_embedding_response(dim=8, count=3)
+        embedder = GeminiEmbedder(client=client, model="gemini-embedding-001")
+
+        result = embedder.encode(["a", "b", "c"], normalize_embeddings=True)
+
+        norms = np.linalg.norm(result, axis=1)
+        assert np.allclose(norms, 1.0, atol=1e-6)
+
+    def test_kwargs_are_swallowed(self) -> None:
+        # atlas-rag's runtime path passes `query_type="edge"` and possibly
+        # other forward-compatible kwargs; our encoder must accept them
+        # without erroring even though we don't act on them.
+        client = MagicMock()
+        client.embeddings.create.return_value = _fake_embedding_response(dim=4, count=1)
+        embedder = GeminiEmbedder(client=client, model="gemini-embedding-001")
+
+        result = embedder.encode(["q"], normalize_embeddings=False, query_type="edge")
+        assert result.shape == (1, 4)
+
+    def test_dtype_is_float32(self) -> None:
+        # atlas-rag's persisted pickles are float32; if we return float64
+        # the downstream dot-product math gets slower + the pickles inflate.
+        client = MagicMock()
+        client.embeddings.create.return_value = _fake_embedding_response(dim=4, count=2)
+        embedder = GeminiEmbedder(client=client, model="gemini-embedding-001")
+
+        result = embedder.encode(["a", "b"])
+        assert result.dtype == np.float32
+
+    def test_model_attribute_is_exposed(self) -> None:
+        # AtlasRagRetriever.build_index records `sentence_encoder_model` in
+        # the manifest; callers read `.model` (or pass it separately). The
+        # attribute is public.
+        embedder = GeminiEmbedder(client=MagicMock(), model="gemini-embedding-001")
+        assert embedder.model == "gemini-embedding-001"
+
+
+class TestGeminiEmbedderRequestShape:
+    """Wire-format expectations atlas-rag relies on."""
+
+    def test_passes_sentences_as_input_kwarg(self) -> None:
+        client = MagicMock()
+        client.embeddings.create.return_value = _fake_embedding_response(dim=4, count=2)
+        embedder = GeminiEmbedder(client=client, model="m")
+
+        embedder.encode(["alpha", "beta"])
+
+        client.embeddings.create.assert_called_once()
+        _, kwargs = client.embeddings.create.call_args
+        assert kwargs["model"] == "m"
+        assert _equal_lists(kwargs["input"], ["alpha", "beta"])
+
+
+def _equal_lists(a: Iterable[str], b: Iterable[str]) -> bool:
+    return list(a) == list(b)


### PR DESCRIPTION
## Summary

Phase C retrieve-cli prep. The atlas-rag arm needs a precomputed embeddings index (~5 min + ~\$0.05 of Gemini embeddings on \`test-kg-04\`). Splitting it out of \`arandu retrieve\` keeps the benchmark command from quietly becoming an LLM-spending action and matches where the precompute actually lives on disk (\`results/<id>/kg/outputs/atlas_output/precompute/\`).

This is the foundation PR for the upcoming \`arandu retrieve\` CLI; design captured at \`retrieve-cli-design.md\` (untracked working doc).

## Three pieces

### 1. \`arandu.shared.embeddings\` — new module

Promotes the \`GeminiEmbedder\` from \`scripts/test_atlas_rag_retriever.py\` into a proper home. Adds:

- \`GeminiEmbedder\`: duck-types against atlas-rag's encoder contract (\`encode(list[str], normalize_embeddings=bool) -> 2D ndarray\`), with Gemini's 100-input batch cap fanned out + 50ms pacing + OpenAI SDK's built-in \`Retry-After\` handling. Same code that ran 75k embeddings against test-kg-04 in ~5 min.
- \`EmbedderSettings(BaseSettings)\`: Pydantic settings, env prefix \`ARANDU_EMBEDDER_\`. Two providers: \`gemini\` (default) and \`sentence_transformers\` (local GPU for PCAD).
- \`build_embedder(settings)\`: factory dispatching to the right backend. Fails fast if Gemini provider is requested without \`GEMINI_API_KEY\`.

### 2. \`arandu.kg.retriever_index\` — new domain helper

Resolves \`kg_outputs_dir\` from a \`pipeline_id\` (mirrors \`link_passages\`), builds the embedder, and dispatches to the existing \`AtlasRagRetriever.build_index\` classmethod. Skips the build when an existing \`precompute/manifest.json\` is found unless \`rebuild=True\`.

### 3. \`arandu kg-build-retriever-index\` — new CLI command

```bash
ARANDU_EMBEDDER_PROVIDER=gemini \\
ARANDU_EMBEDDER_MODEL=gemini-embedding-001 \\
GEMINI_API_KEY=... \\
arandu kg-build-retriever-index --id my-run
```

Sits next to \`kg-link-passages\` in \`cli/kg.py\`, registered in \`cli/app.py\`. Failure modes (missing KG outputs, missing graphml, missing API key) surface cleanly before any compute starts.

## Why split out vs. inline in \`arandu retrieve\`

- **Cost separation**: \`arandu retrieve\` should be runnable cheaply with non-atlas arms (BM25, k-hop variants, null). Inlining the build path would either need to no-op on those arms (confusing UX) or run unnecessarily.
- **Cache semantics**: the precompute depends on the graphml's sha, not on the benchmark run. Building it under \`kg/\` rather than \`retrieve/\` makes the dependency explicit.
- **Operator ergonomics**: \`arandu retrieve\` becomes a fast, low-stakes command for the actual benchmark. The expensive setup is a separate, explicit step.

## Smoke-script cleanup

\`scripts/test_atlas_rag_retriever.py\` previously carried its own inline \`GeminiEmbedder\`. Now imports from the shared module — same behaviour, no duplication.

## Coverage

- **GeminiEmbedder** (8 tests): batch chunking (100-cap fan-out on 250 inputs → 3 sub-requests), 2D return shape, dtype=float32, L2 normalization, kwarg swallowing (\`query_type=...\`), wire-format (\`input\` kwarg + \`model\` kwarg), empty-input short-circuit (no API call).
- **Factory** (6 tests): default settings shape, env-var override, Gemini API-key requirement, Gemini wire URL (\`generativelanguage.googleapis.com\`), sentence-transformers dispatch (gracefully skipped under CI without \`--extra kg\`), unknown-provider \`ValueError\` guard.
- **CLI** (6 tests): missing KG outputs, missing graphml, missing API key, existing manifest is skipped without \`--rebuild\`, \`--rebuild\` forces the call, first build invokes \`AtlasRagRetriever.build_index\` with the right kwargs.

**1258 passed, 1 skipped** locally. \`ruff check\` + \`ruff format --check\` both clean.

## Test plan

- [ ] \`uv run pytest tests/shared/embeddings/ tests/cli/test_kg_build_retriever_index_cli.py\` — green (19 passed, 1 skipped)
- [ ] \`uv run pytest\` — full suite green
- [ ] \`uv run ruff check src/ tests/\` — clean
- [ ] \`uv run ruff format --check src/ tests/\` — clean
- [ ] CLI help renders: \`uv run arandu kg-build-retriever-index --help\`
- [ ] Smoke against test-kg-04 (manual, requires \`GEMINI_API_KEY\`): \`arandu kg-build-retriever-index --id test-kg-04\` skips when manifest exists; \`--rebuild\` triggers a fresh build