### PR TITLE
feat(rag): arandu retrieve — drive Phase C arms over a populated run

### DIFF
--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -148,7 +148,7 @@ Give every pipeline run a self-describing home on disk so different stages can c
 
 Every run is a directory under `results/`, named with the run's `pipeline_id` (an opaque ID; locally that is `YYYYMMDD_HHMMSS_local`, on SLURM it is `YYYYMMDD_HHMMSS_slurm_<partition>_<job_id>`). The `pipeline_id` is the run identifier — pipeline ID and run ID are the same value.
 
-Every stage of the run lives as a child subdirectory of the run dir, named after the stage (the value of its `PipelineType`: `transcription`, `cep`, `kg`, `qa`, `evaluation`, etc.). Each stage subdirectory has the same shape, regardless of which stage it is:
+Every stage of the run lives as a child subdirectory of the run dir, named after the stage (the value of its `PipelineType`: `transcription`, `cep`, `kg`, `qa`, `retrieve`, `evaluation`, etc.). Each stage subdirectory has the same shape, regardless of which stage it is:
 
 - A `<stage>_checkpoint.json` (or `checkpoint.json` for transcription, kept for historical reasons) — the `CheckpointManager` state file. This is what `mark_completed()` and `mark_failed()` write to; only its contents differ between stages, never its location.
 - A `run_metadata.json` — a `RunMetadata` snapshot capturing `started_at`, `ended_at`, `status` (`RunStatus`), the `ConfigSnapshot` of whatever `BaseSettings`/`BaseModel` the stage was given, the `HardwareInfo`, the `ExecutionEnvironment` (local vs SLURM, partition, job id), the arandu version, and progress counters (`completed_items`, `failed_items`, `total_items`).
@@ -167,7 +167,18 @@ The `results/` root itself carries a single aggregate file, `index.json`, which 
 
 ### Extensions
 
-Phase C (RAG evaluation) plugs new stages (`chunk`, `retrieval_indexes`, `retrieval`, `answers`, `judge_answers`, `analysis`) into this same shape under each `results/<run-id>/`. See `docs/superpowers/specs/2026-05-08-phase-c-rag-evaluation-design.md` §11 for the binding spec, in particular §11.0 which restates this convention for Phase C.
+Phase C (RAG evaluation) plugs new stages (`chunk`, `retrieve`, `answers`, `judge_answers`, `analysis`) into this same shape under each `results/<run-id>/`. See `docs/superpowers/specs/2026-05-08-phase-c-rag-evaluation-design.md` §11 for the binding spec, in particular §11.0 which restates this convention for Phase C.
+
+#### The `retrieve` stage
+
+`arandu retrieve --id <pipeline_id>` runs one or more retriever arms over a populated run and persists `RetrievalRecord` artifacts. The stage's footprint:
+
+- `results/<id>/retrieve/retrieve_checkpoint.json` — composite keys `"<arm>::<qa_pair_id>"` so resume works across arm sets (re-running the same `--id` with a subset of arms doesn't replay completed tuples).
+- `results/<id>/retrieve/run_metadata.json` — the standard `RunMetadata` snapshot, plus the `RetrieveBatchConfig` (arms, top_k, rebuild flag).
+- `results/<id>/retrieve/indexes/bm25_<chunker_id>/` — BM25's pickled index, built lazily on first use and reused across reruns. K-hop arms build their state in-memory from the KG graphml at construction time and have no on-disk index footprint.
+- `results/<id>/retrieve/outputs/<arm_id>/<source>/<safe_qa_pair_id>.json` — one `RetrievalRecord` per (arm, question) tuple. `<source>` is `cep` or `nonanswerable`. `<safe_qa_pair_id>` is the schema's `qa_pair_id` with `":"` replaced by `"__"` for cross-platform path safety; the `RetrievalRecord.qa_pair_id` field INSIDE the file preserves the original colons.
+
+Atlas-rag's precompute lives under `results/<id>/kg/outputs/atlas_output/precompute/`, NOT under `retrieve/indexes/`. Rationale: the precompute is intrinsic to the KG (depends on the graphml's sha256), not to the benchmark run that consumes it. `arandu kg-build-retriever-index` builds it; `arandu retrieve` only reads it.
 
 ---
 

--- a/src/arandu/cli/app.py
+++ b/src/arandu/cli/app.py
@@ -61,6 +61,7 @@ from arandu.cli.manage import (  # noqa: E402
 )
 from arandu.cli.qa import generate_cep_qa, judge_qa  # noqa: E402
 from arandu.cli.report import report, serve_report  # noqa: E402
