### PR TITLE
feat(rag): wire atlas_rag arm into arandu retrieve — 5/5 arms complete

### DIFF
--- a/src/arandu/cli/retrieve.py
+++ b/src/arandu/cli/retrieve.py
@@ -16,6 +16,7 @@ import typer
 from arandu.shared.rag.retrieve.batch import run_retrieve_batch
 from arandu.shared.rag.retrieve.settings import (
     ALL_ARMS,
+    AtlasRagRetrieveSettings,
     Bm25RetrieveSettings,
     KHopRetrieveSettings,
 )
@@ -24,9 +25,7 @@ from arandu.utils.logger import print_error, print_info, print_success, print_wa
 logger = logging.getLogger(__name__)
 
 
-# All ALL_ARMS members EXCEPT atlas_rag; atlas_rag joins the default set in a
-# follow-up PR once its LLM-client wiring lands.
-_DEFAULT_ARMS: tuple[str, ...] = tuple(a for a in ALL_ARMS if a != "atlas_rag")
+_DEFAULT_ARMS: tuple[str, ...] = ALL_ARMS
 
 
 def retrieve(
@@ -54,8 +53,7 @@ def retrieve(
             help=(
                 "Retriever arm; repeatable. Known: "
                 + ", ".join(ALL_ARMS)
-                + f". Defaults to: {', '.join(_DEFAULT_ARMS)}. "
-                + "atlas_rag is currently disabled (LLM-client wiring deferred)."
+                + f". Defaults to all 5 arms ({', '.join(_DEFAULT_ARMS)})."
             ),
         ),
     ] = None,
@@ -99,6 +97,7 @@ def retrieve(
     selected_arms = list(arms) if arms else list(_DEFAULT_ARMS)
     bm25_settings = Bm25RetrieveSettings()
     khop_settings = KHopRetrieveSettings()
+    atlas_rag_settings = AtlasRagRetrieveSettings() if "atlas_rag" in selected_arms else None
 
     print_info(f"Run: {pipeline_id}")
     print_info(f"Arms: {', '.join(selected_arms)}")
@@ -106,6 +105,11 @@ def retrieve(
         print_info(f"BM25 chunker: {bm25_settings.chunker_id}")
     if any(a.startswith("khop_") for a in selected_arms):
         print_info(f"K-hop: k_hop={khop_settings.k_hop}, max_postings={khop_settings.max_postings}")
+    if atlas_rag_settings is not None:
+        print_info(
+            f"atlas_rag LLM: provider={atlas_rag_settings.provider}, "
+            f"model={atlas_rag_settings.model_id}"
+        )
 
     try:
         result = run_retrieve_batch(
@@ -114,6 +118,7 @@ def retrieve(
             top_k=top_k,
             bm25_settings=bm25_settings,
             khop_settings=khop_settings,
+            atlas_rag_settings=atlas_rag_settings,
             rebuild_index=rebuild_index,
         )
     except FileNotFoundError as exc:

--- a/src/arandu/cli/retrieve.py
+++ b/src/arandu/cli/retrieve.py
@@ -51,9 +51,8 @@ def retrieve(
         typer.Option(
             "--arm",
             help=(
-                "Retriever arm; repeatable. Known: "
-                + ", ".join(ALL_ARMS)
-                + f". Defaults to all 5 arms ({', '.join(_DEFAULT_ARMS)})."
+                f"Retriever arm; repeatable. Known: {', '.join(ALL_ARMS)}. "
+                f"Defaults to: {', '.join(_DEFAULT_ARMS)}."
             ),
         ),
     ] = None,

--- a/src/arandu/shared/rag/retrieve/__init__.py
+++ b/src/arandu/shared/rag/retrieve/__init__.py
@@ -18,12 +18,14 @@ from arandu.shared.rag.retrieve.factory import build_retriever
 from arandu.shared.rag.retrieve.loader import QuestionRecord, load_questions
 from arandu.shared.rag.retrieve.settings import (
     ArmName,
+    AtlasRagRetrieveSettings,
     Bm25RetrieveSettings,
     KHopRetrieveSettings,
 )
 
 __all__ = [
     "ArmName",
+    "AtlasRagRetrieveSettings",
     "Bm25RetrieveSettings",
     "KHopRetrieveSettings",
     "QuestionRecord",

--- a/src/arandu/shared/rag/retrieve/batch.py
+++ b/src/arandu/shared/rag/retrieve/batch.py
@@ -109,8 +109,20 @@ def run_retrieve_batch(
             instantiated from env when omitted.
         khop_settings: K-hop arm settings (k_hop, max_postings, keyword).
             Defaults instantiated from env when omitted.
+        atlas_rag_settings: atlas-rag arm settings (LLM provider/model/
+            api_key/base_url + keyword/include_events/include_concept).
+            Only consulted when ``"atlas_rag"`` is in ``arms``; the CLI
+            passes ``None`` otherwise to avoid eagerly reading
+            ``ARANDU_ATLAS_RAG_*`` env vars for runs that don't use the
+            arm.
+        embedder_settings: Sentence-encoder choice for the atlas-rag arm.
+            Ignored by the other arms. Defaults are instantiated inside
+            :func:`build_retriever` from ``ARANDU_EMBEDDER_*`` when
+            omitted.
         rebuild_index: Force arm-side index rebuilds where supported
-            (BM25 only; k-hop arms build state in-memory).
+            (BM25 only; k-hop arms build state in-memory; atlas-rag's
+            precompute is rebuilt via
+            ``arandu kg-build-retriever-index --rebuild``).
         base_dir: Override the project ``results/`` root.
 
     Returns:

--- a/src/arandu/shared/rag/retrieve/batch.py
+++ b/src/arandu/shared/rag/retrieve/batch.py
@@ -20,6 +20,7 @@ from arandu.shared.rag.retrieve.loader import load_questions
 from arandu.shared.rag.retrieve.settings import (
     ALL_ARMS,
     ArmName,
+    AtlasRagRetrieveSettings,
     Bm25RetrieveSettings,
     KHopRetrieveSettings,
 )
@@ -30,6 +31,7 @@ from arandu.shared.schemas import PipelineType
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from arandu.shared.embeddings import EmbedderSettings
     from arandu.shared.rag.protocol import Retriever
     from arandu.shared.rag.retrieve.loader import QuestionRecord
 
@@ -86,6 +88,8 @@ def run_retrieve_batch(
     *,
     bm25_settings: Bm25RetrieveSettings | None = None,
     khop_settings: KHopRetrieveSettings | None = None,
+    atlas_rag_settings: AtlasRagRetrieveSettings | None = None,
+    embedder_settings: EmbedderSettings | None = None,
     rebuild_index: bool = False,
     base_dir: Path | None = None,
 ) -> RetrieveBatchResult:
@@ -168,6 +172,8 @@ def run_retrieve_batch(
             pipeline_id=pipeline_id,
             bm25_settings=bm25_settings,
             khop_settings=khop_settings,
+            atlas_rag_settings=atlas_rag_settings,
+            embedder_settings=embedder_settings,
             base_dir=base,
             rebuild_index=rebuild_index,
         )
@@ -236,30 +242,36 @@ def _build_with_logging(
     pipeline_id: str,
     bm25_settings: Bm25RetrieveSettings | None,
     khop_settings: KHopRetrieveSettings | None,
+    atlas_rag_settings: AtlasRagRetrieveSettings | None,
+    embedder_settings: EmbedderSettings | None,
     base_dir: Path,
     rebuild_index: bool,
 ) -> Retriever | None:
     """Construct a retriever for ``arm``; log + return ``None`` on failure.
 
-    Per-arm build failures (missing index, missing KG outputs, ...) are
-    logged with full context. Returning ``None`` lets the batch runner
-    continue with the next arm rather than aborting the whole run.
+    Per-arm build failures (missing index, missing KG outputs, missing
+    API key, …) are logged with full context. Returning ``None`` lets
+    the batch runner continue with the next arm rather than aborting
+    the whole run.
     """
-    settings: Bm25RetrieveSettings | KHopRetrieveSettings | None = None
+    settings: Bm25RetrieveSettings | KHopRetrieveSettings | AtlasRagRetrieveSettings | None = None
     if arm == "bm25":
         settings = bm25_settings
     elif arm in ("khop_passage", "khop_triple"):
         settings = khop_settings
+    elif arm == "atlas_rag":
+        settings = atlas_rag_settings
 
     try:
         return build_retriever(
             arm,
             pipeline_id=pipeline_id,
             settings=settings,
+            embedder_settings=embedder_settings,
             base_dir=base_dir,
             rebuild_index=rebuild_index,
         )
-    except (FileNotFoundError, ValueError) as exc:
+    except (FileNotFoundError, ValueError, RuntimeError) as exc:
         logger.error("Failed to build %s arm for pipeline %s: %s", arm, pipeline_id, exc)
         return None
 

--- a/src/arandu/shared/rag/retrieve/factory.py
+++ b/src/arandu/shared/rag/retrieve/factory.py
@@ -2,16 +2,14 @@
 
 The CLI passes a flat ``(arm, pipeline_id, settings, rebuild_index)`` to
 :func:`build_retriever`; this module hides the per-arm wiring (chunk
-loading + BM25 index build, KG path resolution, …).
-
-Atlas-rag arm dispatch is intentionally **not** wired here — that arm
-needs an LLM client + sentence encoder at retrieve time and is the
-subject of a follow-up PR. Requesting it now raises ``ValueError``.
+loading + BM25 index build, KG path resolution, LLM client + sentence
+encoder for atlas-rag, …).
 """
 
 from __future__ import annotations
 
 import logging
+import os
 from typing import TYPE_CHECKING
 
 from pydantic import ValidationError
@@ -19,9 +17,17 @@ from pydantic import ValidationError
 from arandu.shared.chunking.resolver import ChunkResolver
 from arandu.shared.chunking.schemas import Chunk, ChunkSet
 from arandu.shared.config import ResultsConfig
+from arandu.shared.embeddings import EmbedderSettings, build_embedder
+from arandu.shared.llm_client import LLMClient, LLMProvider
 from arandu.shared.rag.retrieve.settings import (
+    AtlasRagRetrieveSettings,
     Bm25RetrieveSettings,
     KHopRetrieveSettings,
+)
+from arandu.shared.rag.retrievers.atlas_rag import (
+    MANIFEST_FILENAME,
+    PRECOMPUTE_DIR_NAME,
+    AtlasRagRetriever,
 )
 from arandu.shared.rag.retrievers.bm25 import BM25Retriever
 from arandu.shared.rag.retrievers.khop_subgraph import KHopSubgraphRetriever
@@ -41,40 +47,54 @@ logger = logging.getLogger(__name__)
 _BM25_INDEX_FILENAME = "bm25.pkl"
 
 
+RetrieveSettings = Bm25RetrieveSettings | KHopRetrieveSettings | AtlasRagRetrieveSettings
+
+
 def build_retriever(
     arm: ArmName,
     *,
     pipeline_id: str,
-    settings: Bm25RetrieveSettings | KHopRetrieveSettings | None = None,
+    settings: RetrieveSettings | None = None,
+    embedder_settings: EmbedderSettings | None = None,
     base_dir: Path | None = None,
     rebuild_index: bool = False,
 ) -> Retriever:
     """Construct the retriever for ``arm`` against ``pipeline_id``'s artifacts.
 
     Args:
-        arm: One of ``"bm25"``, ``"khop_passage"``, ``"khop_triple"``,
-            ``"null"``. ``"atlas_rag"`` raises ``ValueError`` (deferred
-            to a follow-up PR).
+        arm: One of ``"bm25"``, ``"atlas_rag"``, ``"khop_passage"``,
+            ``"khop_triple"``, ``"null"``.
         pipeline_id: The run identifier; all paths resolve relative to
             ``<base_dir>/<pipeline_id>/``.
         settings: Arm-specific settings instance. For ``null``, ignored.
             For ``bm25``, must be :class:`Bm25RetrieveSettings`; for
-            k-hop arms, :class:`KHopRetrieveSettings`. Defaults are
-            instantiated when omitted.
+            k-hop arms, :class:`KHopRetrieveSettings`; for atlas-rag,
+            :class:`AtlasRagRetrieveSettings`. Defaults are instantiated
+            when omitted.
+        embedder_settings: Sentence-encoder choice (atlas-rag arm only,
+            ignored otherwise). Defaults to :class:`EmbedderSettings()`,
+            which reads ``ARANDU_EMBEDDER_*`` env vars — the same vars
+            ``arandu kg-build-retriever-index`` consumes, so the encoder
+            that built the precompute matches the one used to embed
+            queries at retrieve time.
         base_dir: Project ``results/`` root. Defaults to
             ``ResultsConfig().base_dir``.
         rebuild_index: Force-rebuild arm-side indexes (BM25 pickle only;
             no-op for k-hop and null, which build their state in-memory
-            from the KG/graphml at construction).
+            from the KG/graphml at construction; for atlas-rag the
+            precompute is the responsibility of
+            ``arandu kg-build-retriever-index``).
 
     Returns:
         A retriever instance satisfying :class:`Retriever`.
 
     Raises:
-        FileNotFoundError: If required artifacts (chunks, KG outputs)
-            are missing for ``pipeline_id``.
-        ValueError: For ``arm="atlas_rag"`` (not yet wired) or unknown
-            arm names.
+        FileNotFoundError: If required artifacts (chunks, KG outputs,
+            atlas-rag precompute) are missing for ``pipeline_id``.
+        RuntimeError: From :func:`build_embedder` (atlas-rag arm) if the
+            embedder API key is unset, or from the atlas-rag LLM
+            construction if its API key env var is unset.
+        ValueError: For unknown arm names or invalid arm/settings combos.
 
     """
     base = base_dir if base_dir is not None else ResultsConfig().base_dir
@@ -112,10 +132,17 @@ def build_retriever(
         )
 
     if arm == "atlas_rag":
-        raise ValueError(
-            "atlas_rag arm is not wired in this PR. It requires an LLM client + "
-            "sentence encoder at retrieve time, which depends on a Phase C task "
-            "still in flight. Pass --arm bm25/khop_passage/khop_triple/null instead."
+        atlas_settings = (
+            settings
+            if isinstance(settings, AtlasRagRetrieveSettings)
+            else AtlasRagRetrieveSettings()
+        )
+        emb_settings = embedder_settings if embedder_settings is not None else EmbedderSettings()
+        return _build_atlas_rag(
+            pipeline_id=pipeline_id,
+            base_dir=base,
+            settings=atlas_settings,
+            embedder_settings=emb_settings,
         )
 
     raise ValueError(f"Unknown arm {arm!r}.")
@@ -208,3 +235,62 @@ def _build_chunk_resolver(*, pipeline_id: str, base_dir: Path) -> ChunkResolver:
         return record.transcription_text
 
     return ChunkResolver(text_loader=_load_text)
+
+
+def _build_atlas_rag(
+    *,
+    pipeline_id: str,
+    base_dir: Path,
+    settings: AtlasRagRetrieveSettings,
+    embedder_settings: EmbedderSettings,
+) -> AtlasRagRetriever:
+    """Construct :class:`AtlasRagRetriever` for ``pipeline_id``.
+
+    Verifies the precompute exists (built separately by
+    ``arandu kg-build-retriever-index``), constructs the LLM client + the
+    sentence encoder, and dispatches to the retriever's constructor —
+    which then runs its own integrity validation against the manifest
+    (graphml sha + per-pickle sha + flag-mismatch checks).
+    """
+    atlas_output_dir = base_dir / pipeline_id / "kg" / "outputs" / "atlas_output"
+    if not atlas_output_dir.exists():
+        raise FileNotFoundError(
+            f"atlas-rag KG outputs not found for pipeline_id {pipeline_id!r}: "
+            f"{atlas_output_dir}. Run `arandu build-kg --id {pipeline_id}` first."
+        )
+
+    precompute_manifest = atlas_output_dir / PRECOMPUTE_DIR_NAME / MANIFEST_FILENAME
+    if not precompute_manifest.exists():
+        raise FileNotFoundError(
+            f"atlas-rag precompute manifest not found at {precompute_manifest}. "
+            f"Run `arandu kg-build-retriever-index --id {pipeline_id}` first "
+            f"(this is the LLM-spending step that builds the embeddings index "
+            f"the atlas-rag retriever reads at retrieve time)."
+        )
+
+    api_key = os.environ.get(settings.api_key_env)
+    if not api_key and settings.provider != "ollama":
+        # Ollama lets a bogus key through; cloud providers don't.
+        raise RuntimeError(
+            f"atlas_rag arm requested but {settings.api_key_env} is unset. "
+            f"Set it or switch ARANDU_ATLAS_RAG_PROVIDER to 'ollama'."
+        )
+
+    llm_client = LLMClient(
+        provider=LLMProvider(settings.provider),
+        model_id=settings.model_id,
+        api_key=api_key,
+        base_url=settings.base_url,
+    )
+    encoder = build_embedder(embedder_settings)
+
+    return AtlasRagRetriever(
+        kg_outputs_dir=atlas_output_dir,
+        llm_client=llm_client.client,
+        llm_model_id=llm_client.model_id,
+        sentence_encoder=encoder,
+        sentence_encoder_model=embedder_settings.model,
+        keyword=settings.keyword,
+        include_events=settings.include_events,
+        include_concept=settings.include_concept,
+    )

--- a/src/arandu/shared/rag/retrieve/factory.py
+++ b/src/arandu/shared/rag/retrieve/factory.py
@@ -268,8 +268,20 @@ def _build_atlas_rag(
             f"the atlas-rag retriever reads at retrieve time)."
         )
 
+    # Settings validator has already lowercased `provider` and applied
+    # the per-provider base_url default; here we coerce to the enum and
+    # use it for the API-key check so the comparison is exhaustive
+    # rather than string-fragile.
+    try:
+        provider_enum = LLMProvider(settings.provider)
+    except ValueError as exc:
+        raise ValueError(
+            f"Unknown atlas_rag provider {settings.provider!r}. "
+            f"Valid: {[p.value for p in LLMProvider]}."
+        ) from exc
+
     api_key = os.environ.get(settings.api_key_env)
-    if not api_key and settings.provider != "ollama":
+    if not api_key and provider_enum is not LLMProvider.OLLAMA:
         # Ollama lets a bogus key through; cloud providers don't.
         raise RuntimeError(
             f"atlas_rag arm requested but {settings.api_key_env} is unset. "
@@ -277,7 +289,7 @@ def _build_atlas_rag(
         )
 
     llm_client = LLMClient(
-        provider=LLMProvider(settings.provider),
+        provider=provider_enum,
         model_id=settings.model_id,
         api_key=api_key,
         base_url=settings.base_url,

--- a/src/arandu/shared/rag/retrieve/settings.py
+++ b/src/arandu/shared/rag/retrieve/settings.py
@@ -1,14 +1,16 @@
 """Per-arm settings for ``arandu retrieve``.
 
 Each retriever arm exposes a distinct set of knobs (chunker view, k-hop
-radius, postings cap, …). Rather than overload one CLI command with a
-union of all knobs, each arm has its own :class:`BaseSettings` subclass
-(env prefix ``ARANDU_<ARM>_``). The CLI instantiates only the settings
-classes for arms it was asked to run.
+radius, postings cap, LLM/embedder for atlas-rag's NER + edge filter,
+…). Rather than overload one CLI command with a union of all knobs,
+each arm has its own :class:`BaseSettings` subclass (env prefix
+``ARANDU_<ARM>_``). The CLI instantiates only the settings classes for
+arms it was asked to run.
 
-Atlas-rag's settings live in a follow-up PR — that arm needs an LLM
-client + sentence encoder at retrieve time and is intentionally kept
-out of this PR's scope.
+Atlas-rag is the only arm that hits the network at retrieve time (NER
+step in front of PPR). It needs an :class:`LLMClient` and a sentence
+encoder; configuration lives in :class:`AtlasRagRetrieveSettings` plus
+the existing :class:`arandu.shared.embeddings.EmbedderSettings`.
 """
 
 from __future__ import annotations
@@ -55,6 +57,70 @@ class Bm25RetrieveSettings(BaseSettings):
     )
 
     model_config = SettingsConfigDict(env_prefix="ARANDU_BM25_", extra="ignore")
+
+
+class AtlasRagRetrieveSettings(BaseSettings):
+    """Knobs for the atlas-rag (HippoRAG-style) arm.
+
+    atlas-rag uses an LLM at retrieve time for the NER step that
+    identifies entities in the query before personalized PageRank
+    seeding. The provider + model + base_url are read from
+    ``ARANDU_ATLAS_RAG_*`` env vars; the sentence encoder is read
+    separately from ``ARANDU_EMBEDDER_*`` (the same vars the
+    ``arandu kg-build-retriever-index`` command uses, so the encoder
+    that built the precompute matches the one used to embed queries).
+
+    Attributes:
+        provider: LLM provider for the NER step. ``"openai"``,
+            ``"ollama"``, or ``"custom"``. Defaults to ``"openai"`` —
+            the Gemini-compatible endpoint is the project's cloud path
+            (set ``base_url`` to the Gemini URL when using it).
+        model_id: Model identifier passed to the LLMClient (e.g.
+            ``"gemini-2.5-flash"`` on Gemini, ``"qwen3:14b"`` on Ollama).
+        api_key_env: Name of the env var holding the LLM API key. The
+            CLI reads this env var when constructing the LLMClient.
+        base_url: Optional explicit base URL. Required for ``custom``
+            provider; ignored for ``openai``/``ollama`` defaults.
+        keyword: atlas-rag's filename pattern. Defaults to project
+            convention ``"transcriptions.json"`` (must match the value
+            used at index-build time).
+        include_events: Whether event nodes participate in the embedded
+            node set. Must match the value used at index-build time —
+            mismatches are caught by atlas-rag's manifest validator.
+        include_concept: Whether concept nodes participate. Same
+            mismatch-detection contract as ``include_events``.
+    """
+
+    provider: str = Field(
+        default="openai",
+        description="LLM provider for the NER step: openai, ollama, custom.",
+    )
+    model_id: str = Field(
+        default="gemini-2.5-flash",
+        description="Model identifier (e.g. gemini-2.5-flash, qwen3:14b).",
+    )
+    api_key_env: str = Field(
+        default="GEMINI_API_KEY",
+        description="Env var name holding the LLM API key.",
+    )
+    base_url: str | None = Field(
+        default="https://generativelanguage.googleapis.com/v1beta/openai/",
+        description="Base URL for OpenAI-compatible endpoints. Use Gemini's URL by default.",
+    )
+    keyword: str = Field(
+        default="transcriptions.json",
+        description="atlas-rag filename pattern (must match index build).",
+    )
+    include_events: bool = Field(
+        default=True,
+        description="Include event nodes in the embedded set.",
+    )
+    include_concept: bool = Field(
+        default=True,
+        description="Include concept nodes in the embedded set.",
+    )
+
+    model_config = SettingsConfigDict(env_prefix="ARANDU_ATLAS_RAG_", extra="ignore")
 
 
 class KHopRetrieveSettings(BaseSettings):

--- a/src/arandu/shared/rag/retrieve/settings.py
+++ b/src/arandu/shared/rag/retrieve/settings.py
@@ -15,10 +15,16 @@ the existing :class:`arandu.shared.embeddings.EmbedderSettings`.
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
-from pydantic import Field
+from pydantic import Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+if TYPE_CHECKING:
+    from typing import Self
+
+
+_GEMINI_OPENAI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai/"
 
 ArmName = Literal["bm25", "atlas_rag", "khop_passage", "khop_triple", "null"]
 
@@ -104,8 +110,14 @@ class AtlasRagRetrieveSettings(BaseSettings):
         description="Env var name holding the LLM API key.",
     )
     base_url: str | None = Field(
-        default="https://generativelanguage.googleapis.com/v1beta/openai/",
-        description="Base URL for OpenAI-compatible endpoints. Use Gemini's URL by default.",
+        default=None,
+        description=(
+            "Base URL for OpenAI-compatible endpoints. When unset, defaults "
+            "are applied per-provider in the post-init validator: openai "
+            "defaults to Gemini's compatibility URL (the project's primary "
+            "cloud path); ollama leaves it None so LLMClient picks its own "
+            "localhost default; custom requires an explicit value."
+        ),
     )
     keyword: str = Field(
         default="transcriptions.json",
@@ -121,6 +133,33 @@ class AtlasRagRetrieveSettings(BaseSettings):
     )
 
     model_config = SettingsConfigDict(env_prefix="ARANDU_ATLAS_RAG_", extra="ignore")
+
+    @field_validator("provider", mode="before")
+    @classmethod
+    def _normalize_provider(cls, v: str) -> str:
+        """Normalize provider to lowercase so env-var case doesn't break dispatch."""
+        if isinstance(v, str):
+            return v.lower()
+        return v
+
+    @model_validator(mode="after")
+    def _default_base_url_per_provider(self) -> Self:
+        """Apply per-provider base_url defaults when the user hasn't set one.
+
+        Without this, the field-level default of ``None`` would leave Gemini
+        users with no base URL (LLMClient's PROVIDER_URLS[openai] is also
+        None — OpenAI proper). Setting the project's primary cloud path
+        here keeps the "just works" UX without baking the URL into a default
+        that would override the ollama path's localhost endpoint.
+        """
+        if self.base_url is not None:
+            return self
+        if self.provider == "openai":
+            object.__setattr__(self, "base_url", _GEMINI_OPENAI_BASE_URL)
+        # ollama: leave None — LLMClient will use http://localhost:11434/v1.
+        # custom: leave None — the factory will surface a clear error if
+        # LLMClient can't resolve a URL.
+        return self
 
 
 class KHopRetrieveSettings(BaseSettings):

--- a/tests/shared/rag/retrieve/test_batch.py
+++ b/tests/shared/rag/retrieve/test_batch.py
@@ -157,14 +157,15 @@ class TestRunRetrieveBatchValidation:
             )
 
 
-class TestAtlasRagDeferred:
-    def test_atlas_rag_arm_logs_deferred_message_without_blocking_other_arms(
+class TestAtlasRagMissingPrerequisites:
+    def test_atlas_rag_arm_logs_missing_precompute_without_blocking_other_arms(
         self, tmp_path: Path, caplog: pytest.LogCaptureFixture
     ) -> None:
         # atlas_rag is in ALL_ARMS so the batch-runner validation accepts
-        # it, but the factory raises ValueError with the "deferred to a
-        # follow-up PR" message. That error is caught by the per-arm
-        # build-with-logging path; the run continues with other arms.
+        # it. With no KG / no precompute on disk, the factory raises
+        # FileNotFoundError pointing at `arandu kg-build-retriever-index`.
+        # That error is caught by the per-arm build-with-logging path;
+        # the run continues with other arms.
         import logging
 
         _seed_cep(tmp_path)
@@ -179,8 +180,8 @@ class TestAtlasRagDeferred:
         # null arm completes both questions; atlas_rag fails both.
         assert result.retrievals_written == 2
         assert result.retrievals_failed >= 2
-        # The user gets a logged hint pointing at the follow-up PR.
-        assert any("not wired in this PR" in r.message for r in caplog.records)
+        # The user gets a logged hint pointing at the build command.
+        assert any("atlas-rag KG outputs not found" in r.message for r in caplog.records)
 
 
 class TestPerArmFailureIsolation:

--- a/tests/shared/rag/retrieve/test_factory.py
+++ b/tests/shared/rag/retrieve/test_factory.py
@@ -9,12 +9,18 @@ from __future__ import annotations
 
 import json
 from typing import TYPE_CHECKING
+from unittest.mock import patch
 
 import networkx as nx
 import pytest
 
+from arandu.shared.embeddings import EmbedderSettings
 from arandu.shared.rag.retrieve.factory import build_retriever
-from arandu.shared.rag.retrieve.settings import Bm25RetrieveSettings, KHopRetrieveSettings
+from arandu.shared.rag.retrieve.settings import (
+    AtlasRagRetrieveSettings,
+    Bm25RetrieveSettings,
+    KHopRetrieveSettings,
+)
 from arandu.shared.rag.retrievers.khop_subgraph import KHopSubgraphRetriever
 from arandu.shared.rag.retrievers.khop_triple import KHopTripleRetriever
 from arandu.shared.rag.retrievers.null import NullRetriever
@@ -31,10 +37,34 @@ class TestNullArm:
         assert isinstance(retriever, NullRetriever)
 
 
-class TestAtlasRagArmRejected:
-    def test_atlas_rag_raises_with_followup_pr_hint(self, tmp_path: Path) -> None:
-        with pytest.raises(ValueError, match="not wired in this PR"):
-            build_retriever("atlas_rag", pipeline_id="any", base_dir=tmp_path)
+class TestAtlasRagArmFailureModes:
+    """The atlas_rag arm needs precompute + LLM API key; failures surface clearly."""
+
+    def test_missing_kg_raises_file_not_found(self, tmp_path: Path) -> None:
+        # No KG built for this pipeline_id at all.
+        with pytest.raises(FileNotFoundError, match="atlas-rag KG outputs not found"):
+            build_retriever("atlas_rag", pipeline_id="never_built", base_dir=tmp_path)
+
+    def test_missing_precompute_raises_file_not_found(self, tmp_path: Path) -> None:
+        # KG built but `arandu kg-build-retriever-index` was never run.
+        _seed_khop_kg(tmp_path, "run_x")  # creates kg/outputs/atlas_output/ + kg_graphml
+        with pytest.raises(FileNotFoundError, match="precompute manifest not found"):
+            build_retriever("atlas_rag", pipeline_id="run_x", base_dir=tmp_path)
+
+    def test_missing_api_key_raises_runtime_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # KG + precompute present; LLM provider is the cloud default but
+        # the API key env var is unset. Surface a clear error instead of
+        # constructing an unusable LLMClient.
+        _seed_khop_kg(tmp_path, "run_x")
+        precompute_dir = tmp_path / "run_x" / "kg" / "outputs" / "atlas_output" / "precompute"
+        precompute_dir.mkdir(parents=True)
+        (precompute_dir / "manifest.json").write_text("{}")
+        monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+
+        with pytest.raises(RuntimeError, match="GEMINI_API_KEY"):
+            build_retriever("atlas_rag", pipeline_id="run_x", base_dir=tmp_path)
 
 
 class TestUnknownArm:
@@ -92,6 +122,56 @@ class TestKHopArms:
                 pipeline_id="nonexistent",
                 base_dir=tmp_path,
             )
+
+
+class TestAtlasRagArmConstructs:
+    """All prerequisites present → :class:`AtlasRagRetriever` is constructed.
+
+    The real AtlasRagRetriever constructor reads pickles + builds an
+    upstream HippoRAGRetriever, which is too heavy for unit tests. We
+    patch the class so the test verifies wiring (LLM client + embedder
+    plumbing, kwarg names) without touching atlas-rag internals.
+    """
+
+    def test_wires_llm_and_embedder_correctly(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _seed_khop_kg(tmp_path, "run_x")
+        precompute_dir = tmp_path / "run_x" / "kg" / "outputs" / "atlas_output" / "precompute"
+        precompute_dir.mkdir(parents=True)
+        (precompute_dir / "manifest.json").write_text("{}")
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+
+        sentinel_encoder = object()
+        with (
+            patch(
+                "arandu.shared.rag.retrieve.factory.build_embedder",
+                return_value=sentinel_encoder,
+            ) as mock_build_embedder,
+            patch("arandu.shared.rag.retrieve.factory.AtlasRagRetriever") as mock_retriever_cls,
+        ):
+            build_retriever(
+                "atlas_rag",
+                pipeline_id="run_x",
+                settings=AtlasRagRetrieveSettings(
+                    provider="openai",
+                    model_id="gemini-2.5-flash",
+                    base_url="https://gemini.example/v1/",
+                ),
+                embedder_settings=EmbedderSettings(model="gemini-embedding-001"),
+                base_dir=tmp_path,
+            )
+
+        mock_build_embedder.assert_called_once()
+        mock_retriever_cls.assert_called_once()
+        kwargs = mock_retriever_cls.call_args.kwargs
+        assert kwargs["kg_outputs_dir"] == tmp_path / "run_x" / "kg" / "outputs" / "atlas_output"
+        assert kwargs["sentence_encoder"] is sentinel_encoder
+        assert kwargs["sentence_encoder_model"] == "gemini-embedding-001"
+        assert kwargs["llm_model_id"] == "gemini-2.5-flash"
+        # llm_client is an openai.OpenAI instance (the .client on LLMClient).
+        # We don't assert its full type — just that it was passed.
+        assert kwargs["llm_client"] is not None
 
 
 class TestBm25Arm:

--- a/tests/shared/rag/retrieve/test_settings.py
+++ b/tests/shared/rag/retrieve/test_settings.py
@@ -75,3 +75,36 @@ class TestAtlasRagSettings:
         assert s.provider == "ollama"
         assert s.model_id == "qwen3:14b"
         assert s.base_url == "http://localhost:11434/v1"
+
+    def test_provider_normalized_to_lowercase(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Without normalization, ARANDU_ATLAS_RAG_PROVIDER=Ollama would
+        # later break the LLMProvider(value) coercion (enum values are
+        # lowercase). Settings flatten the case here so the dispatch is
+        # robust to env-var case.
+        monkeypatch.setenv("ARANDU_ATLAS_RAG_PROVIDER", "Ollama")
+        assert AtlasRagRetrieveSettings().provider == "ollama"
+
+    def test_base_url_stays_none_for_ollama_without_override(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Bug fix from PR #108 review: previously ``base_url`` defaulted
+        # to Gemini's URL, so ``ARANDU_ATLAS_RAG_PROVIDER=ollama`` would
+        # silently send Ollama requests to Gemini's endpoint. The per-
+        # provider validator now leaves ``base_url`` None for ollama so
+        # ``LLMClient.PROVIDER_URLS[OLLAMA]`` (localhost:11434) wins.
+        monkeypatch.delenv("ARANDU_ATLAS_RAG_BASE_URL", raising=False)
+        monkeypatch.setenv("ARANDU_ATLAS_RAG_PROVIDER", "ollama")
+        assert AtlasRagRetrieveSettings().base_url is None
+
+    def test_base_url_defaults_to_gemini_for_openai(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ARANDU_ATLAS_RAG_BASE_URL", raising=False)
+        monkeypatch.setenv("ARANDU_ATLAS_RAG_PROVIDER", "openai")
+        s = AtlasRagRetrieveSettings()
+        assert s.base_url is not None
+        assert "generativelanguage.googleapis.com" in s.base_url
+
+    def test_explicit_base_url_preserved(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ARANDU_ATLAS_RAG_PROVIDER", "openai")
+        monkeypatch.setenv("ARANDU_ATLAS_RAG_BASE_URL", "https://custom.example/v1/")
+        s = AtlasRagRetrieveSettings()
+        assert s.base_url == "https://custom.example/v1/"

--- a/tests/shared/rag/retrieve/test_settings.py
+++ b/tests/shared/rag/retrieve/test_settings.py
@@ -6,6 +6,7 @@ import pytest
 
 from arandu.shared.rag.retrieve.settings import (
     ALL_ARMS,
+    AtlasRagRetrieveSettings,
     Bm25RetrieveSettings,
     KHopRetrieveSettings,
 )
@@ -51,3 +52,26 @@ class TestKHopSettings:
         # in the retriever stack.
         with pytest.raises(ValueError, match="greater than or equal to 1"):
             KHopRetrieveSettings(k_hop=0)
+
+
+class TestAtlasRagSettings:
+    def test_defaults(self) -> None:
+        # Defaults assume the Gemini cloud path (matches the project's
+        # primary smoke configuration); switch to ollama for PCAD.
+        s = AtlasRagRetrieveSettings(_env_file=None)
+        assert s.provider == "openai"
+        assert s.model_id == "gemini-2.5-flash"
+        assert s.api_key_env == "GEMINI_API_KEY"
+        assert "generativelanguage.googleapis.com" in (s.base_url or "")
+        assert s.keyword == "transcriptions.json"
+        assert s.include_events is True
+        assert s.include_concept is True
+
+    def test_env_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ARANDU_ATLAS_RAG_PROVIDER", "ollama")
+        monkeypatch.setenv("ARANDU_ATLAS_RAG_MODEL_ID", "qwen3:14b")
+        monkeypatch.setenv("ARANDU_ATLAS_RAG_BASE_URL", "http://localhost:11434/v1")
+        s = AtlasRagRetrieveSettings()
+        assert s.provider == "ollama"
+        assert s.model_id == "qwen3:14b"
+        assert s.base_url == "http://localhost:11434/v1"


### PR DESCRIPTION
## Summary

PR #107 shipped \`arandu retrieve\` with 4 of 5 arms; this PR closes the loop on the 5th (\`atlas_rag\`) by wiring the LLM client + sentence encoder construction at retrieve time. **Phase C's retrieval stack now ships every arm the spec calls for.**

## Module changes

- **\`AtlasRagRetrieveSettings\`** (env prefix \`ARANDU_ATLAS_RAG_\`) carries LLM provider/model/api_key/base_url plus atlas-rag's keyword/include_events/include_concept. The sentence encoder is configured via the existing \`EmbedderSettings\` (\`ARANDU_EMBEDDER_*\`) so the encoder used at retrieve time matches the one that built the precompute via \`arandu kg-build-retriever-index\` (PR #106).

- **\`_build_atlas_rag\`** in \`factory.py\` checks:
  1. \`kg/outputs/atlas_output/\` exists (KG was built)
  2. \`precompute/manifest.json\` exists (build-retriever-index ran)
  3. LLM API key env var is set (cloud providers only — ollama lets anything through)

  Then constructs \`LLMClient\` + the embedder via existing factories and dispatches to \`AtlasRagRetriever\`, whose own manifest validator catches parameter mismatches between requested flags and the precompute on disk.

- **Batch runner** forwards \`atlas_rag_settings\` + \`embedder_settings\` to the per-arm builder. \`_build_with_logging\`'s exception catch widens to include \`RuntimeError\` so a missing API key surfaces cleanly via the same logged-failure path as missing chunks / KG.

- **CLI** lifts \`atlas_rag\` into \`_DEFAULT_ARMS\` (it now runs by default), instantiates \`AtlasRagRetrieveSettings\` only when the arm is requested, prints the LLM provider/model on startup, and drops the "atlas_rag is currently disabled" help text.

## Usage

\`\`\`bash
# Prerequisites
arandu build-kg --id my-run ...
arandu kg-build-retriever-index --id my-run  # builds atlas-rag's precompute (~\$0.05 + 5 min via Gemini)

# Run all 5 arms (now the default)
ARANDU_ATLAS_RAG_API_KEY_ENV=GEMINI_API_KEY \\
GEMINI_API_KEY=... \\
arandu retrieve --id my-run --top-k 10

# Or atlas-rag only
arandu retrieve --id my-run --arm atlas_rag --top-k 10
\`\`\`

## Coverage

- **Settings** (2 new tests): defaults + env override
- **Factory** (4 new tests): 3 failure modes (missing KG, missing precompute, missing API key) + 1 positive wiring test that mocks \`AtlasRagRetriever\` and verifies LLM + embedder are plumbed through with the right kwargs
- **Batch** (existing test updated): the per-arm-failure-isolation test now asserts the new "missing KG" log message instead of the removed "not wired in this PR" message

**1299 passed, 1 skipped** locally. Lint + format clean.

## Test plan

- [ ] \`uv run pytest tests/shared/rag/retrieve/ tests/cli/test_retrieve_cli.py\` — green (39 tests)
- [ ] \`uv run pytest\` — full suite green
- [ ] \`uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/\` — clean
- [ ] CLI help renders the 5 arms without the "disabled" caveat: \`uv run arandu retrieve --help\`
- [ ] End-to-end smoke against test-kg-04 (manual, requires \`GEMINI_API_KEY\` + prior precompute build): \`arandu retrieve --id test-kg-04 --top-k 5\` produces records for all 5 arms