+from arandu.cli.retrieve import retrieve  # noqa: E402
 from arandu.cli.transcribe import (  # noqa: E402
     batch_transcribe,
     drive_transcribe,
@@ -79,6 +80,7 @@ app.command()(judge_qa)
 app.command()(build_kg)
 app.command()(kg_link_passages)
 app.command()(kg_build_retriever_index)
+app.command()(retrieve)
 app.command()(replicate)
 app.command()(info)
 app.command()(list_runs)

--- a/src/arandu/cli/retrieve.py
+++ b/src/arandu/cli/retrieve.py
@@ -1,0 +1,122 @@
+"""CLI command: ``arandu retrieve`` — drive Phase C retriever arms over a run.
+
+Iterates a run's CEP QA + (when present) non-answerable items, runs
+retrieval per requested arm, and persists one :class:`RetrievalRecord`
+per (arm, question) tuple under
+``results/<id>/retrieve/outputs/<arm>/<source>/``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Annotated
+
+import typer
+
+from arandu.shared.rag.retrieve.batch import run_retrieve_batch
+from arandu.shared.rag.retrieve.settings import (
+    ALL_ARMS,
+    Bm25RetrieveSettings,
+    KHopRetrieveSettings,
+)
+from arandu.utils.logger import print_error, print_info, print_success, print_warning
+
+logger = logging.getLogger(__name__)
+
+
+# All ALL_ARMS members EXCEPT atlas_rag; atlas_rag joins the default set in a
+# follow-up PR once its LLM-client wiring lands.
+_DEFAULT_ARMS: tuple[str, ...] = tuple(a for a in ALL_ARMS if a != "atlas_rag")
+
+
+def retrieve(
+    pipeline_id: Annotated[
+        str,
+        typer.Option(
+            "--id",
+            help=(
+                "Pipeline ID for the run. The cep/ stage must already be populated; "
+                "each arm has its own prerequisites (chunk/ for bm25, kg/ for k-hop)."
+            ),
+        ),
+    ],
+    arms: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--arm",
+            help=(
+                "Retriever arm; repeatable. Known: "
+                + ", ".join(ALL_ARMS)
+                + f". Defaults to: {', '.join(_DEFAULT_ARMS)}. "
+                + "atlas_rag is currently disabled (LLM-client wiring deferred)."
+            ),
+        ),
+    ] = None,
+    top_k: Annotated[
+        int,
+        typer.Option(
+            "--top-k",
+            "-k",
+            help="Passages per question per arm.",
+            min=1,
+        ),
+    ] = 10,
+    rebuild_index: Annotated[
+        bool,
+        typer.Option(
+            "--rebuild-index",
+            help=(
+                "Force-rebuild arm-side indexes (BM25 pickle only; "
+                "k-hop arms build state in-memory at construction)."
+            ),
+        ),
+    ] = False,
+) -> None:
+    """Run Phase C retrievers over a populated run.
+
+    Reads QA pairs from ``results/<id>/cep/outputs/`` and (when present)
+    non-answerable items from ``results/<id>/nonanswerable/outputs/``;
+    emits one ``RetrievalRecord`` per (arm, question) tuple under
+    ``results/<id>/retrieve/outputs/<arm>/<source>/<qa_pair_id>.json``.
+
+    Arm-specific knobs (chunker view, k-hop radius, ...) are read from
+    ``ARANDU_BM25_*`` / ``ARANDU_KHOP_*`` env vars; see the per-arm
+    settings classes for the fields.
+    """
+    selected_arms = list(arms) if arms else list(_DEFAULT_ARMS)
+    bm25_settings = Bm25RetrieveSettings()
+    khop_settings = KHopRetrieveSettings()
+
+    print_info(f"Run: {pipeline_id}")
+    print_info(f"Arms: {', '.join(selected_arms)}")
+    if "bm25" in selected_arms:
+        print_info(f"BM25 chunker: {bm25_settings.chunker_id}")
+    if any(a.startswith("khop_") for a in selected_arms):
+        print_info(f"K-hop: k_hop={khop_settings.k_hop}, max_postings={khop_settings.max_postings}")
+
+    try:
+        result = run_retrieve_batch(
+            pipeline_id=pipeline_id,
+            arms=selected_arms,
+            top_k=top_k,
+            bm25_settings=bm25_settings,
+            khop_settings=khop_settings,
+            rebuild_index=rebuild_index,
+        )
+    except FileNotFoundError as exc:
+        print_error(str(exc))
+        raise typer.Exit(code=1) from exc
+    except ValueError as exc:
+        print_error(f"Invalid retrieve configuration: {exc}")
+        raise typer.Exit(code=1) from exc
+
+    if result.retrievals_failed:
+        print_warning(
+            f"Failed retrievals: {result.retrievals_failed} "
+            f"(check logs for per-(arm, qa_pair) errors)."
+        )
+    if result.retrievals_resumed:
+        print_info(f"Resumed: {result.retrievals_resumed} (arm, qa_pair) tuple(s).")
+    print_success(
+        f"Wrote {result.retrievals_written} RetrievalRecord(s) to {result.run_dir}/outputs/"
+    )

--- a/src/arandu/cli/retrieve.py
+++ b/src/arandu/cli/retrieve.py
@@ -30,6 +30,13 @@ _DEFAULT_ARMS: tuple[str, ...] = tuple(a for a in ALL_ARMS if a != "atlas_rag")
 
 
 def retrieve(
+    # `--id` is REQUIRED here (no default), unlike `arandu chunk` where it's
+    # optional + auto-generated. Rationale: retrieve consumes a populated run
+    # (cep/ + kg/ + chunk/ stages must already exist) and emits records that
+    # downstream judges join against the run id. An auto-generated id would
+    # silently create an empty `retrieve/` tree under a brand-new run dir
+    # — confusing operationally. Pinning to an explicit id forces the caller
+    # to point at the right upstream run.
     pipeline_id: Annotated[
         str,
         typer.Option(

--- a/src/arandu/cli/retrieve.py
+++ b/src/arandu/cli/retrieve.py
@@ -77,7 +77,13 @@ def retrieve(
     Reads QA pairs from ``results/<id>/cep/outputs/`` and (when present)
     non-answerable items from ``results/<id>/nonanswerable/outputs/``;
     emits one ``RetrievalRecord`` per (arm, question) tuple under
-    ``results/<id>/retrieve/outputs/<arm>/<source>/<qa_pair_id>.json``.
+    ``results/<id>/retrieve/outputs/<arm>/<source>/<safe_qa_pair_id>.json``.
+
+    The on-disk ``safe_qa_pair_id`` is the schema's ``qa_pair_id`` with
+    ``":"`` replaced by ``"__"`` for cross-platform path safety (the
+    composite carries ``"<file_id>:<chunk_id>:<idx>"``). The
+    ``RetrievalRecord.qa_pair_id`` field inside each file preserves the
+    original colons.
 
     Arm-specific knobs (chunker view, k-hop radius, ...) are read from
     ``ARANDU_BM25_*`` / ``ARANDU_KHOP_*`` env vars; see the per-arm

--- a/src/arandu/shared/rag/retrieve/__init__.py
+++ b/src/arandu/shared/rag/retrieve/__init__.py
@@ -13,6 +13,7 @@ Per-arm settings classes live in :mod:`arandu.shared.rag.retrieve.settings`
 and read ``ARANDU_*`` env vars via Pydantic Settings.
 """
 
+from arandu.shared.rag.retrieve.batch import run_retrieve_batch
 from arandu.shared.rag.retrieve.factory import build_retriever
 from arandu.shared.rag.retrieve.loader import QuestionRecord, load_questions
 from arandu.shared.rag.retrieve.settings import (
@@ -28,4 +29,5 @@ __all__ = [
     "QuestionRecord",
     "build_retriever",
     "load_questions",
+    "run_retrieve_batch",
 ]

--- a/src/arandu/shared/rag/retrieve/__init__.py
+++ b/src/arandu/shared/rag/retrieve/__init__.py
@@ -1,0 +1,31 @@
+"""``arandu retrieve`` machinery — settings, factory, loader, batch runner.
+
+This module is the bridge between a populated ``results/<id>/`` run and
+the per-arm :class:`Retriever` implementations. Public entry points:
+
+- :func:`run_retrieve_batch` — top-level driver invoked by the CLI.
+- :func:`build_retriever` — construct an arm-specific retriever from a
+  pipeline id + arm-specific settings.
+- :func:`load_questions` — iterate the run's QA + non-answerable items
+  (when present) as ``(source, qa_pair_id, question_text, is_answerable)``.
+
+Per-arm settings classes live in :mod:`arandu.shared.rag.retrieve.settings`
+and read ``ARANDU_*`` env vars via Pydantic Settings.
+"""
+
+from arandu.shared.rag.retrieve.factory import build_retriever
+from arandu.shared.rag.retrieve.loader import QuestionRecord, load_questions
+from arandu.shared.rag.retrieve.settings import (
+    ArmName,
+    Bm25RetrieveSettings,
+    KHopRetrieveSettings,
+)
+
+__all__ = [
+    "ArmName",
+    "Bm25RetrieveSettings",
+    "KHopRetrieveSettings",
+    "QuestionRecord",
+    "build_retriever",
+    "load_questions",
+]

--- a/src/arandu/shared/rag/retrieve/batch.py
+++ b/src/arandu/shared/rag/retrieve/batch.py
@@ -47,6 +47,7 @@ class RetrieveBatchConfig(BaseModel):
         arms: Ordered list of arm names this run targeted.
         top_k: Passages per question per arm.
         rebuild_index: Whether arm-side indexes were forcibly rebuilt.
+
     """
 
     pipeline_id: str
@@ -68,6 +69,7 @@ class RetrieveBatchResult(BaseModel):
             during retrieval. Failures are logged with full context;
             the run continues so a single bad arm doesn't kill the whole
             batch.
+
     """
 
     pipeline_id: str
@@ -115,6 +117,7 @@ def run_retrieve_batch(
             prerequisite) are missing for ``pipeline_id``.
         ValueError: If ``arms`` is empty or contains an unknown name,
             or ``top_k < 1``.
+
     """
     if not arms:
         raise ValueError("Must request at least one arm; got empty list.")
@@ -187,6 +190,13 @@ def run_retrieve_batch(
                     top_k=top_k,
                 )
             except Exception as exc:
+                # Deliberately broad: each Retriever implementation has its
+                # own failure surface (atlas-rag's PPR, BM25's tokenizer,
+                # NetworkX's graph ops, …). Catching narrowly would force
+                # this module to know each retriever's internals, breaking
+                # the Protocol abstraction. The per-(arm, qa_pair) isolation
+                # contract takes precedence — log + continue + mark failed
+                # so one bad question doesn't kill the rest of the batch.
                 logger.exception(
                     "Retrieval failed for arm=%s qa_pair_id=%s: %s",
                     arm,

--- a/src/arandu/shared/rag/retrieve/batch.py
+++ b/src/arandu/shared/rag/retrieve/batch.py
@@ -1,0 +1,293 @@
+"""Batch runner for ``arandu retrieve`` — driver invoked by the CLI.
+
+Iterates ``(arm, question)`` tuples, runs each retrieval, and persists
+one :class:`RetrievalRecord` per pair. Checkpoint keys are composite
+(``"<arm>::<qa_pair_id>"``) so resume works across arm sets.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, Field
+
+from arandu.shared.checkpoint import CheckpointManager
+from arandu.shared.config import ResultsConfig
+from arandu.shared.rag.retrieve.factory import build_retriever
+from arandu.shared.rag.retrieve.loader import load_questions
+from arandu.shared.rag.retrieve.settings import (
+    ALL_ARMS,
+    ArmName,
+    Bm25RetrieveSettings,
+    KHopRetrieveSettings,
+)
+from arandu.shared.rag.schemas import RetrievalRecord
+from arandu.shared.results_manager import ResultsManager
+from arandu.shared.schemas import PipelineType
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from arandu.shared.rag.protocol import Retriever
+    from arandu.shared.rag.retrieve.loader import QuestionRecord
+
+logger = logging.getLogger(__name__)
+
+
+CHECKPOINT_FILENAME = "retrieve_checkpoint.json"
+
+
+class RetrieveBatchConfig(BaseModel):
+    """Persisted run-metadata snapshot for the retrieve stage.
+
+    Attributes:
+        pipeline_id: The run identifier.
+        arms: Ordered list of arm names this run targeted.
+        top_k: Passages per question per arm.
+        rebuild_index: Whether arm-side indexes were forcibly rebuilt.
+    """
+
+    pipeline_id: str
+    arms: list[str]
+    top_k: int = Field(..., gt=0)
+    rebuild_index: bool = False
+
+
+class RetrieveBatchResult(BaseModel):
+    """Summary of a completed retrieve batch run.
+
+    Attributes:
+        pipeline_id: Resolved run identifier.
+        run_dir: Absolute path of ``results/<pipeline_id>/retrieve/``.
+        retrievals_written: Count of ``RetrievalRecord`` JSON files emitted.
+        retrievals_resumed: Count of (arm, qa_pair) tuples skipped because
+            the checkpoint already marked them completed.
+        retrievals_failed: Count of (arm, qa_pair) tuples that raised
+            during retrieval. Failures are logged with full context;
+            the run continues so a single bad arm doesn't kill the whole
+            batch.
+    """
+
+    pipeline_id: str
+    run_dir: str
+    retrievals_written: int = 0
+    retrievals_resumed: int = 0
+    retrievals_failed: int = 0
+
+
+def run_retrieve_batch(
+    pipeline_id: str,
+    arms: list[ArmName],
+    top_k: int,
+    *,
+    bm25_settings: Bm25RetrieveSettings | None = None,
+    khop_settings: KHopRetrieveSettings | None = None,
+    rebuild_index: bool = False,
+    base_dir: Path | None = None,
+) -> RetrieveBatchResult:
+    """Drive retrieval across one or more arms over a run's CEP + non-answerable items.
+
+    Args:
+        pipeline_id: Run identifier. The qa/cep stages must already be
+            populated; each arm has its own prerequisites (chunk for
+            bm25, kg for k-hop arms).
+        arms: Ordered list of arm names to run. Empty list raises
+            ``ValueError``.
+        top_k: Passages per question per arm. Must be ``>= 1``; arms
+            internally handle ``top_k=0`` defensively but the batch
+            runner rejects that input upfront because a zero-result
+            benchmark is almost certainly a misconfiguration.
+        bm25_settings: BM25 arm settings (chunker view). Defaults
+            instantiated from env when omitted.
+        khop_settings: K-hop arm settings (k_hop, max_postings, keyword).
+            Defaults instantiated from env when omitted.
+        rebuild_index: Force arm-side index rebuilds where supported
+            (BM25 only; k-hop arms build state in-memory).
+        base_dir: Override the project ``results/`` root.
+
+    Returns:
+        Summary counts via :class:`RetrieveBatchResult`.
+
+    Raises:
+        FileNotFoundError: If the CEP outputs (or any arm-specific
+            prerequisite) are missing for ``pipeline_id``.
+        ValueError: If ``arms`` is empty or contains an unknown name,
+            or ``top_k < 1``.
+    """
+    if not arms:
+        raise ValueError("Must request at least one arm; got empty list.")
+    if top_k < 1:
+        raise ValueError(f"top_k must be >= 1, got {top_k}.")
+    unknown = [a for a in arms if a not in ALL_ARMS]
+    if unknown:
+        raise ValueError(f"Unknown arm(s) {unknown!r}. Valid arms: {list(ALL_ARMS)}.")
+
+    base = base_dir if base_dir is not None else ResultsConfig().base_dir
+    cep_dir = base / pipeline_id / "cep" / "outputs"
+    nonanswerable_dir = base / pipeline_id / "nonanswerable" / "outputs"
+
+    questions = load_questions(cep_dir, nonanswerable_dir)
+    if not questions:
+        logger.warning(
+            "No questions found for pipeline %s (CEP dir empty). Returning empty result.",
+            pipeline_id,
+        )
+
+    config = RetrieveBatchConfig(
+        pipeline_id=pipeline_id,
+        arms=list(arms),
+        top_k=top_k,
+        rebuild_index=rebuild_index,
+    )
+    results_mgr = ResultsManager(
+        base,
+        PipelineType.RETRIEVE,
+        pipeline_id=pipeline_id,
+    )
+    results_mgr.create_run(
+        config,
+        input_source=str(cep_dir),
+        checkpoint_filename=CHECKPOINT_FILENAME,
+    )
+    checkpoint = CheckpointManager(results_mgr.run_dir / CHECKPOINT_FILENAME)
+
+    total_units = len(questions) * len(arms)
+    checkpoint.set_total_files(total_units)
+
+    written = 0
+    resumed = 0
+    failed = 0
+    for arm in arms:
+        retriever = _build_with_logging(
+            arm=arm,
+            pipeline_id=pipeline_id,
+            bm25_settings=bm25_settings,
+            khop_settings=khop_settings,
+            base_dir=base,
+            rebuild_index=rebuild_index,
+        )
+        if retriever is None:
+            # Arm-build failure already logged; skip every question for it.
+            failed += len(questions)
+            continue
+
+        for question in questions:
+            ckpt_key = _checkpoint_key(arm, question.qa_pair_id)
+            if checkpoint.is_completed(ckpt_key):
+                resumed += 1
+                continue
+
+            try:
+                record = _retrieve_one(
+                    retriever=retriever,
+                    arm=arm,
+                    question=question,
+                    top_k=top_k,
+                )
+            except Exception as exc:
+                logger.exception(
+                    "Retrieval failed for arm=%s qa_pair_id=%s: %s",
+                    arm,
+                    question.qa_pair_id,
+                    exc,
+                )
+                checkpoint.mark_failed(ckpt_key, str(exc))
+                failed += 1
+                continue
+
+            output_path = _output_path(
+                outputs_dir=results_mgr.outputs_dir,
+                arm=arm,
+                source=question.source,
+                qa_pair_id=question.qa_pair_id,
+            )
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            record.save(output_path)
+            checkpoint.mark_completed(ckpt_key)
+            written += 1
+
+    results_mgr.update_progress(written + resumed, failed, total_units)
+    results_mgr.complete_run(success=(failed == 0))
+
+    return RetrieveBatchResult(
+        pipeline_id=results_mgr.metadata.pipeline_id,
+        run_dir=str(results_mgr.run_dir),
+        retrievals_written=written,
+        retrievals_resumed=resumed,
+        retrievals_failed=failed,
+    )
+
+
+def _build_with_logging(
+    *,
+    arm: ArmName,
+    pipeline_id: str,
+    bm25_settings: Bm25RetrieveSettings | None,
+    khop_settings: KHopRetrieveSettings | None,
+    base_dir: Path,
+    rebuild_index: bool,
+) -> Retriever | None:
+    """Construct a retriever for ``arm``; log + return ``None`` on failure.
+
+    Per-arm build failures (missing index, missing KG outputs, ...) are
+    logged with full context. Returning ``None`` lets the batch runner
+    continue with the next arm rather than aborting the whole run.
+    """
+    settings: Bm25RetrieveSettings | KHopRetrieveSettings | None = None
+    if arm == "bm25":
+        settings = bm25_settings
+    elif arm in ("khop_passage", "khop_triple"):
+        settings = khop_settings
+
+    try:
+        return build_retriever(
+            arm,
+            pipeline_id=pipeline_id,
+            settings=settings,
+            base_dir=base_dir,
+            rebuild_index=rebuild_index,
+        )
+    except (FileNotFoundError, ValueError) as exc:
+        logger.error("Failed to build %s arm for pipeline %s: %s", arm, pipeline_id, exc)
+        return None
+
+
+def _retrieve_one(
+    *,
+    retriever: Retriever,
+    arm: ArmName,
+    question: QuestionRecord,
+    top_k: int,
+) -> RetrievalRecord:
+    """Run one retrieval call and wrap the result as a :class:`RetrievalRecord`."""
+    t0 = time.perf_counter()
+    passages = retriever.retrieve(question.question, top_k=top_k)
+    elapsed_ms = (time.perf_counter() - t0) * 1000.0
+    return RetrievalRecord(
+        qa_pair_id=question.qa_pair_id,
+        question=question.question,
+        retriever_id=retriever.retriever_id,
+        chunker_id=question.chunker_id,
+        top_k=top_k,
+        passages=passages,
+        elapsed_ms=elapsed_ms,
+        is_answerable=question.is_answerable,
+    )
+
+
+def _checkpoint_key(arm: ArmName, qa_pair_id: str) -> str:
+    """Composite checkpoint key for the (arm, qa_pair) work unit."""
+    return f"{arm}::{qa_pair_id}"
+
+
+def _output_path(*, outputs_dir: Path, arm: ArmName, source: str, qa_pair_id: str) -> Path:
+    """Resolve the on-disk path for one retrieval record.
+
+    Layout: ``<outputs_dir>/<arm>/<source>/<sanitized_qa_pair_id>.json``.
+    ``qa_pair_id`` carries ``:`` and possibly other path-unfriendly chars
+    (``"<file_id>:<chunk_id>:<idx>"``); sanitize for cross-platform safety.
+    """
+    safe_id = qa_pair_id.replace(":", "__").replace("/", "_")
+    return outputs_dir / arm / source / f"{safe_id}.json"

--- a/src/arandu/shared/rag/retrieve/factory.py
+++ b/src/arandu/shared/rag/retrieve/factory.py
@@ -1,0 +1,207 @@
+"""Construct retriever instances from a pipeline id + arm-specific settings.
+
+The CLI passes a flat ``(arm, pipeline_id, settings, rebuild_index)`` to
+:func:`build_retriever`; this module hides the per-arm wiring (chunk
+loading + BM25 index build, KG path resolution, …).
+
+Atlas-rag arm dispatch is intentionally **not** wired here — that arm
+needs an LLM client + sentence encoder at retrieve time and is the
+subject of a follow-up PR. Requesting it now raises ``ValueError``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from arandu.shared.chunking.resolver import ChunkResolver
+from arandu.shared.chunking.schemas import Chunk, ChunkSet
+from arandu.shared.config import ResultsConfig
+from arandu.shared.rag.retrieve.settings import (
+    Bm25RetrieveSettings,
+    KHopRetrieveSettings,
+)
+from arandu.shared.rag.retrievers.bm25 import BM25Retriever
+from arandu.shared.rag.retrievers.khop_subgraph import KHopSubgraphRetriever
+from arandu.shared.rag.retrievers.khop_triple import KHopTripleRetriever
+from arandu.shared.rag.retrievers.null import NullRetriever
+from arandu.shared.schemas import EnrichedRecord
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from arandu.shared.rag.protocol import Retriever
+    from arandu.shared.rag.retrieve.settings import ArmName
+
+logger = logging.getLogger(__name__)
+
+
+_BM25_INDEX_FILENAME = "bm25.pkl"
+
+
+def build_retriever(
+    arm: ArmName,
+    *,
+    pipeline_id: str,
+    settings: Bm25RetrieveSettings | KHopRetrieveSettings | None = None,
+    base_dir: Path | None = None,
+    rebuild_index: bool = False,
+) -> Retriever:
+    """Construct the retriever for ``arm`` against ``pipeline_id``'s artifacts.
+
+    Args:
+        arm: One of ``"bm25"``, ``"khop_passage"``, ``"khop_triple"``,
+            ``"null"``. ``"atlas_rag"`` raises ``ValueError`` (deferred
+            to a follow-up PR).
+        pipeline_id: The run identifier; all paths resolve relative to
+            ``<base_dir>/<pipeline_id>/``.
+        settings: Arm-specific settings instance. For ``null``, ignored.
+            For ``bm25``, must be :class:`Bm25RetrieveSettings`; for
+            k-hop arms, :class:`KHopRetrieveSettings`. Defaults are
+            instantiated when omitted.
+        base_dir: Project ``results/`` root. Defaults to
+            ``ResultsConfig().base_dir``.
+        rebuild_index: Force-rebuild arm-side indexes (BM25 pickle only;
+            no-op for k-hop and null, which build their state in-memory
+            from the KG/graphml at construction).
+
+    Returns:
+        A retriever instance satisfying :class:`Retriever`.
+
+    Raises:
+        FileNotFoundError: If required artifacts (chunks, KG outputs)
+            are missing for ``pipeline_id``.
+        ValueError: For ``arm="atlas_rag"`` (not yet wired) or unknown
+            arm names.
+    """
+    base = base_dir if base_dir is not None else ResultsConfig().base_dir
+
+    if arm == "null":
+        return NullRetriever()
+
+    if arm == "bm25":
+        bm25_settings = (
+            settings if isinstance(settings, Bm25RetrieveSettings) else Bm25RetrieveSettings()
+        )
+        return _build_bm25(
+            pipeline_id=pipeline_id,
+            base_dir=base,
+            chunker_id=bm25_settings.chunker_id,
+            rebuild_index=rebuild_index,
+        )
+
+    if arm in ("khop_passage", "khop_triple"):
+        khop_settings = (
+            settings if isinstance(settings, KHopRetrieveSettings) else KHopRetrieveSettings()
+        )
+        kg_outputs_dir = base / pipeline_id / "kg" / "outputs" / "atlas_output"
+        if not kg_outputs_dir.exists():
+            raise FileNotFoundError(
+                f"atlas-rag KG outputs not found for pipeline_id {pipeline_id!r}: "
+                f"{kg_outputs_dir}. Run `arandu build-kg --id {pipeline_id}` first."
+            )
+        retriever_cls = KHopSubgraphRetriever if arm == "khop_passage" else KHopTripleRetriever
+        return retriever_cls(
+            kg_outputs_dir=kg_outputs_dir,
+            keyword=khop_settings.keyword,
+            k_hop=khop_settings.k_hop,
+            max_postings=khop_settings.max_postings,
+        )
+
+    if arm == "atlas_rag":
+        raise ValueError(
+            "atlas_rag arm is not wired in this PR. It requires an LLM client + "
+            "sentence encoder at retrieve time, which depends on a Phase C task "
+            "still in flight. Pass --arm bm25/khop_passage/khop_triple/null instead."
+        )
+
+    raise ValueError(f"Unknown arm {arm!r}.")
+
+
+def _build_bm25(
+    *,
+    pipeline_id: str,
+    base_dir: Path,
+    chunker_id: str,
+    rebuild_index: bool,
+) -> BM25Retriever:
+    """Load (or build) the BM25 index for ``chunker_id`` and return the retriever.
+
+    The pickle lives under
+    ``<base_dir>/<pipeline_id>/retrieve/indexes/bm25_<chunker_id>/`` —
+    co-located with the retrieve stage's outputs so the index follows
+    the same run-id lifecycle as the rest of the benchmark artifacts.
+    """
+    chunk_dir = base_dir / pipeline_id / "chunk" / "outputs" / chunker_id
+    if not chunk_dir.exists():
+        raise FileNotFoundError(
+            f"Chunks not found for chunker_id {chunker_id!r} under {chunk_dir}. "
+            f"Run `arandu chunk --id {pipeline_id} --view {chunker_id}` first."
+        )
+
+    index_dir = base_dir / pipeline_id / "retrieve" / "indexes" / f"bm25_{chunker_id}"
+    if rebuild_index or not (index_dir / _BM25_INDEX_FILENAME).exists():
+        chunks = _load_chunks(chunk_dir, chunker_id)
+        if not chunks:
+            raise FileNotFoundError(
+                f"No chunks found in {chunk_dir} for chunker_id {chunker_id!r}. "
+                f"The chunking stage produced no output for this view."
+            )
+        resolver = _build_chunk_resolver(pipeline_id=pipeline_id, base_dir=base_dir)
+        BM25Retriever.build_index(
+            chunks=chunks,
+            resolver=resolver,
+            index_dir=index_dir,
+            chunker_id=chunker_id,
+        )
+
+    return BM25Retriever(index_dir=index_dir, chunker_id=chunker_id)
+
+
+def _load_chunks(chunk_dir: Path, chunker_id: str) -> list[Chunk]:
+    """Flatten every ``ChunkSet`` under ``chunk_dir`` into a single chunk list.
+
+    Each on-disk file is a single-view ``ChunkSet`` (per the chunking
+    batch convention in PR #99: one file per (chunker, source) pair).
+    """
+    chunks: list[Chunk] = []
+    for path in sorted(chunk_dir.glob("*.json")):
+        try:
+            chunk_set = ChunkSet.model_validate_json(path.read_text(encoding="utf-8"))
+        except Exception as exc:
+            logger.warning("Skipping unreadable ChunkSet %s: %s", path, exc)
+            continue
+        if chunker_id not in chunk_set.views:
+            logger.warning(
+                "ChunkSet %s has no view %r (has: %s); skipping.",
+                path,
+                chunker_id,
+                sorted(chunk_set.views),
+            )
+            continue
+        chunks.extend(chunk_set.views[chunker_id])
+    return chunks
+
+
+def _build_chunk_resolver(*, pipeline_id: str, base_dir: Path) -> ChunkResolver:
+    """Construct a :class:`ChunkResolver` reading source text from this run.
+
+    Source text lives at ``<base_dir>/<pipeline_id>/transcription/outputs/
+    <file_id>.json`` as an :class:`EnrichedRecord`. The loader reads it
+    lazily; ``ChunkResolver`` caches loaded texts in its LRU.
+    """
+    transcription_dir = base_dir / pipeline_id / "transcription" / "outputs"
+    if not transcription_dir.exists():
+        raise FileNotFoundError(
+            f"Transcription outputs not found at {transcription_dir}. "
+            f"BM25 index building needs source text to resolve chunks."
+        )
+
+    def _load_text(file_id: str) -> str:
+        path = transcription_dir / f"{file_id}.json"
+        if not path.exists():
+            raise FileNotFoundError(f"Transcription not found for file_id {file_id!r}: {path}")
+        record = EnrichedRecord.model_validate_json(path.read_text(encoding="utf-8"))
+        return record.transcription_text
+
+    return ChunkResolver(text_loader=_load_text)

--- a/src/arandu/shared/rag/retrieve/factory.py
+++ b/src/arandu/shared/rag/retrieve/factory.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
+from pydantic import ValidationError
+
 from arandu.shared.chunking.resolver import ChunkResolver
 from arandu.shared.chunking.schemas import Chunk, ChunkSet
 from arandu.shared.config import ResultsConfig
@@ -73,6 +75,7 @@ def build_retriever(
             are missing for ``pipeline_id``.
         ValueError: For ``arm="atlas_rag"`` (not yet wired) or unknown
             arm names.
+
     """
     base = base_dir if base_dir is not None else ResultsConfig().base_dir
 
@@ -168,7 +171,7 @@ def _load_chunks(chunk_dir: Path, chunker_id: str) -> list[Chunk]:
     for path in sorted(chunk_dir.glob("*.json")):
         try:
             chunk_set = ChunkSet.model_validate_json(path.read_text(encoding="utf-8"))
-        except Exception as exc:
+        except (OSError, ValidationError) as exc:
             logger.warning("Skipping unreadable ChunkSet %s: %s", path, exc)
             continue
         if chunker_id not in chunk_set.views:

--- a/src/arandu/shared/rag/retrieve/loader.py
+++ b/src/arandu/shared/rag/retrieve/loader.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import AliasChoices, BaseModel, Field, ValidationError
 
 from arandu.qa.schemas import QARecordCEP
 
@@ -30,6 +30,40 @@ logger = logging.getLogger(__name__)
 
 
 QuestionSource = Literal["cep", "nonanswerable"]
+
+
+class _NonAnswerableItem(BaseModel):
+    """Provisional schema for one non-answerable item.
+
+    Mirrors the spec §10.3 description of ``NonAnswerableItem`` shape
+    until the producer (``arandu generate-non-answerable``, still in
+    flight) lands and pins the canonical schema. When that producer
+    ships, this stub gets deleted in favour of the real model.
+
+    Accepts the spec field names plus a few likely aliases via
+    :class:`AliasChoices` so we don't have to second-guess the producer's
+    eventual field naming. Each ``AliasChoices`` tries its options in
+    order; first hit wins.
+    """
+
+    model_config = {"extra": "ignore"}
+
+    qa_pair_id: str = Field(..., validation_alias=AliasChoices("qa_pair_id", "id"), min_length=1)
+    question: str = Field(..., min_length=1)
+    source_file_id: str = Field(
+        ...,
+        validation_alias=AliasChoices("source_file_id", "source_gdrive_id"),
+        min_length=1,
+    )
+    chunker_id: str = Field(default="unknown")
+
+
+class _NonAnswerableBatch(BaseModel):
+    """File-level wrapper around a list of :class:`_NonAnswerableItem`."""
+
+    model_config = {"extra": "ignore"}
+
+    items: list[_NonAnswerableItem] = Field(default_factory=list)
 
 
 class QuestionRecord(BaseModel):
@@ -51,6 +85,7 @@ class QuestionRecord(BaseModel):
             generation). The retrieve stage records this on each
             :class:`RetrievalRecord` to preserve the chunker → retriever
             provenance.
+
     """
 
     qa_pair_id: str = Field(..., min_length=1)
@@ -79,6 +114,7 @@ def load_questions(cep_dir: Path, nonanswerable_dir: Path | None = None) -> list
 
     Raises:
         FileNotFoundError: If ``cep_dir`` does not exist.
+
     """
     if not cep_dir.exists():
         raise FileNotFoundError(
@@ -108,7 +144,7 @@ def _iter_cep_questions(cep_dir: Path) -> Iterator[QuestionRecord]:
     for path in sorted(cep_dir.glob("*.json")):
         try:
             record = QARecordCEP.model_validate_json(path.read_text(encoding="utf-8"))
-        except Exception as exc:
+        except (OSError, ValidationError) as exc:
             logger.warning("Skipping unreadable CEP file %s: %s", path, exc)
             continue
         for idx, pair in enumerate(record.qa_pairs):
@@ -126,33 +162,24 @@ def _iter_cep_questions(cep_dir: Path) -> Iterator[QuestionRecord]:
 def _iter_nonanswerable_questions(nonanswerable_dir: Path) -> Iterator[QuestionRecord]:
     """Yield non-answerable items as :class:`QuestionRecord`.
 
-    Defensive shape: the non-answerable stage doesn't exist on disk yet,
-    so the schema we load against is the spec-described one but read
-    permissively (skip unrecognized files). Once
-    ``arandu generate-non-answerable`` lands and pins the schema, this
-    helper can tighten.
+    Files are parsed as :class:`_NonAnswerableBatch`. Items missing
+    required fields (qa_pair_id, question, source_file_id) are dropped
+    by Pydantic validation rather than silently skipped with manual
+    ``.get()`` calls — the validation error is logged at file scope so
+    operators can spot malformed inputs.
     """
-    import json
-
     for path in sorted(nonanswerable_dir.glob("*.json")):
         try:
-            payload = json.loads(path.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError) as exc:
+            batch = _NonAnswerableBatch.model_validate_json(path.read_text(encoding="utf-8"))
+        except (OSError, ValidationError) as exc:
             logger.warning("Skipping unreadable non-answerable file %s: %s", path, exc)
             continue
-        for item in payload.get("items", []):
-            qa_pair_id = item.get("qa_pair_id") or item.get("id")
-            question = item.get("question")
-            source_file_id = item.get("source_file_id") or item.get("source_gdrive_id")
-            chunker_id = item.get("chunker_id", "unknown")
-            if not (qa_pair_id and question and source_file_id):
-                logger.debug("Skipping incomplete non-answerable item in %s", path)
-                continue
+        for item in batch.items:
             yield QuestionRecord(
-                qa_pair_id=qa_pair_id,
-                question=question,
+                qa_pair_id=item.qa_pair_id,
+                question=item.question,
                 is_answerable=False,
                 source="nonanswerable",
-                source_file_id=source_file_id,
-                chunker_id=chunker_id,
+                source_file_id=item.source_file_id,
+                chunker_id=item.chunker_id,
             )

--- a/src/arandu/shared/rag/retrieve/loader.py
+++ b/src/arandu/shared/rag/retrieve/loader.py
@@ -1,0 +1,158 @@
+"""Load CEP QA + (when present) non-answerable items as a uniform question stream.
+
+The retrieve stage iterates two source datasets:
+
+- **CEP QA**: per-source ``QARecordCEP`` files at ``results/<id>/cep/outputs/*.json``.
+  Each record holds many :class:`QAPairCEP` items; we iterate them.
+- **Non-answerable** (optional, when the ``nonanswerable`` stage has
+  populated): at ``results/<id>/nonanswerable/outputs/`` — silently
+  skipped when absent (that stage is still in development).
+
+Both produce :class:`QuestionRecord` rows, distinguished by ``source``
+(``"cep"`` or ``"nonanswerable"``). The retrieve batch runner emits
+outputs into separate subdirectories per the spec §10.4 amendment.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Literal
+
+from pydantic import BaseModel, Field
+
+from arandu.qa.schemas import QARecordCEP
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+QuestionSource = Literal["cep", "nonanswerable"]
+
+
+class QuestionRecord(BaseModel):
+    """One question to retrieve against, normalized across source types.
+
+    Attributes:
+        qa_pair_id: Composite identifier per :class:`RetrievalRecord`'s
+            contract (``"<file_id>:<chunk_id>:<idx>"``). Unique within a run.
+        question: Verbatim question text to feed the retriever.
+        is_answerable: Mirrored from the source item. CEP pairs are
+            answerable by construction; non-answerable items are not.
+        source: ``"cep"`` or ``"nonanswerable"`` — drives the output
+            subdirectory under ``retrieve/outputs/<arm_id>/``.
+        source_file_id: The source media file id the item is associated with.
+            Useful for downstream grouping but not used by the retriever
+            itself.
+        chunker_id: Chunker view recorded on the source item (CEP records
+            track which view was used to slice the transcription for QA
+            generation). The retrieve stage records this on each
+            :class:`RetrievalRecord` to preserve the chunker → retriever
+            provenance.
+    """
+
+    qa_pair_id: str = Field(..., min_length=1)
+    question: str = Field(..., min_length=1)
+    is_answerable: bool
+    source: QuestionSource
+    source_file_id: str
+    chunker_id: str
+
+
+def load_questions(cep_dir: Path, nonanswerable_dir: Path | None = None) -> list[QuestionRecord]:
+    """Walk the CEP + non-answerable output directories into a flat question list.
+
+    Args:
+        cep_dir: ``results/<id>/cep/outputs/``. Each ``*.json`` is a
+            :class:`QARecordCEP`. ``FileNotFoundError`` if missing —
+            CEP is required for any retrieve run.
+        nonanswerable_dir: ``results/<id>/nonanswerable/outputs/``. When
+            ``None`` or non-existent, silently skipped (the stage that
+            populates this is still in development).
+
+    Returns:
+        Flat list of :class:`QuestionRecord` rows. CEP rows first, in
+        sorted file order; then non-answerable. Stable ordering so
+        checkpoint resume + cross-run diffing are deterministic.
+
+    Raises:
+        FileNotFoundError: If ``cep_dir`` does not exist.
+    """
+    if not cep_dir.exists():
+        raise FileNotFoundError(
+            f"CEP outputs not found at {cep_dir}. Run `arandu generate-cep-qa` first."
+        )
+
+    questions: list[QuestionRecord] = list(_iter_cep_questions(cep_dir))
+    if nonanswerable_dir is not None and nonanswerable_dir.exists():
+        questions.extend(_iter_nonanswerable_questions(nonanswerable_dir))
+    else:
+        logger.debug(
+            "Non-answerable dir absent (%s); only CEP questions will be retrieved.",
+            nonanswerable_dir,
+        )
+    return questions
+
+
+def _iter_cep_questions(cep_dir: Path) -> Iterator[QuestionRecord]:
+    """Yield one :class:`QuestionRecord` per ``QAPairCEP`` in the dir.
+
+    Each on-disk file is a :class:`QARecordCEP` holding many pairs. The
+    composite ``qa_pair_id`` follows the schema's documented form:
+    ``"<file_id>:<chunk_id or 'none'>:<idx>"``. ``idx`` is the pair's
+    position within the record, so the id stays stable across reruns
+    that produce the same file.
+    """
+    for path in sorted(cep_dir.glob("*.json")):
+        try:
+            record = QARecordCEP.model_validate_json(path.read_text(encoding="utf-8"))
+        except Exception as exc:
+            logger.warning("Skipping unreadable CEP file %s: %s", path, exc)
+            continue
+        for idx, pair in enumerate(record.qa_pairs):
+            chunk_id_segment = pair.chunk_id or "none"
+            yield QuestionRecord(
+                qa_pair_id=f"{record.source_file_id}:{chunk_id_segment}:{idx}",
+                question=pair.question,
+                is_answerable=True,
+                source="cep",
+                source_file_id=record.source_file_id,
+                chunker_id=record.chunker_id,
+            )
+
+
+def _iter_nonanswerable_questions(nonanswerable_dir: Path) -> Iterator[QuestionRecord]:
+    """Yield non-answerable items as :class:`QuestionRecord`.
+
+    Defensive shape: the non-answerable stage doesn't exist on disk yet,
+    so the schema we load against is the spec-described one but read
+    permissively (skip unrecognized files). Once
+    ``arandu generate-non-answerable`` lands and pins the schema, this
+    helper can tighten.
+    """
+    import json
+
+    for path in sorted(nonanswerable_dir.glob("*.json")):
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            logger.warning("Skipping unreadable non-answerable file %s: %s", path, exc)
+            continue
+        for item in payload.get("items", []):
+            qa_pair_id = item.get("qa_pair_id") or item.get("id")
+            question = item.get("question")
+            source_file_id = item.get("source_file_id") or item.get("source_gdrive_id")
+            chunker_id = item.get("chunker_id", "unknown")
+            if not (qa_pair_id and question and source_file_id):
+                logger.debug("Skipping incomplete non-answerable item in %s", path)
+                continue
+            yield QuestionRecord(
+                qa_pair_id=qa_pair_id,
+                question=question,
+                is_answerable=False,
+                source="nonanswerable",
+                source_file_id=source_file_id,
+                chunker_id=chunker_id,
+            )

--- a/src/arandu/shared/rag/retrieve/settings.py
+++ b/src/arandu/shared/rag/retrieve/settings.py
@@ -18,11 +18,23 @@ from typing import Literal
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-ArmName = Literal["bm25", "khop_passage", "khop_triple", "null"]
+ArmName = Literal["bm25", "atlas_rag", "khop_passage", "khop_triple", "null"]
 
 # Stable ordering — drives the CLI's default arm set + the iteration
 # order in the batch runner. Keeps benchmark output reproducible.
-ALL_ARMS: tuple[ArmName, ...] = ("bm25", "khop_passage", "khop_triple", "null")
+#
+# ``atlas_rag`` is recognized but not yet wired in this PR: the factory
+# routes it to a clear "deferred to a follow-up PR" error. Including it
+# in the catalog so ``--arm atlas_rag`` produces the helpful error
+# message rather than an unknown-arm rejection at the batch-runner
+# validation layer. The CLI's ``_DEFAULT_ARMS`` filter excludes it.
+ALL_ARMS: tuple[ArmName, ...] = (
+    "bm25",
+    "atlas_rag",
+    "khop_passage",
+    "khop_triple",
+    "null",
+)
 
 
 class Bm25RetrieveSettings(BaseSettings):

--- a/src/arandu/shared/rag/retrieve/settings.py
+++ b/src/arandu/shared/rag/retrieve/settings.py
@@ -1,0 +1,85 @@
+"""Per-arm settings for ``arandu retrieve``.
+
+Each retriever arm exposes a distinct set of knobs (chunker view, k-hop
+radius, postings cap, …). Rather than overload one CLI command with a
+union of all knobs, each arm has its own :class:`BaseSettings` subclass
+(env prefix ``ARANDU_<ARM>_``). The CLI instantiates only the settings
+classes for arms it was asked to run.
+
+Atlas-rag's settings live in a follow-up PR — that arm needs an LLM
+client + sentence encoder at retrieve time and is intentionally kept
+out of this PR's scope.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+ArmName = Literal["bm25", "khop_passage", "khop_triple", "null"]
+
+# Stable ordering — drives the CLI's default arm set + the iteration
+# order in the batch runner. Keeps benchmark output reproducible.
+ALL_ARMS: tuple[ArmName, ...] = ("bm25", "khop_passage", "khop_triple", "null")
+
+
+class Bm25RetrieveSettings(BaseSettings):
+    """Knobs for the BM25 arm.
+
+    Attributes:
+        chunker_id: ChunkSet view to query against. Must match a chunker
+            id present in ``results/<id>/chunk/outputs/<chunker_id>/``
+            (the chunking stage emits one directory per view it ran).
+            Defaults to ``"cep_4k"`` — the project's primary view, used
+            by the CEP QA generator.
+    """
+
+    chunker_id: str = Field(
+        default="cep_4k",
+        description="Chunker view to retrieve over (must exist under chunk/outputs/).",
+    )
+
+    model_config = SettingsConfigDict(env_prefix="ARANDU_BM25_", extra="ignore")
+
+
+class KHopRetrieveSettings(BaseSettings):
+    """Knobs shared by the two k-hop arms (passage + triple).
+
+    Both arms operate on the same atlas-rag KG and share the same
+    entity-link + k-hop ego graph machinery. They differ only in their
+    output unit (passages vs linearized triples), so the configuration
+    surface is identical.
+
+    Attributes:
+        k_hop: Ego-graph radius around entity-linked seeds. Higher →
+            more recall, slower, more dilution. The 2026-05-23 calibration
+            against ``test-kg-04`` runs at ``k_hop=2`` for seconds-per-query
+            wall time.
+        max_postings: IDF-style cap on per-token entity-link expansion.
+            Tokens whose inverted-index posting list exceeds this size
+            are dropped from the entity link (e.g. ``"enchente"`` in a
+            flood-themed corpus would otherwise link to thousands of
+            entities and dominate the ego graph).
+        keyword: atlas-rag's filename pattern for the graphml. Defaults
+            to project convention ``"transcriptions.json"`` (see
+            :mod:`arandu.kg.atlas_backend`).
+    """
+
+    k_hop: int = Field(
+        default=2,
+        ge=1,
+        description="Ego-graph radius around entity-linked seeds.",
+    )
+    max_postings: int = Field(
+        default=200,
+        ge=1,
+        description="IDF-style cap on per-token entity-link expansion.",
+    )
+    keyword: str = Field(
+        default="transcriptions.json",
+        description="atlas-rag filename pattern (rarely changed).",
+    )
+
+    model_config = SettingsConfigDict(env_prefix="ARANDU_KHOP_", extra="ignore")

--- a/src/arandu/shared/rag/retrieve/settings.py
+++ b/src/arandu/shared/rag/retrieve/settings.py
@@ -46,6 +46,7 @@ class Bm25RetrieveSettings(BaseSettings):
             (the chunking stage emits one directory per view it ran).
             Defaults to ``"cep_4k"`` — the project's primary view, used
             by the CEP QA generator.
+
     """
 
     chunker_id: str = Field(
@@ -77,6 +78,7 @@ class KHopRetrieveSettings(BaseSettings):
         keyword: atlas-rag's filename pattern for the graphml. Defaults
             to project convention ``"transcriptions.json"`` (see
             :mod:`arandu.kg.atlas_backend`).
+
     """
 
     k_hop: int = Field(

--- a/src/arandu/shared/rag/retrievers/_khop_common.py
+++ b/src/arandu/shared/rag/retrievers/_khop_common.py
@@ -1,0 +1,83 @@
+"""Shared tokenizer + stopword constants for the k-hop retriever family.
+
+Both :class:`KHopSubgraphRetriever` (passage variant) and
+:class:`KHopTripleRetriever` (triple variant) run the SAME entity-link
++ k-hop machinery — they differ only in how they score and emit results
+from the induced subgraph. Keeping the tokenizer + stopwords here means
+both arms produce identical seed sets for the same question, which is
+load-bearing for the cross-arm comparison the methodology rewrite will
+report.
+
+Private to the ``retrievers/`` package — the underscore prefix signals
+"don't import this from elsewhere in the codebase." If a third k-hop
+variant ever appears, it imports from here too.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+
+_TOKEN_RE = re.compile(r"\w+", flags=re.UNICODE)
+_MIN_TOKEN_LEN = 3
+_DEFAULT_MAX_POSTINGS = 200
+
+# Linkable node types (used by both arms during entity-linking). Concept
+# nodes ARE linkable — a question may name a concept directly — but the
+# triple variant additionally excludes them from triple ENDPOINTS via its
+# own constant (see ``khop_triple._TRIPLE_ENDPOINT_TYPES``).
+_LINKABLE_TYPES: frozenset[str] = frozenset({"entity", "event", "concept"})
+
+# Short, hand-curated PT + EN stopword list. Deliberately tiny (the most
+# common articles, prepositions, conjunctions, copulas) rather than
+# pulling in spaCy's full list — the k-hop arms are the sanity baseline,
+# and a small list gives most of the signal-vs-noise improvement without
+# the dependency. The first smoke against `test-kg-04` (a 14k-node KG)
+# without any filtering linked common tokens like "a"/"que"/"de" to
+# thousands of entities, producing identical query results across very
+# different questions in ~25 min wall time per query.
+_STOPWORDS: frozenset[str] = frozenset(
+    {
+        # Portuguese
+        "a", "o", "as", "os", "um", "uma", "uns", "umas",
+        "de", "do", "da", "dos", "das", "no", "na", "nos", "nas",
+        "em", "por", "para", "com", "sem", "sob", "sobre", "ate", "até",
+        "e", "ou", "mas", "porem", "porém", "que", "se", "como", "quando",
+        "onde", "qual", "quais", "quem", "porque", "porquê",
+        "eu", "tu", "ele", "ela", "nós", "vos", "vós", "eles", "elas",
+        "meu", "minha", "teu", "tua", "seu", "sua", "nosso", "nossa",
+        "este", "esta", "esse", "essa", "aquele", "aquela",
+        "isto", "isso", "aquilo",
+        "ser", "ter", "estar", "haver", "ir", "vir", "fazer",
+        "é", "foi", "era", "são", "está", "estão", "tem", "têm", "ha", "há",
+        "muito", "muitos", "muita", "muitas",
+        "pouco", "poucos", "todo", "todos",
+        "não", "nao", "sim", "já", "ja", "ainda", "também", "tambem",
+        # English (queries may mix PT/EN in this corpus)
+        "an", "the", "of", "in", "on", "at", "to", "for", "with",
+        "by", "from", "into", "about", "and", "or", "but",
+        "is", "are", "was", "were", "be", "been", "being",
+        "i", "you", "he", "she", "it", "we", "they", "this", "that",
+        "does", "did", "have", "has", "had",
+        "not", "yes", "what", "which", "who", "whom",
+        "when", "where", "why", "how",
+    }
+)  # fmt: skip
+
+
+def _tokenize(text: str, *, filter_stopwords: bool = False) -> list[str]:
+    """Whitespace + punctuation split, lowercased + NFKC-normalised.
+
+    When ``filter_stopwords`` is true, tokens in :data:`_STOPWORDS` and
+    tokens shorter than :data:`_MIN_TOKEN_LEN` are dropped. We do NOT
+    filter at index-build time (node labels keep all tokens so multi-word
+    names like "rio Uruguai" remain linkable when the question mentions
+    only the rare half); only the QUERY tokens are filtered, so a question
+    composed only of stopwords degenerates to an empty entity link and
+    the graph-floor guarantee fires (returns ``[]``).
+    """
+    normalised = unicodedata.normalize("NFKC", text).casefold()
+    tokens = _TOKEN_RE.findall(normalised)
+    if filter_stopwords:
+        tokens = [t for t in tokens if t not in _STOPWORDS and len(t) >= _MIN_TOKEN_LEN]
+    return tokens

--- a/src/arandu/shared/rag/retrievers/khop_subgraph.py
+++ b/src/arandu/shared/rag/retrievers/khop_subgraph.py
@@ -37,8 +37,6 @@ Implementation notes:
 from __future__ import annotations
 
 import logging
-import re
-import unicodedata
 from collections import Counter, defaultdict
 from pathlib import Path  # noqa: TC003
 from typing import TYPE_CHECKING
@@ -46,198 +44,17 @@ from typing import TYPE_CHECKING
 import networkx as nx
 
 from arandu.kg.passage_offsets import build_passage_text_to_atlas_passage_id
+from arandu.shared.rag.retrievers._khop_common import (
+    _DEFAULT_MAX_POSTINGS,
+    _LINKABLE_TYPES,
+    _tokenize,
+)
 from arandu.shared.rag.schemas import RetrievedPassage
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
 logger = logging.getLogger(__name__)
-
-
-_TOKEN_RE = re.compile(r"\w+", flags=re.UNICODE)
-_LINKABLE_TYPES: frozenset[str] = frozenset({"entity", "event", "concept"})
-_MIN_TOKEN_LEN = 3
-_DEFAULT_MAX_POSTINGS = 200
-
-# Short, hand-curated PT + EN stopword list. We deliberately keep this tiny
-# (the most common articles, prepositions, conjunctions, copulas) rather than
-# pulling in spaCy's full list — the NetworkX retriever's role is the sanity
-# baseline, and a small list gives most of the signal-vs-noise improvement
-# without the dependency. The first smoke against `test-kg-04` (a 14k-node
-# KG) without any filtering linked common tokens like "a"/"que"/"de" to
-# thousands of entities, producing identical query results across very
-# different questions in ~25 min wall time per query.
-_STOPWORDS: frozenset[str] = frozenset(
-    {
-        # Portuguese
-        "a",
-        "o",
-        "as",
-        "os",
-        "um",
-        "uma",
-        "uns",
-        "umas",
-        "de",
-        "do",
-        "da",
-        "dos",
-        "das",
-        "no",
-        "na",
-        "nos",
-        "nas",
-        "em",
-        "por",
-        "para",
-        "com",
-        "sem",
-        "sob",
-        "sobre",
-        "ate",
-        "até",
-        "e",
-        "ou",
-        "mas",
-        "porem",
-        "porém",
-        "que",
-        "se",
-        "como",
-        "quando",
-        "onde",
-        "qual",
-        "quais",
-        "quem",
-        "porque",
-        "porquê",
-        "eu",
-        "tu",
-        "ele",
-        "ela",
-        "nós",
-        "vos",
-        "vós",
-        "eles",
-        "elas",
-        "meu",
-        "minha",
-        "teu",
-        "tua",
-        "seu",
-        "sua",
-        "nosso",
-        "nossa",
-        "este",
-        "esta",
-        "esse",
-        "essa",
-        "aquele",
-        "aquela",
-        "isto",
-        "isso",
-        "aquilo",
-        "ser",
-        "ter",
-        "estar",
-        "haver",
-        "ir",
-        "vir",
-        "fazer",
-        "é",
-        "foi",
-        "era",
-        "são",
-        "está",
-        "estão",
-        "tem",
-        "têm",
-        "ha",
-        "há",
-        "muito",
-        "muitos",
-        "muita",
-        "muitas",
-        "pouco",
-        "poucos",
-        "todo",
-        "todos",
-        "não",
-        "nao",
-        "sim",
-        "já",
-        "ja",
-        "ainda",
-        "também",
-        "tambem",
-        # English (queries may mix PT/EN in this corpus)
-        "an",
-        "the",
-        "of",
-        "in",
-        "on",
-        "at",
-        "to",
-        "for",
-        "with",
-        "by",
-        "from",
-        "into",
-        "about",
-        "and",
-        "or",
-        "but",
-        "is",
-        "are",
-        "was",
-        "were",
-        "be",
-        "been",
-        "being",
-        "i",
-        "you",
-        "he",
-        "she",
-        "it",
-        "we",
-        "they",
-        "this",
-        "that",
-        "does",
-        "did",
-        "have",
-        "has",
-        "had",
-        "not",
-        "yes",
-        "what",
-        "which",
-        "who",
-        "whom",
-        "when",
-        "where",
-        "why",
-        "how",
-    }
-)
-
-
-def _tokenize(text: str, *, filter_stopwords: bool = False) -> list[str]:
-    """Whitespace + punctuation split, lowercased + NFKC-normalised.
-
-    When ``filter_stopwords`` is true, tokens in :data:`_STOPWORDS` and tokens
-    shorter than :data:`_MIN_TOKEN_LEN` are dropped. We do NOT filter at
-    index-build time (node labels keep all tokens so multi-word names like
-    "rio Uruguai" remain linkable when the question mentions only the rare
-    half); only the QUERY tokens are filtered, so a question composed only
-    of stopwords degenerates to an empty entity link and the graph-floor
-    guarantee fires (returns ``[]``).
-    """
-    normalised = unicodedata.normalize("NFKC", text).casefold()
-    tokens = _TOKEN_RE.findall(normalised)
-    if filter_stopwords:
-        tokens = [t for t in tokens if t not in _STOPWORDS and len(t) >= _MIN_TOKEN_LEN]
-    return tokens
 
 
 class KHopSubgraphRetriever:

--- a/src/arandu/shared/rag/retrievers/khop_triple.py
+++ b/src/arandu/shared/rag/retrievers/khop_triple.py
@@ -27,35 +27,30 @@ offset-based source-text resolution.
 from __future__ import annotations
 
 import hashlib
-import re
-import unicodedata
 from collections import defaultdict
 from pathlib import Path  # noqa: TC003
 from typing import TYPE_CHECKING
 
 import networkx as nx
 
+from arandu.shared.rag.retrievers._khop_common import (
+    _DEFAULT_MAX_POSTINGS,
+    _LINKABLE_TYPES,
+    _tokenize,
+)
 from arandu.shared.rag.schemas import RetrievedPassage
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
 
-# The shared helpers (tokenizer, stopwords, postings cap) are duplicated from
-# :mod:`arandu.shared.rag.retrievers.khop_subgraph` rather than imported. Reason:
-# the constants are private (`_TOKEN_RE`, `_STOPWORDS`, etc.) and the user
-# may want them to evolve independently. A follow-up refactor can extract
-# them into a sibling helper module once both retrievers stabilise.
-_TOKEN_RE = re.compile(r"\w+", flags=re.UNICODE)
-# Concept nodes ARE linkable (a question may name a concept directly), but
-# are EXCLUDED from triple endpoints below — see `_TRIPLE_ENDPOINT_TYPES`.
-_LINKABLE_TYPES: frozenset[str] = frozenset({"entity", "event", "concept"})
-# Triple endpoints deliberately exclude `concept` nodes. atlas-rag's
-# conceptualization stage (AutoSchemaKG schema induction, see
-# `kg/atlas_backend.py` + methodology §5.3) attaches every entity to its
-# concept(s) via `has_concept` edges — a star pattern where the concept
-# node accumulates extremely high in-degree. With endpoint-degree
-# scoring, those `entity --[has_concept]--> concept` edges dominate any
+# Triple endpoints deliberately exclude `concept` nodes (which ARE in
+# the shared :data:`_LINKABLE_TYPES`). atlas-rag's conceptualization
+# stage (AutoSchemaKG schema induction, see `kg/atlas_backend.py` +
+# methodology §5.3) attaches every entity to its concept(s) via
+# `has_concept` edges — a star pattern where the concept node
+# accumulates extremely high in-degree. With endpoint-degree scoring,
+# those `entity --[has_concept]--> concept` edges dominate any
 # question's top-k results because the concept is a hub, not because
 # the relation is semantically relevant.
 #
@@ -66,45 +61,7 @@ _LINKABLE_TYPES: frozenset[str] = frozenset({"entity", "event", "concept"})
 # (2026-05-23) without this exclusion returned identical top-3
 # `has_concept` triples for every question.
 _TRIPLE_ENDPOINT_TYPES: frozenset[str] = frozenset({"entity", "event"})
-_MIN_TOKEN_LEN = 3
-_DEFAULT_MAX_POSTINGS = 200
 _INFINITY = 10**9  # sentinel for "unreachable from any seed" in distance dicts
-
-_STOPWORDS: frozenset[str] = frozenset(
-    {
-        "a", "o", "as", "os", "um", "uma", "uns", "umas",
-        "de", "do", "da", "dos", "das", "no", "na", "nos", "nas",
-        "em", "por", "para", "com", "sem", "sob", "sobre", "ate", "até",
-        "e", "ou", "mas", "porem", "porém", "que", "se", "como", "quando",
-        "onde", "qual", "quais", "quem", "porque", "porquê",
-        "eu", "tu", "ele", "ela", "nós", "vos", "vós", "eles", "elas",
-        "meu", "minha", "teu", "tua", "seu", "sua", "nosso", "nossa",
-        "este", "esta", "esse", "essa", "aquele", "aquela", "isto", "isso", "aquilo",
-        "ser", "ter", "estar", "haver", "ir", "vir", "fazer",
-        "é", "foi", "era", "são", "está", "estão", "tem", "têm", "ha", "há",
-        "muito", "muitos", "muita", "muitas", "pouco", "poucos", "todo", "todos",
-        "não", "nao", "sim", "já", "ja", "ainda", "também", "tambem",
-        "an", "the", "of", "in", "on", "at", "to", "for", "with",
-        "by", "from", "into", "about", "and", "or", "but",
-        "is", "are", "was", "were", "be", "been", "being",
-        "i", "you", "he", "she", "it", "we", "they", "this", "that",
-        "does", "did", "have", "has", "had",
-        "not", "yes", "what", "which", "who", "whom", "when", "where", "why", "how",
-    }
-)  # fmt: skip
-
-
-def _tokenize(text: str, *, filter_stopwords: bool = False) -> list[str]:
-    """Whitespace + punctuation split, NFKC-normalised, casefolded.
-
-    Mirrors :func:`arandu.shared.rag.retrievers.khop_subgraph._tokenize` so the
-    entity-link stage produces identical seeds across both retrievers.
-    """
-    normalised = unicodedata.normalize("NFKC", text).casefold()
-    tokens = _TOKEN_RE.findall(normalised)
-    if filter_stopwords:
-        tokens = [t for t in tokens if t not in _STOPWORDS and len(t) >= _MIN_TOKEN_LEN]
-    return tokens
 
 
 def _format_triple(

--- a/src/arandu/shared/schemas.py
+++ b/src/arandu/shared/schemas.py
@@ -195,6 +195,7 @@ class PipelineType(StrEnum):
     QA = "qa"
     CEP = "cep"
     KG = "kg"
+    RETRIEVE = "retrieve"
     EVALUATION = "evaluation"
 
 

--- a/tests/cli/test_retrieve_cli.py
+++ b/tests/cli/test_retrieve_cli.py
@@ -1,0 +1,106 @@
+"""Tests for ``arandu retrieve`` CLI command.
+
+Locks the surface arrived at by the design proposal in
+``retrieve-cli-design.md``: ``--id`` required, ``--arm`` repeatable
+with a sane default, clear failure modes.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+from typer.testing import CliRunner
+
+from arandu.cli.app import app
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def results_base(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    base = tmp_path / "results"
+    monkeypatch.setenv("ARANDU_RESULTS_BASE_DIR", str(base))
+    return base
+
+
+def _seed_cep(base: Path, pipeline_id: str = "run_x") -> None:
+    cep_dir = base / pipeline_id / "cep" / "outputs"
+    cep_dir.mkdir(parents=True)
+    record = {
+        "source_file_id": "src_a",
+        "source_filename": "src_a.mp4",
+        "transcription_text": "Texto.",
+        "chunker_id": "cep_4k",
+        "qa_pairs": [
+            {
+                "question": "Q1?",
+                "answer": "A1.",
+                "context": "C1.",
+                "question_type": "factual",
+                "confidence": 0.9,
+                "bloom_level": "remember",
+                "chunk_id": "chk_00",
+            }
+        ],
+        "model_id": "qwen3:14b",
+        "provider": "ollama",
+        "language": "pt",
+        "total_pairs": 1,
+        "bloom_distribution": {},
+    }
+    (cep_dir / "src_a_cep_qa.json").write_text(json.dumps(record))
+
+
+class TestRetrieveCli:
+    def test_null_arm_end_to_end(self, runner: CliRunner, results_base: Path) -> None:
+        _seed_cep(results_base)
+        result = runner.invoke(app, ["retrieve", "--id", "run_x", "--arm", "null", "--top-k", "5"])
+
+        assert result.exit_code == 0, result.output
+        outputs = results_base / "run_x" / "retrieve" / "outputs" / "null" / "cep"
+        assert len(list(outputs.glob("*.json"))) == 1
+        assert "Wrote 1 RetrievalRecord" in result.output
+
+    def test_default_arms_includes_four(self, runner: CliRunner, results_base: Path) -> None:
+        # With no --arm, the CLI runs the 4 non-atlas_rag arms. Three of
+        # them (bm25 / khop_passage / khop_triple) fail at construction
+        # because no chunks/KG are seeded; the null arm completes.
+        _seed_cep(results_base)
+        result = runner.invoke(app, ["retrieve", "--id", "run_x"])
+
+        assert result.exit_code == 0, result.output
+        # null arm should have emitted at least one record.
+        null_outputs = results_base / "run_x" / "retrieve" / "outputs" / "null" / "cep"
+        assert null_outputs.exists()
+        assert "Failed retrievals" in result.output
+
+    def test_missing_cep_fails_with_clear_error(
+        self, runner: CliRunner, results_base: Path
+    ) -> None:
+        result = runner.invoke(app, ["retrieve", "--id", "never_built", "--arm", "null"])
+        assert result.exit_code == 1
+        assert "CEP outputs not found" in result.output
+
+    def test_top_k_zero_rejected_by_typer(self, runner: CliRunner, results_base: Path) -> None:
+        # Typer's min=1 catches this before any business logic runs.
+        _seed_cep(results_base)
+        result = runner.invoke(app, ["retrieve", "--id", "run_x", "--arm", "null", "--top-k", "0"])
+        assert result.exit_code != 0
+
+    def test_help_renders(self, runner: CliRunner) -> None:
+        # Rich/Typer's help panel wraps + truncates inside CliRunner's
+        # default terminal width, making content-level assertions brittle.
+        # Lock the structural surface only: command is registered, --help
+        # exits 0, and the synopsis line is present.
+        result = runner.invoke(app, ["retrieve", "--help"])
+        assert result.exit_code == 0
+        assert "Usage:" in result.output
+        assert "retrieve" in result.output

--- a/tests/shared/rag/retrieve/test_batch.py
+++ b/tests/shared/rag/retrieve/test_batch.py
@@ -157,6 +157,32 @@ class TestRunRetrieveBatchValidation:
             )
 
 
+class TestAtlasRagDeferred:
+    def test_atlas_rag_arm_logs_deferred_message_without_blocking_other_arms(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # atlas_rag is in ALL_ARMS so the batch-runner validation accepts
+        # it, but the factory raises ValueError with the "deferred to a
+        # follow-up PR" message. That error is caught by the per-arm
+        # build-with-logging path; the run continues with other arms.
+        import logging
+
+        _seed_cep(tmp_path)
+        with caplog.at_level(logging.ERROR, logger="arandu.shared.rag.retrieve.batch"):
+            result = run_retrieve_batch(
+                pipeline_id="run_x",
+                arms=["atlas_rag", "null"],
+                top_k=5,
+                base_dir=tmp_path,
+            )
+
+        # null arm completes both questions; atlas_rag fails both.
+        assert result.retrievals_written == 2
+        assert result.retrievals_failed >= 2
+        # The user gets a logged hint pointing at the follow-up PR.
+        assert any("not wired in this PR" in r.message for r in caplog.records)
+
+
 class TestPerArmFailureIsolation:
     def test_one_arm_missing_prereq_doesnt_block_others(self, tmp_path: Path) -> None:
         # BM25 arm without chunks fails at retriever construction; the

--- a/tests/shared/rag/retrieve/test_batch.py
+++ b/tests/shared/rag/retrieve/test_batch.py
@@ -1,0 +1,180 @@
+"""Tests for ``shared/rag/retrieve/batch.py`` — the retrieve batch runner.
+
+End-to-end with the null arm (always available, no on-disk artifacts).
+Locks: checkpoint resume, output directory layout (cep/ vs nonanswerable/),
+graceful per-arm failure (one arm down doesn't kill the batch), the
+top_k validation surface.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from arandu.shared.rag.retrieve.batch import (
+    CHECKPOINT_FILENAME,
+    run_retrieve_batch,
+)
+from arandu.shared.rag.schemas import RetrievalRecord
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _seed_cep(base: Path, pipeline_id: str = "run_x") -> None:
+    """Populate a minimal CEP outputs tree with two QA pairs in one record."""
+    cep_dir = base / pipeline_id / "cep" / "outputs"
+    cep_dir.mkdir(parents=True)
+    record = {
+        "source_file_id": "src_a",
+        "source_filename": "src_a.mp4",
+        "transcription_text": "Texto do teste.",
+        "chunker_id": "cep_4k",
+        "qa_pairs": [
+            {
+                "question": "Pergunta 1?",
+                "answer": "R1.",
+                "context": "C1.",
+                "question_type": "factual",
+                "confidence": 0.9,
+                "bloom_level": "remember",
+                "chunk_id": "chk_00",
+            },
+            {
+                "question": "Pergunta 2?",
+                "answer": "R2.",
+                "context": "C2.",
+                "question_type": "factual",
+                "confidence": 0.9,
+                "bloom_level": "remember",
+                "chunk_id": "chk_01",
+            },
+        ],
+        "model_id": "qwen3:14b",
+        "provider": "ollama",
+        "language": "pt",
+        "total_pairs": 2,
+        "bloom_distribution": {},
+    }
+    (cep_dir / "src_a_cep_qa.json").write_text(json.dumps(record))
+
+
+class TestRunRetrieveBatchNullArm:
+    def test_null_arm_end_to_end(self, tmp_path: Path) -> None:
+        _seed_cep(tmp_path)
+
+        result = run_retrieve_batch(
+            pipeline_id="run_x",
+            arms=["null"],
+            top_k=5,
+            base_dir=tmp_path,
+        )
+
+        # Two CEP pairs xone arm = two records.
+        assert result.retrievals_written == 2
+        assert result.retrievals_failed == 0
+
+        # Output layout: <outputs>/<arm>/<source>/<sanitized_qa_pair_id>.json
+        outputs = tmp_path / "run_x" / "retrieve" / "outputs"
+        cep_records = sorted((outputs / "null" / "cep").glob("*.json"))
+        assert len(cep_records) == 2
+
+        # Records round-trip via the RetrievalRecord schema and carry
+        # the null arm's empty passage list.
+        first = RetrievalRecord.load(cep_records[0])
+        assert first.retriever_id == "null"
+        assert first.passages == []
+        assert first.is_answerable is True
+        assert first.chunker_id == "cep_4k"
+
+    def test_resume_skips_completed_tuples(self, tmp_path: Path) -> None:
+        _seed_cep(tmp_path)
+
+        first = run_retrieve_batch(
+            pipeline_id="run_x",
+            arms=["null"],
+            top_k=5,
+            base_dir=tmp_path,
+        )
+        assert first.retrievals_written == 2
+
+        # Second invocation must replay nothing — checkpoint already
+        # marks both (null, qa_pair) tuples as completed.
+        second = run_retrieve_batch(
+            pipeline_id="run_x",
+            arms=["null"],
+            top_k=5,
+            base_dir=tmp_path,
+        )
+        assert second.retrievals_written == 0
+        assert second.retrievals_resumed == 2
+
+    def test_checkpoint_file_persisted(self, tmp_path: Path) -> None:
+        # The checkpoint file is the resume contract; locking its
+        # location prevents accidental relocation that would silently
+        # disable resume.
+        _seed_cep(tmp_path)
+        run_retrieve_batch(
+            pipeline_id="run_x",
+            arms=["null"],
+            top_k=5,
+            base_dir=tmp_path,
+        )
+        ckpt_path = tmp_path / "run_x" / "retrieve" / CHECKPOINT_FILENAME
+        assert ckpt_path.exists()
+
+
+class TestRunRetrieveBatchValidation:
+    def test_empty_arms_raises(self, tmp_path: Path) -> None:
+        _seed_cep(tmp_path)
+        with pytest.raises(ValueError, match="at least one arm"):
+            run_retrieve_batch(pipeline_id="run_x", arms=[], top_k=5, base_dir=tmp_path)
+
+    def test_top_k_zero_raises(self, tmp_path: Path) -> None:
+        _seed_cep(tmp_path)
+        with pytest.raises(ValueError, match="top_k must be >= 1"):
+            run_retrieve_batch(pipeline_id="run_x", arms=["null"], top_k=0, base_dir=tmp_path)
+
+    def test_unknown_arm_raises(self, tmp_path: Path) -> None:
+        _seed_cep(tmp_path)
+        with pytest.raises(ValueError, match="Unknown arm"):
+            run_retrieve_batch(
+                pipeline_id="run_x",
+                arms=["not_a_real_arm"],  # type: ignore[list-item]
+                top_k=5,
+                base_dir=tmp_path,
+            )
+
+    def test_missing_cep_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError, match="CEP outputs not found"):
+            run_retrieve_batch(
+                pipeline_id="never_built",
+                arms=["null"],
+                top_k=5,
+                base_dir=tmp_path,
+            )
+
+
+class TestPerArmFailureIsolation:
+    def test_one_arm_missing_prereq_doesnt_block_others(self, tmp_path: Path) -> None:
+        # BM25 arm without chunks fails at retriever construction; the
+        # null arm should still run its questions and write records.
+        # This is the "single bad arm doesn't kill the whole batch"
+        # contract called out in the docstring.
+        _seed_cep(tmp_path)
+
+        result = run_retrieve_batch(
+            pipeline_id="run_x",
+            arms=["bm25", "null"],
+            top_k=5,
+            base_dir=tmp_path,
+        )
+
+        # BM25 fails for both questions (build failure counts each as failed),
+        # but null completes both.
+        assert result.retrievals_written == 2  # null x2 questions
+        assert result.retrievals_failed >= 2  # bm25 x2 questions
+        null_outputs = tmp_path / "run_x" / "retrieve" / "outputs" / "null" / "cep"
+        assert len(list(null_outputs.glob("*.json"))) == 2

--- a/tests/shared/rag/retrieve/test_factory.py
+++ b/tests/shared/rag/retrieve/test_factory.py
@@ -1,0 +1,106 @@
+"""Tests for ``shared/rag/retrieve/factory.py`` — per-arm retriever construction.
+
+Locks the dispatch + failure-mode surface. End-to-end retrieve behaviour
+(query → passages) is covered by the per-retriever tests in
+``tests/shared/rag/retrievers/``.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import networkx as nx
+import pytest
+
+from arandu.shared.rag.retrieve.factory import build_retriever
+from arandu.shared.rag.retrieve.settings import Bm25RetrieveSettings, KHopRetrieveSettings
+from arandu.shared.rag.retrievers.khop_subgraph import KHopSubgraphRetriever
+from arandu.shared.rag.retrievers.khop_triple import KHopTripleRetriever
+from arandu.shared.rag.retrievers.null import NullRetriever
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class TestNullArm:
+    def test_returns_null_retriever_without_paths(self, tmp_path: Path) -> None:
+        # Null arm needs no on-disk artifacts — useful smoke for the
+        # CLI's "always at least the null arm runs" contract.
+        retriever = build_retriever("null", pipeline_id="any", base_dir=tmp_path)
+        assert isinstance(retriever, NullRetriever)
+
+
+class TestAtlasRagArmRejected:
+    def test_atlas_rag_raises_with_followup_pr_hint(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="not wired in this PR"):
+            build_retriever("atlas_rag", pipeline_id="any", base_dir=tmp_path)
+
+
+class TestUnknownArm:
+    def test_unknown_arm_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="Unknown arm"):
+            build_retriever("does_not_exist", pipeline_id="any", base_dir=tmp_path)  # type: ignore[arg-type]
+
+
+def _seed_khop_kg(base: Path, pipeline_id: str, keyword: str = "transcriptions.json") -> Path:
+    """Lay out a minimal atlas-rag KG tree with a real graphml file."""
+    kg_outputs_dir = base / pipeline_id / "kg" / "outputs" / "atlas_output"
+    graphml_dir = kg_outputs_dir / "kg_graphml"
+    extraction_dir = kg_outputs_dir / "kg_extraction"
+    graphml_dir.mkdir(parents=True)
+    extraction_dir.mkdir(parents=True)
+
+    kg = nx.DiGraph()
+    kg.add_node("e_a", type="entity", id="entidade a", file_id="src_a")
+    kg.add_node("p_a", type="passage", id="texto teste", file_id="src_a")
+    kg.add_edge("e_a", "p_a", relation="mentions")
+    nx.write_graphml(kg, graphml_dir / f"{keyword}_graph.graphml")
+
+    (extraction_dir / "qwen3.json").write_text(
+        json.dumps({"id": "src_a", "original_text": "texto teste"}) + "\n"
+    )
+    return kg_outputs_dir
+
+
+class TestKHopArms:
+    def test_khop_passage_constructs_retriever(self, tmp_path: Path) -> None:
+        _seed_khop_kg(tmp_path, "run_x")
+        retriever = build_retriever(
+            "khop_passage",
+            pipeline_id="run_x",
+            settings=KHopRetrieveSettings(k_hop=2, max_postings=10),
+            base_dir=tmp_path,
+        )
+        assert isinstance(retriever, KHopSubgraphRetriever)
+
+    def test_khop_triple_constructs_retriever(self, tmp_path: Path) -> None:
+        _seed_khop_kg(tmp_path, "run_x")
+        retriever = build_retriever(
+            "khop_triple",
+            pipeline_id="run_x",
+            settings=KHopRetrieveSettings(k_hop=2, max_postings=10),
+            base_dir=tmp_path,
+        )
+        assert isinstance(retriever, KHopTripleRetriever)
+
+    def test_khop_missing_kg_raises(self, tmp_path: Path) -> None:
+        # No KG built for this pipeline_id at all.
+        with pytest.raises(FileNotFoundError, match="atlas-rag KG outputs not found"):
+            build_retriever(
+                "khop_passage",
+                pipeline_id="nonexistent",
+                base_dir=tmp_path,
+            )
+
+
+class TestBm25Arm:
+    def test_missing_chunks_raises(self, tmp_path: Path) -> None:
+        # No chunks for this chunker_id.
+        with pytest.raises(FileNotFoundError, match="Chunks not found"):
+            build_retriever(
+                "bm25",
+                pipeline_id="run_x",
+                settings=Bm25RetrieveSettings(chunker_id="cep_4k"),
+                base_dir=tmp_path,
+            )

--- a/tests/shared/rag/retrieve/test_loader.py
+++ b/tests/shared/rag/retrieve/test_loader.py
@@ -1,0 +1,163 @@
+"""Tests for ``shared/rag/retrieve/loader.py`` — question stream iteration.
+
+Locks the ``qa_pair_id`` composite format (the spec's
+``"<file_id>:<chunk_id>:<idx>"``) and the optional-non-answerable
+behaviour (silently skipped when the stage hasn't populated).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from arandu.shared.rag.retrieve.loader import load_questions
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write_cep_record(
+    cep_dir: Path,
+    source_file_id: str,
+    qa_pairs: list[dict],
+    chunker_id: str = "cep_4k",
+) -> None:
+    """Write a minimal ``QARecordCEP`` JSON file."""
+    record = {
+        "source_file_id": source_file_id,
+        "source_filename": f"{source_file_id}.mp4",
+        "transcription_text": "Texto de teste.",
+        "chunker_id": chunker_id,
+        "qa_pairs": qa_pairs,
+        "model_id": "qwen3:14b",
+        "provider": "ollama",
+        "language": "pt",
+        "total_pairs": len(qa_pairs),
+        "bloom_distribution": {},
+    }
+    (cep_dir / f"{source_file_id}_cep_qa.json").write_text(json.dumps(record))
+
+
+def _qa_pair(
+    question: str,
+    answer: str = "Resposta.",
+    chunk_id: str | None = None,
+    bloom_level: str = "remember",
+) -> dict:
+    return {
+        "question": question,
+        "answer": answer,
+        "context": "Contexto.",
+        "question_type": "factual",
+        "confidence": 0.9,
+        "bloom_level": bloom_level,
+        "chunk_id": chunk_id,
+    }
+
+
+class TestLoadQuestionsCepOnly:
+    def test_missing_cep_dir_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError, match="CEP outputs not found"):
+            load_questions(tmp_path / "absent")
+
+    def test_qa_pair_id_format_with_chunk_id(self, tmp_path: Path) -> None:
+        cep_dir = tmp_path / "cep"
+        cep_dir.mkdir()
+        _write_cep_record(
+            cep_dir,
+            source_file_id="src_a",
+            qa_pairs=[
+                _qa_pair("Pergunta 1?", chunk_id="chk_aa"),
+                _qa_pair("Pergunta 2?", chunk_id="chk_bb"),
+            ],
+        )
+
+        questions = load_questions(cep_dir)
+
+        # Composite id follows the schema docstring: <file_id>:<chunk_id>:<idx>.
+        assert [q.qa_pair_id for q in questions] == [
+            "src_a:chk_aa:0",
+            "src_a:chk_bb:1",
+        ]
+        assert all(q.is_answerable for q in questions)
+        assert all(q.source == "cep" for q in questions)
+        assert all(q.chunker_id == "cep_4k" for q in questions)
+
+    def test_qa_pair_id_with_none_chunk_id_uses_placeholder(self, tmp_path: Path) -> None:
+        # The schema allows QAPairCEP.chunk_id to be None (CEP generator
+        # doesn't always pin a chunk). The id must still be uniquely
+        # identifiable; we substitute "none" — stable across reruns.
+        cep_dir = tmp_path / "cep"
+        cep_dir.mkdir()
+        _write_cep_record(
+            cep_dir,
+            source_file_id="src_b",
+            qa_pairs=[_qa_pair("Sem chunk?", chunk_id=None)],
+        )
+
+        questions = load_questions(cep_dir)
+        assert questions[0].qa_pair_id == "src_b:none:0"
+
+    def test_files_iterated_in_sorted_order(self, tmp_path: Path) -> None:
+        # Stable ordering matters for checkpoint resume + cross-run diffs.
+        cep_dir = tmp_path / "cep"
+        cep_dir.mkdir()
+        _write_cep_record(cep_dir, "src_b", [_qa_pair("B?")])
+        _write_cep_record(cep_dir, "src_a", [_qa_pair("A?")])
+
+        questions = load_questions(cep_dir)
+        assert [q.source_file_id for q in questions] == ["src_a", "src_b"]
+
+    def test_unreadable_cep_file_skipped(self, tmp_path: Path) -> None:
+        cep_dir = tmp_path / "cep"
+        cep_dir.mkdir()
+        _write_cep_record(cep_dir, "src_ok", [_qa_pair("Ok?")])
+        (cep_dir / "src_bad_cep_qa.json").write_text("not json {")
+
+        questions = load_questions(cep_dir)
+        assert [q.source_file_id for q in questions] == ["src_ok"]
+
+
+class TestLoadQuestionsNonAnswerable:
+    def test_absent_nonanswerable_dir_silently_skipped(self, tmp_path: Path) -> None:
+        # The non-answerable stage doesn't exist on disk yet for most runs;
+        # absence is not an error.
+        cep_dir = tmp_path / "cep"
+        cep_dir.mkdir()
+        _write_cep_record(cep_dir, "src_a", [_qa_pair("Q?")])
+
+        questions = load_questions(cep_dir, tmp_path / "nonanswerable" / "outputs")
+        assert len(questions) == 1
+        assert questions[0].source == "cep"
+
+    def test_nonanswerable_items_loaded_when_present(self, tmp_path: Path) -> None:
+        cep_dir = tmp_path / "cep"
+        cep_dir.mkdir()
+        _write_cep_record(cep_dir, "src_a", [_qa_pair("CEP question?")])
+
+        na_dir = tmp_path / "nonanswerable"
+        na_dir.mkdir()
+        (na_dir / "items.json").write_text(
+            json.dumps(
+                {
+                    "items": [
+                        {
+                            "qa_pair_id": "swap:0001",
+                            "question": "Non-answerable question?",
+                            "source_file_id": "src_a",
+                            "chunker_id": "cep_4k",
+                        }
+                    ]
+                }
+            )
+        )
+
+        questions = load_questions(cep_dir, na_dir)
+        sources = [q.source for q in questions]
+        assert sources.count("cep") == 1
+        assert sources.count("nonanswerable") == 1
+        na_item = next(q for q in questions if q.source == "nonanswerable")
+        assert na_item.qa_pair_id == "swap:0001"
+        assert na_item.is_answerable is False

--- a/tests/shared/rag/retrieve/test_settings.py
+++ b/tests/shared/rag/retrieve/test_settings.py
@@ -1,0 +1,50 @@
+"""Tests for ``shared/rag/retrieve/settings.py`` — per-arm Pydantic settings."""
+
+from __future__ import annotations
+
+import pytest
+
+from arandu.shared.rag.retrieve.settings import (
+    ALL_ARMS,
+    Bm25RetrieveSettings,
+    KHopRetrieveSettings,
+)
+
+
+class TestArmCatalog:
+    def test_known_arms(self) -> None:
+        # The CLI's default arm set + the batch runner's validation both
+        # key off this tuple. Drift would silently break either path.
+        assert ALL_ARMS == ("bm25", "khop_passage", "khop_triple", "null")
+
+
+class TestBm25Settings:
+    def test_defaults(self) -> None:
+        s = Bm25RetrieveSettings(_env_file=None)
+        assert s.chunker_id == "cep_4k"
+
+    def test_env_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ARANDU_BM25_CHUNKER_ID", "bm25_512t")
+        assert Bm25RetrieveSettings().chunker_id == "bm25_512t"
+
+
+class TestKHopSettings:
+    def test_defaults(self) -> None:
+        s = KHopRetrieveSettings(_env_file=None)
+        assert s.k_hop == 2
+        assert s.max_postings == 200
+        assert s.keyword == "transcriptions.json"
+
+    def test_env_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ARANDU_KHOP_K_HOP", "3")
+        monkeypatch.setenv("ARANDU_KHOP_MAX_POSTINGS", "50")
+        s = KHopRetrieveSettings()
+        assert s.k_hop == 3
+        assert s.max_postings == 50
+
+    def test_invalid_k_hop_rejected(self) -> None:
+        # k_hop=0 doesn't match any real retrieval pattern; reject at
+        # settings-construction time so the error doesn't surface deep
+        # in the retriever stack.
+        with pytest.raises(ValueError, match="greater than or equal to 1"):
+            KHopRetrieveSettings(k_hop=0)

--- a/tests/shared/rag/retrieve/test_settings.py
+++ b/tests/shared/rag/retrieve/test_settings.py
@@ -15,7 +15,10 @@ class TestArmCatalog:
     def test_known_arms(self) -> None:
         # The CLI's default arm set + the batch runner's validation both
         # key off this tuple. Drift would silently break either path.
-        assert ALL_ARMS == ("bm25", "khop_passage", "khop_triple", "null")
+        # atlas_rag is recognized (so --arm atlas_rag routes to the
+        # factory's clear "deferred PR" error) but excluded from the
+        # CLI's default set until its LLM-client wiring lands.
+        assert ALL_ARMS == ("bm25", "atlas_rag", "khop_passage", "khop_triple", "null")
 
 
 class TestBm25Settings:

--- a/tests/shared/test_results_manager.py
+++ b/tests/shared/test_results_manager.py
@@ -770,7 +770,7 @@ class TestPipelineType:
 
     def test_all_pipeline_types(self) -> None:
         """Test all pipeline types are defined."""
-        expected = {"transcription", "chunk", "qa", "cep", "kg", "evaluation"}
+        expected = {"transcription", "chunk", "qa", "cep", "kg", "retrieve", "evaluation"}
         actual = {p.value for p in PipelineType}
         assert actual == expected
 


### PR DESCRIPTION
## Summary

Phase C's core benchmark command. Reads QA pairs from `results/<id>/cep/outputs/` and (when present) non-answerable items from `results/<id>/nonanswerable/outputs/`, runs retrieval per requested arm, and persists one `RetrievalRecord` per (arm, question) tuple under `results/<id>/retrieve/outputs/<arm>/<source>/`.

Design captured in `retrieve-cli-design.md` (untracked working doc); decisions locked before code landed.

## Scope: 4 of 5 arms wired

This PR wires 4 of the 5 Phase C arms:

- ✅ `bm25` — loads chunks from `chunk/outputs/<chunker_id>/`, builds the BM25 index lazily on first use, persists to `retrieve/indexes/bm25_<chunker_id>/`
- ✅ `khop_passage` — `KHopSubgraphRetriever` over the atlas-rag KG
- ✅ `khop_triple` — `KHopTripleRetriever` over the same KG
- ✅ `null` — `NullRetriever`, always available, returns `[]`
- ⏸️ `atlas_rag` — **deferred to a follow-up PR**. Needs LLM client + sentence encoder at retrieve time; raises `ValueError` with a clear "follow-up PR" hint if requested

The default arm set runs the 4 wired arms when `--arm` is omitted. The 5th arm joins the default in the follow-up PR.

## Three locked design decisions (from `retrieve-cli-design.md`)

1. **atlas-rag precompute is a separate command** (`arandu kg-build-retriever-index`, PR #106) — `arandu retrieve` never spends LLM tokens.
2. **CEP + non-answerable land in separate output subdirs**: `retrieve/outputs/<arm>/cep/` and `.../<arm>/nonanswerable/`. Source datasets are different stages on disk with different schemas; the judges treat them differently.
3. **Default arm set = all wired arms** when `--arm` is omitted.

## Module shape

| Module | Purpose |
| --- | --- |
| `arandu.shared.rag.retrieve.settings` | Per-arm `BaseSettings` classes; env prefixes `ARANDU_BM25_*` / `ARANDU_KHOP_*` |
| `arandu.shared.rag.retrieve.loader` | `load_questions(cep_dir, nonanswerable_dir=None)` produces a stable `QuestionRecord` stream with composite `qa_pair_id` per the spec |
| `arandu.shared.rag.retrieve.factory` | `build_retriever(arm, ...)` dispatches to the right retriever; clear failure messages |
| `arandu.shared.rag.retrieve.batch` | `run_retrieve_batch(...)` driver with `ResultsManager`-backed stage scaffolding + composite checkpoint keys for cross-arm resume |
| `arandu.cli.retrieve.retrieve` | CLI command, registered in `app.py` |

## Schema changes

- `PipelineType` enum gains `RETRIEVE = "retrieve"`.
- Output file naming sanitizes `qa_pair_id` (`:` → `__`) for cross-platform path safety.

## Failure isolation

Per-arm build failures (missing index, missing KG) don't kill the batch — they're logged and the runner continues with the next arm. Each (arm, question) tuple is checkpointed independently, so resume after a partial failure picks up cleanly.

## Coverage

Full suite: **1293 passed, 1 skipped** locally. Lint + format clean.

- **Settings** (4 tests): defaults, env-var override, validation
- **Loader** (8 tests): `qa_pair_id` format with/without `chunk_id`, sorted ordering, unreadable file resilience, optional non-answerable dir
- **Factory** (7 tests): `null` + `khop_passage` + `khop_triple` end-to-end construction with seeded fixtures, `bm25` missing-chunks error, `atlas_rag` deferred-PR error, unknown-arm error
- **Batch** (8 tests): null-arm end-to-end, checkpoint resume, output layout, validation surface, per-arm failure isolation
- **CLI** (5 tests): null-arm happy path, default arm set, missing CEP, top-k validation, help renders

## Test plan

- [ ] `uv run pytest tests/shared/rag/retrieve/ tests/cli/test_retrieve_cli.py` — green (33 tests)
- [ ] `uv run pytest` — full suite green
- [ ] `uv run ruff check src/ tests/` — clean
- [ ] `uv run ruff format --check src/ tests/` — clean
- [ ] CLI help renders: `uv run arandu retrieve --help`
- [ ] End-to-end smoke against `test-kg-04` (manual): `arandu retrieve --id test-kg-04 --arm null --top-k 5` produces `RetrievalRecord`s under `results/test-kg-04/retrieve/outputs/null/cep/`