### PR TITLE
feat(rag): arandu answer — Answerer LLM held constant across retrieval arms

### DIFF
--- a/src/arandu/cli/answer.py
+++ b/src/arandu/cli/answer.py
@@ -1,0 +1,72 @@
+"""CLI command: ``arandu answer`` — drive the Answerer over a populated retrieve stage.
+
+Iterates every ``RetrievalRecord`` under ``results/<id>/retrieve/outputs/``
+and emits one ``AnswerRecord`` per record under
+``results/<id>/answers/outputs/<arm>/<source>/``.
+
+The Answerer is held constant across arms — same LLM, same prompt, same
+temperature — so the cross-arm benchmark isolates retrieval quality
+from generation quality (spec §5.1).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Annotated
+
+import typer
+
+from arandu.shared.rag.answer.batch import run_answer_batch
+from arandu.shared.rag.answer.settings import AnswererSettings
+from arandu.utils.logger import print_error, print_info, print_success, print_warning
+
+logger = logging.getLogger(__name__)
+
+
+def answer(
+    pipeline_id: Annotated[
+        str,
+        typer.Option(
+            "--id",
+            help=(
+                "Pipeline ID for the run. The retrieve/ stage must already "
+                "be populated; the answerer reads its RetrievalRecord JSON files."
+            ),
+        ),
+    ],
+) -> None:
+    """Run the Answerer LLM over every RetrievalRecord in a populated run.
+
+    Reads ``results/<id>/retrieve/outputs/<arm>/<source>/*.json`` and
+    emits one ``AnswerRecord`` per record under
+    ``results/<id>/answers/outputs/<arm>/<source>/`` (same layout,
+    different stage).
+
+    Answerer configuration is read from ``ARANDU_ANSWERER_*`` env vars;
+    see :class:`AnswererSettings` for fields. The same configuration
+    applies to every arm in this run — the methodological constant
+    that makes cross-arm comparison fair.
+    """
+    settings = AnswererSettings()
+    print_info(f"Run: {pipeline_id}")
+    print_info(
+        f"Answerer: provider={settings.provider}, model={settings.model_id}, "
+        f"temperature={settings.temperature}, language={settings.language}"
+    )
+
+    try:
+        result = run_answer_batch(pipeline_id=pipeline_id, settings=settings)
+    except FileNotFoundError as exc:
+        print_error(str(exc))
+        raise typer.Exit(code=1) from exc
+    except (RuntimeError, ValueError) as exc:
+        print_error(f"Invalid answer configuration: {exc}")
+        raise typer.Exit(code=1) from exc
+
+    if result.answers_failed:
+        print_warning(
+            f"Failed answers: {result.answers_failed} (check logs for per-record errors)."
+        )
+    if result.answers_resumed:
+        print_info(f"Resumed: {result.answers_resumed} record(s) already completed.")
+    print_success(f"Wrote {result.answers_written} AnswerRecord(s) to {result.run_dir}/outputs/")

--- a/src/arandu/cli/app.py
+++ b/src/arandu/cli/app.py
@@ -48,6 +48,7 @@ def main(
 
 
 # Register commands from submodules
+from arandu.cli.answer import answer  # noqa: E402
 from arandu.cli.chunking import chunk  # noqa: E402
 from arandu.cli.kg import build_kg, kg_build_retriever_index, kg_link_passages  # noqa: E402
 from arandu.cli.manage import (  # noqa: E402
@@ -81,6 +82,7 @@ app.command()(build_kg)
 app.command()(kg_link_passages)
 app.command()(kg_build_retriever_index)
 app.command()(retrieve)
+app.command()(answer)
 app.command()(replicate)
 app.command()(info)
 app.command()(list_runs)

--- a/src/arandu/shared/rag/answer/__init__.py
+++ b/src/arandu/shared/rag/answer/__init__.py
@@ -1,0 +1,28 @@
+"""Answerer machinery — LLM with structured output, held constant across retrieval arms.
+
+Spec §5. Public entry points:
+
+- :func:`run_answer_batch` — CLI driver, iterates ``RetrievalRecord``
+  artifacts under a run and produces ``AnswerRecord`` artifacts.
+- :class:`AnswererClient` — wraps :class:`LLMClient.generate_structured`
+  with the spec's malformed-output retry contract (3 attempts with
+  ``temperature += 0.1`` each, fallback to an abstained record on
+  exhaustion).
+- :class:`AnswererSettings` — Pydantic settings (env prefix
+  ``ARANDU_ANSWERER_``).
+- :func:`pack_passages` — token-budget passage packing.
+"""
+
+from arandu.shared.rag.answer.answerer import AnswererClient
+from arandu.shared.rag.answer.batch import run_answer_batch
+from arandu.shared.rag.answer.packer import pack_passages
+from arandu.shared.rag.answer.schemas import AnswererOutput
+from arandu.shared.rag.answer.settings import AnswererSettings
+
+__all__ = [
+    "AnswererClient",
+    "AnswererOutput",
+    "AnswererSettings",
+    "pack_passages",
+    "run_answer_batch",
+]

--- a/src/arandu/shared/rag/answer/answerer.py
+++ b/src/arandu/shared/rag/answer/answerer.py
@@ -1,0 +1,131 @@
+"""Answerer client — wraps LLMClient.generate_structured with spec §5.6 retry contract.
+
+The spec's retry strategy differs from :meth:`LLMClient.generate_structured`'s
+default: on each failed attempt, bump the temperature by 0.1 (rather than
+retrying at the same temperature). The rationale is that a deterministic
+model that produced malformed JSON once will likely produce it again at
+the same temperature; nudging temperature breaks the loop.
+
+After three exhausted attempts, fall back to an abstained record with
+``fallback_reason`` recorded in :attr:`AnswerRecord.answerer_meta` for
+later audit.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from arandu.shared.llm_client import StructuredOutputError
+from arandu.shared.rag.answer.prompts import render_prompt
+from arandu.shared.rag.answer.schemas import AnswererOutput
+
+if TYPE_CHECKING:
+    from arandu.shared.llm_client import LLMClient
+    from arandu.shared.rag.answer.settings import AnswererSettings
+
+logger = logging.getLogger(__name__)
+
+
+_TEMPERATURE_BUMP_PER_ATTEMPT = 0.1
+_MAX_ATTEMPTS = 3
+_FALLBACK_RATIONALE = "Failed to produce structured output after 3 retries"
+
+
+class AnswererClient:
+    """Drive the Answerer LLM end-to-end for one question + passage set.
+
+    Stateless across calls — construct once per run (so the LLMClient
+    connection is reused) and call :meth:`answer` per question.
+
+    Attributes:
+        settings: The :class:`AnswererSettings` snapshot this client
+            was built with. Persisted on every :class:`AnswerRecord`
+            so reruns can attribute outputs to their configuration.
+    """
+
+    def __init__(self, llm_client: LLMClient, settings: AnswererSettings) -> None:
+        """Construct from an existing LLMClient + settings snapshot.
+
+        Args:
+            llm_client: Already-constructed :class:`LLMClient`. The CLI
+                builds it from ``settings.provider`` + ``settings.model_id``
+                via the unified client.
+            settings: Per-call configuration (temperature, max_tokens,
+                language, etc.). Read on every :meth:`answer` call.
+        """
+        self._client = llm_client
+        self.settings = settings
+
+    def answer(
+        self,
+        *,
+        question: str,
+        passage_texts: list[str],
+    ) -> tuple[AnswererOutput, dict[str, object]]:
+        """Run the answerer pipeline once for ``question`` over ``passage_texts``.
+
+        Args:
+            question: Verbatim question text.
+            passage_texts: Pre-resolved + pre-packed passage texts in
+                rank order. The caller is responsible for budget
+                packing (see :func:`pack_passages`).
+
+        Returns:
+            A ``(output, meta)`` tuple. ``meta`` carries audit fields
+            ready to merge into :attr:`AnswerRecord.answerer_meta`:
+
+            - ``attempts``: count of LLM calls before success or fallback
+            - ``final_temperature``: the temperature used on the
+              attempt that succeeded (or the last attempt that failed
+              before fallback)
+            - ``fallback_reason``: present only when the output is the
+              abstained fallback
+        """
+        prompt = render_prompt(
+            self.settings.language,
+            question=question,
+            passages=passage_texts,
+        )
+
+        for attempt in range(1, _MAX_ATTEMPTS + 1):
+            temperature = self.settings.temperature + (attempt - 1) * _TEMPERATURE_BUMP_PER_ATTEMPT
+            try:
+                output = self._client.generate_structured(
+                    prompt=prompt,
+                    response_model=AnswererOutput,
+                    temperature=temperature,
+                    max_tokens=self.settings.max_tokens,
+                    max_retries=0,
+                )
+            except StructuredOutputError as exc:
+                logger.warning(
+                    "Answerer attempt %d/%d failed at temperature=%.2f: %s",
+                    attempt,
+                    _MAX_ATTEMPTS,
+                    temperature,
+                    exc,
+                )
+                continue
+            return output, {
+                "attempts": attempt,
+                "final_temperature": temperature,
+            }
+
+        # All attempts exhausted — return the audit-only fallback.
+        logger.error(
+            "Answerer exhausted %d attempts for question %r; falling back to abstained.",
+            _MAX_ATTEMPTS,
+            question[:80],
+        )
+        fallback = AnswererOutput(
+            abstained=True,
+            answer=None,
+            rationale=_FALLBACK_RATIONALE,
+        )
+        return fallback, {
+            "attempts": _MAX_ATTEMPTS,
+            "final_temperature": self.settings.temperature
+            + (_MAX_ATTEMPTS - 1) * _TEMPERATURE_BUMP_PER_ATTEMPT,
+            "fallback_reason": _FALLBACK_RATIONALE,
+        }

--- a/src/arandu/shared/rag/answer/batch.py
+++ b/src/arandu/shared/rag/answer/batch.py
@@ -245,9 +245,17 @@ def _answer_one(
     passage_text: dict[str, str],
     resolved_settings: AnswererSettings,
 ) -> AnswerRecord:
-    """Pack passages, run the answerer, and assemble the persistable record."""
+    """Pack passages, run the answerer, and assemble the persistable record.
+
+    Caps ``retrieval.passages`` at ``settings.top_k`` BEFORE the token-budget
+    pack so the answerer is constrained to the same per-question fan-out
+    regardless of how many passages the retriever returned (the methodology
+    constant from spec §5.7's ``ARANDU_ANSWERER_TOP_K`` knob). The budget
+    pack then trims further if even ``top_k`` passages exceed the context.
+    """
+    capped_passages = retrieval.passages[: resolved_settings.top_k]
     packed = pack_passages(
-        retrieval.passages,
+        capped_passages,
         passage_text=passage_text,
         max_context_tokens=resolved_settings.max_context_tokens,
         prompt_overhead_tokens=resolved_settings.prompt_overhead_tokens,
@@ -275,9 +283,20 @@ def _answer_one(
         answerer_model=resolved_settings.model_id,
         answerer_temperature=resolved_settings.temperature,
         answerer_meta={
+            # LLM retry audit (attempts, final_temperature, fallback_reason if any).
             **meta,
+            # Pack diagnostics — how many passages survived the top_k + token budget.
+            "passages_after_top_k": len(capped_passages),
             "packed_passages": len(packed),
+            # Settings snapshot — persisted on each record so reruns can
+            # attribute outputs back to configuration even if run_metadata.json
+            # is moved, lost, or carries an updated snapshot from a later run.
             "language": resolved_settings.language,
+            "provider": resolved_settings.provider,
+            "top_k": resolved_settings.top_k,
+            "max_tokens": resolved_settings.max_tokens,
+            "max_context_tokens": resolved_settings.max_context_tokens,
+            "prompt_overhead_tokens": resolved_settings.prompt_overhead_tokens,
         },
     )
     return answer_record

--- a/src/arandu/shared/rag/answer/batch.py
+++ b/src/arandu/shared/rag/answer/batch.py
@@ -1,0 +1,299 @@
+"""Batch runner for ``arandu answer`` — drives the Answerer over a populated retrieve stage.
+
+Iterates ``RetrievalRecord`` artifacts produced by ``arandu retrieve``
+under ``results/<id>/retrieve/outputs/<arm>/<source>/`` and writes
+``AnswerRecord`` artifacts under
+``results/<id>/answers/outputs/<arm>/<source>/``.
+
+Same retriever-arm-as-shard layout, same per-arm failure isolation,
+same composite checkpoint keys as the retrieve stage.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, Field, ValidationError
+
+from arandu.shared.checkpoint import CheckpointManager
+from arandu.shared.config import ResultsConfig
+from arandu.shared.llm_client import LLMClient, LLMProvider
+from arandu.shared.rag.answer.answerer import AnswererClient
+from arandu.shared.rag.answer.packer import pack_passages
+from arandu.shared.rag.answer.resolver import build_passage_text_map
+from arandu.shared.rag.answer.settings import AnswererSettings
+from arandu.shared.rag.schemas import AnswerRecord, RetrievalRecord
+from arandu.shared.results_manager import ResultsManager
+from arandu.shared.schemas import PipelineType
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+CHECKPOINT_FILENAME = "answer_checkpoint.json"
+
+
+class AnswerBatchConfig(BaseModel):
+    """Persisted run-metadata snapshot for the answers stage.
+
+    Attributes:
+        pipeline_id: The run identifier.
+        answerer_provider: LLM provider used (e.g. ``"ollama"``).
+        answerer_model_id: LLM model identifier.
+        answerer_temperature: Starting temperature.
+        language: Prompt language (``"pt"`` or ``"en"``).
+    """
+
+    pipeline_id: str
+    answerer_provider: str
+    answerer_model_id: str
+    answerer_temperature: float = Field(..., ge=0.0, le=2.0)
+    language: str
+
+
+class AnswerBatchResult(BaseModel):
+    """Summary of a completed answer batch run."""
+
+    pipeline_id: str
+    run_dir: str
+    answers_written: int = 0
+    answers_resumed: int = 0
+    answers_failed: int = 0
+
+
+def run_answer_batch(
+    pipeline_id: str,
+    *,
+    settings: AnswererSettings | None = None,
+    base_dir: Path | None = None,
+) -> AnswerBatchResult:
+    """Drive the answerer over every ``RetrievalRecord`` for ``pipeline_id``.
+
+    Args:
+        pipeline_id: Run identifier. The retrieve stage must be populated.
+        settings: Answerer configuration. Defaults to
+            :class:`AnswererSettings()` (reads ``ARANDU_ANSWERER_*``
+            env vars).
+        base_dir: Override the project ``results/`` root.
+
+    Returns:
+        Summary counts via :class:`AnswerBatchResult`.
+
+    Raises:
+        FileNotFoundError: If the retrieve stage's outputs aren't
+            present for ``pipeline_id``.
+        RuntimeError: If a cloud-provider API key env var is unset.
+    """
+    resolved_settings = settings if settings is not None else AnswererSettings()
+    base = base_dir if base_dir is not None else ResultsConfig().base_dir
+
+    retrieve_outputs = base / pipeline_id / "retrieve" / "outputs"
+    if not retrieve_outputs.exists():
+        raise FileNotFoundError(
+            f"Retrieve outputs not found for pipeline_id {pipeline_id!r}: "
+            f"{retrieve_outputs}. Run `arandu retrieve --id {pipeline_id}` first."
+        )
+
+    llm_client = _build_llm_client(resolved_settings)
+    answerer = AnswererClient(llm_client=llm_client, settings=resolved_settings)
+    passage_text = _build_passage_text_map(base=base, pipeline_id=pipeline_id)
+
+    config = AnswerBatchConfig(
+        pipeline_id=pipeline_id,
+        answerer_provider=resolved_settings.provider,
+        answerer_model_id=resolved_settings.model_id,
+        answerer_temperature=resolved_settings.temperature,
+        language=resolved_settings.language,
+    )
+    results_mgr = ResultsManager(
+        base,
+        PipelineType.ANSWERS,
+        pipeline_id=pipeline_id,
+    )
+    results_mgr.create_run(
+        config,
+        input_source=str(retrieve_outputs),
+        checkpoint_filename=CHECKPOINT_FILENAME,
+    )
+    checkpoint = CheckpointManager(results_mgr.run_dir / CHECKPOINT_FILENAME)
+
+    retrieval_paths = sorted(retrieve_outputs.glob("*/*/*.json"))
+    checkpoint.set_total_files(len(retrieval_paths))
+
+    written = 0
+    resumed = 0
+    failed = 0
+    for record_path in retrieval_paths:
+        # Path shape: <outputs>/<arm>/<source>/<safe_qa_pair_id>.json.
+        # parts[-3:] = (arm, source, file). Use them as the checkpoint
+        # key so resume is cross-arm safe.
+        ckpt_key = _checkpoint_key(record_path)
+        if checkpoint.is_completed(ckpt_key):
+            resumed += 1
+            continue
+
+        try:
+            retrieval = RetrievalRecord.load(record_path)
+        except (OSError, ValidationError) as exc:
+            logger.warning("Skipping unreadable RetrievalRecord %s: %s", record_path, exc)
+            checkpoint.mark_failed(ckpt_key, f"load failed: {exc}")
+            failed += 1
+            continue
+
+        try:
+            answer_record = _answer_one(
+                answerer=answerer,
+                retrieval=retrieval,
+                passage_text=passage_text,
+                resolved_settings=resolved_settings,
+            )
+        except Exception as exc:
+            # Per-record isolation: log + continue. Mirrors the
+            # retrieve batch runner's rationale (Protocol abstraction
+            # over the LLMClient internals).
+            logger.exception(
+                "Answer failed for arm=%s qa_pair_id=%s: %s",
+                _arm_from_path(record_path),
+                retrieval.qa_pair_id,
+                exc,
+            )
+            checkpoint.mark_failed(ckpt_key, str(exc))
+            failed += 1
+            continue
+
+        output_path = _output_path(
+            outputs_dir=results_mgr.outputs_dir,
+            record_path=record_path,
+        )
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        answer_record.save(output_path)
+        checkpoint.mark_completed(ckpt_key)
+        written += 1
+
+    results_mgr.update_progress(written + resumed, failed, len(retrieval_paths))
+    results_mgr.complete_run(success=(failed == 0))
+
+    return AnswerBatchResult(
+        pipeline_id=results_mgr.metadata.pipeline_id,
+        run_dir=str(results_mgr.run_dir),
+        answers_written=written,
+        answers_resumed=resumed,
+        answers_failed=failed,
+    )
+
+
+def _build_llm_client(settings: AnswererSettings) -> LLMClient:
+    """Construct the unified LLMClient from answerer settings.
+
+    Surfaces a clear ``RuntimeError`` if a cloud provider is requested
+    without its API key env var set; ollama gets a free pass per
+    :class:`LLMClient` convention.
+    """
+    try:
+        provider_enum = LLMProvider(settings.provider)
+    except ValueError as exc:
+        raise ValueError(
+            f"Unknown answerer provider {settings.provider!r}. "
+            f"Valid: {[p.value for p in LLMProvider]}."
+        ) from exc
+
+    api_key = os.environ.get(settings.api_key_env)
+    if not api_key and provider_enum is not LLMProvider.OLLAMA:
+        raise RuntimeError(
+            f"Answerer provider {settings.provider!r} requires {settings.api_key_env} "
+            f"to be set. Either set it, or switch ARANDU_ANSWERER_PROVIDER to 'ollama'."
+        )
+
+    return LLMClient(
+        provider=provider_enum,
+        model_id=settings.model_id,
+        api_key=api_key,
+        base_url=settings.base_url,
+    )
+
+
+def _build_passage_text_map(*, base: Path, pipeline_id: str) -> dict[str, str]:
+    """Aggregate every resolvable ``chunk_id → text`` for the run.
+
+    Walks each chunker view dir under ``chunk/outputs/`` (BM25 arms)
+    plus the ``passage_offsets.json`` sidecar (atlas-rag / khop_passage
+    arms). triple-arm payloads bypass this map entirely.
+    """
+    chunk_outputs_root = base / pipeline_id / "chunk" / "outputs"
+    chunk_dirs: list[Path] = []
+    if chunk_outputs_root.exists():
+        chunk_dirs = [p for p in chunk_outputs_root.iterdir() if p.is_dir()]
+
+    passage_offsets_path = base / pipeline_id / "kg" / "outputs" / "passage_offsets.json"
+    transcription_dir = base / pipeline_id / "transcription" / "outputs"
+
+    return build_passage_text_map(
+        chunk_dirs=chunk_dirs,
+        passage_offsets_path=passage_offsets_path,
+        transcription_dir=transcription_dir,
+    )
+
+
+def _answer_one(
+    *,
+    answerer: AnswererClient,
+    retrieval: RetrievalRecord,
+    passage_text: dict[str, str],
+    resolved_settings: AnswererSettings,
+) -> AnswerRecord:
+    """Pack passages, run the answerer, and assemble the persistable record."""
+    packed = pack_passages(
+        retrieval.passages,
+        passage_text=passage_text,
+        max_context_tokens=resolved_settings.max_context_tokens,
+        prompt_overhead_tokens=resolved_settings.prompt_overhead_tokens,
+        max_answer_tokens=resolved_settings.max_tokens,
+    )
+    output, meta = answerer.answer(
+        question=retrieval.question,
+        passage_texts=[text for _, text in packed],
+    )
+
+    answer_record = AnswerRecord(
+        # RetrievalRecord fields (re-emit so the joined record is self-contained):
+        qa_pair_id=retrieval.qa_pair_id,
+        question=retrieval.question,
+        retriever_id=retrieval.retriever_id,
+        chunker_id=retrieval.chunker_id,
+        top_k=retrieval.top_k,
+        passages=retrieval.passages,
+        elapsed_ms=retrieval.elapsed_ms,
+        is_answerable=retrieval.is_answerable,
+        # AnswerRecord-specific fields:
+        answer_text=output.answer,
+        abstained=output.abstained,
+        rationale=output.rationale,
+        answerer_model=resolved_settings.model_id,
+        answerer_temperature=resolved_settings.temperature,
+        answerer_meta={
+            **meta,
+            "packed_passages": len(packed),
+            "language": resolved_settings.language,
+        },
+    )
+    return answer_record
+
+
+def _checkpoint_key(record_path: Path) -> str:
+    """Composite key: ``<arm>::<source>::<file_stem>``."""
+    parts = record_path.parts
+    return f"{parts[-3]}::{parts[-2]}::{record_path.stem}"
+
+
+def _arm_from_path(record_path: Path) -> str:
+    """Extract the arm name from a retrieve-stage record path."""
+    return record_path.parts[-3]
+
+
+def _output_path(*, outputs_dir: Path, record_path: Path) -> Path:
+    """Mirror the input layout: ``<outputs>/<arm>/<source>/<file>.json``."""
+    return outputs_dir / record_path.parts[-3] / record_path.parts[-2] / record_path.name

--- a/src/arandu/shared/rag/answer/batch.py
+++ b/src/arandu/shared/rag/answer/batch.py
@@ -208,6 +208,17 @@ def _build_llm_client(settings: AnswererSettings) -> LLMClient:
             f"to be set. Either set it, or switch ARANDU_ANSWERER_PROVIDER to 'ollama'."
         )
 
+    # The 'custom' provider exists specifically to point at a non-default
+    # OpenAI-compatible endpoint. Without an explicit base URL the
+    # underlying LLMClient would silently fall back to OpenAI's default,
+    # potentially sending data to the wrong provider — mirrors the guard
+    # in `transcription/judge.py`.
+    if provider_enum is LLMProvider.CUSTOM and not settings.base_url:
+        raise ValueError(
+            "provider='custom' requires a base URL. Set ARANDU_ANSWERER_BASE_URL "
+            "or pass base_url=... explicitly."
+        )
+
     return LLMClient(
         provider=provider_enum,
         model_id=settings.model_id,

--- a/src/arandu/shared/rag/answer/packer.py
+++ b/src/arandu/shared/rag/answer/packer.py
@@ -1,0 +1,108 @@
+"""Token-budget passage packing for the answerer (spec §5.5).
+
+Greedy by rank: include passages in their ranked order until the
+remaining budget can't fit the next one. The first passage that exceeds
+the budget is dropped (along with all lower-ranked passages) — we do
+NOT truncate a passage mid-sentence, since partial passages tend to
+confuse the answerer's grounding more than missing ones.
+
+Token cost is estimated via a simple character-count heuristic
+(:func:`estimate_tokens`). For thesis purposes this is accurate enough:
+budget overruns of ~10% just mean the answerer's context window is
+slightly under-utilized, not that it explodes. Swapping in a real
+tokenizer (tiktoken / transformers AutoTokenizer) would be a follow-up
+if the heuristic proves too loose in practice.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from arandu.shared.rag.schemas import RetrievedPassage
+
+
+# Portuguese text averages ~3 characters per token under GPT-style BPE
+# tokenizers (vs ~4 for English). Use 3 as the conservative (pessimistic)
+# estimate so the budget calculation overshoots on space rather than
+# undershooting and blowing the context window.
+_CHARS_PER_TOKEN = 3
+
+
+def estimate_tokens(text: str) -> int:
+    """Estimate token count via character-count heuristic.
+
+    Returns at least 1 for any non-empty text so a stream of tiny
+    passages doesn't compound floor-division errors into a free pass.
+    """
+    if not text:
+        return 0
+    return max(1, len(text) // _CHARS_PER_TOKEN)
+
+
+def pack_passages(
+    passages: list[RetrievedPassage],
+    *,
+    passage_text: dict[str, str],
+    max_context_tokens: int,
+    prompt_overhead_tokens: int,
+    max_answer_tokens: int,
+) -> list[tuple[RetrievedPassage, str]]:
+    """Pack passages by rank until the token budget is exhausted.
+
+    Args:
+        passages: Ranked retrieval results. Iterated in given order
+            (caller should pre-sort by ``rank`` ascending if it isn't
+            already).
+        passage_text: ``chunk_id`` → resolved text. The caller resolves
+            this externally (via :class:`ChunkResolver`, the
+            ``passage_offsets`` sidecar, or the ``payload`` field) so
+            the packer stays simple and unit-testable. A passage whose
+            ``chunk_id`` has no entry in this map is silently skipped.
+        max_context_tokens: Total context window of the answerer LLM.
+        prompt_overhead_tokens: Reserved budget for the rendered prompt
+            (everything except passage content).
+        max_answer_tokens: Reserved budget for the answerer's response.
+
+    Returns:
+        A list of ``(passage, text)`` tuples, prefix of the input
+        ranking, that fits within the budget. Always preserves rank
+        order.
+
+    Raises:
+        ValueError: If the budget is non-positive (caller misconfiguration).
+    """
+    budget = max_context_tokens - prompt_overhead_tokens - max_answer_tokens
+    if budget <= 0:
+        raise ValueError(
+            f"Token budget exhausted before packing: max_context_tokens="
+            f"{max_context_tokens} - prompt_overhead_tokens={prompt_overhead_tokens} "
+            f"- max_answer_tokens={max_answer_tokens} = {budget}. "
+            f"Reduce prompt_overhead_tokens or max_answer_tokens, or raise max_context_tokens."
+        )
+
+    out: list[tuple[RetrievedPassage, str]] = []
+    used = 0
+    for p in passages:
+        text = _resolve_passage_text(p, passage_text)
+        if text is None:
+            continue
+        cost = estimate_tokens(text)
+        if used + cost > budget:
+            break
+        out.append((p, text))
+        used += cost
+    return out
+
+
+def _resolve_passage_text(passage: RetrievedPassage, passage_text: dict[str, str]) -> str | None:
+    """Look up the text for ``passage`` — prefer payload, fall back to chunk_id map.
+
+    Triple-emitting retrievers (e.g. :class:`KHopTripleRetriever`)
+    populate ``RetrievedPassage.payload`` because their output isn't a
+    sliceable chunk; we honour that override here so the packer
+    doesn't need to know which retriever produced what.
+    """
+    if passage.payload is not None:
+        return passage.payload
+    return passage_text.get(passage.chunk_id)

--- a/src/arandu/shared/rag/answer/prompts.py
+++ b/src/arandu/shared/rag/answer/prompts.py
@@ -1,0 +1,46 @@
+"""Jinja prompt loader for the answerer.
+
+Templates live next to this module under ``prompts/answerer_<lang>.j2``.
+Two templates ship today: ``pt`` (Portuguese, project default) and
+``en`` (English).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Literal
+
+from jinja2 import Environment, FileSystemLoader, StrictUndefined, select_autoescape
+
+_PROMPTS_DIR = Path(__file__).parent / "prompts"
+
+# select_autoescape is irrelevant for plain-text JSON output but the
+# Jinja docs recommend it as a default — keeps surprise out of edits.
+_ENV = Environment(
+    loader=FileSystemLoader(str(_PROMPTS_DIR)),
+    autoescape=select_autoescape(disabled_extensions=("j2",), default_for_string=False),
+    undefined=StrictUndefined,
+    keep_trailing_newline=True,
+)
+
+
+def render_prompt(
+    language: Literal["pt", "en"],
+    *,
+    question: str,
+    passages: list[str],
+) -> str:
+    """Render the answerer prompt for ``language`` with the given passages.
+
+    Args:
+        language: ``"pt"`` or ``"en"``. Selects which template file is loaded.
+        question: The natural-language query to put into the prompt.
+        passages: Pre-resolved passage texts in rank order. May be empty
+            (the template handles the "no passages" branch via Jinja).
+
+    Returns:
+        The rendered prompt string ready to feed to
+        :meth:`LLMClient.generate_structured`.
+    """
+    template = _ENV.get_template(f"answerer_{language}.j2")
+    return template.render(question=question, passages=passages)

--- a/src/arandu/shared/rag/answer/prompts/answerer_en.j2
+++ b/src/arandu/shared/rag/answer/prompts/answerer_en.j2
@@ -1,0 +1,27 @@
+You are an assistant answering questions about riverine communities in southern Brazil
+affected by critical climate events. Use ONLY the provided passages as your source.
+
+RULES:
+1. If the passages contain the needed information, answer concisely and faithfully to the text.
+2. If the passages do NOT contain sufficient information, or if the question asks for something
+   outside the passages' scope, refuse to answer. Set abstained=true and briefly explain what
+   was missing.
+3. Do not use external knowledge. Do not invent names, dates, or events.
+4. Always provide a brief rationale, even when answering.
+
+QUESTION:
+{{ question }}
+
+RETRIEVED PASSAGES:
+{% if passages %}
+{% for p in passages %}
+[Passage {{ loop.index }}]:
+{{ p }}
+
+{% endfor %}
+{% else %}
+(no passages were retrieved)
+{% endif %}
+
+Respond in structured JSON with fields: abstained (boolean), answer (string or null),
+rationale (string).

--- a/src/arandu/shared/rag/answer/prompts/answerer_pt.j2
+++ b/src/arandu/shared/rag/answer/prompts/answerer_pt.j2
@@ -1,0 +1,26 @@
+Você é um assistente que responde perguntas sobre comunidades ribeirinhas do sul do Brasil
+afetadas por eventos climáticos críticos. Use APENAS as passagens fornecidas como fonte.
+
+REGRAS:
+1. Se as passagens contêm a informação necessária, responda de forma concisa e fiel ao texto.
+2. Se as passagens NÃO contêm informação suficiente, ou se a pergunta pede algo fora do escopo
+   das passagens, recuse-se a responder. Defina abstained=true e explique brevemente o que faltava.
+3. Não use conhecimento externo. Não invente nomes, datas, ou eventos.
+4. Sempre forneça uma justificativa breve em rationale, mesmo quando responder.
+
+PERGUNTA:
+{{ question }}
+
+PASSAGENS RECUPERADAS:
+{% if passages %}
+{% for p in passages %}
+[Passagem {{ loop.index }}]:
+{{ p }}
+
+{% endfor %}
+{% else %}
+(nenhuma passagem foi recuperada)
+{% endif %}
+
+Responda em JSON estruturado com os campos: abstained (boolean), answer (string ou null),
+rationale (string).

--- a/src/arandu/shared/rag/answer/resolver.py
+++ b/src/arandu/shared/rag/answer/resolver.py
@@ -1,0 +1,138 @@
+"""Build the ``chunk_id → text`` map an answerer batch needs.
+
+Three retriever families produce three chunk_id namespaces:
+
+- **BM25** emits chunks from a :class:`ChunkSet` view; the text is the
+  source transcription sliced by ``(start_char, end_char)``.
+- **atlas-rag / khop_passage** emit synthesised passage_ids of the form
+  ``"<source_file_id>:<chunk_index>"`` that join to the
+  :class:`PassageOffsetSidecar` from PR #100. The text is again the
+  source transcription sliced by the sidecar's offsets.
+- **khop_triple** emits ``"triple:<sha>"`` ids with the text already
+  in ``RetrievedPassage.payload``; the packer handles those without
+  consulting this map.
+
+This helper unions the BM25 + atlas-rag/khop_passage resolutions into a
+single dict the batch driver can pass to :func:`pack_passages`.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from arandu.kg.passage_offsets import PassageOffsetSidecar
+from arandu.shared.chunking.schemas import ChunkSet
+from arandu.shared.schemas import EnrichedRecord
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def build_passage_text_map(
+    *,
+    chunk_dirs: list[Path],
+    passage_offsets_path: Path | None,
+    transcription_dir: Path,
+) -> dict[str, str]:
+    """Build the ``chunk_id → text`` map for one run.
+
+    Args:
+        chunk_dirs: Per-chunker view directories under
+            ``results/<id>/chunk/outputs/`` whose ChunkSets back the
+            BM25 arm. Each directory holds ``<file_id>.json`` files
+            with single-view ChunkSets (per PR #99's convention).
+        passage_offsets_path: Path to
+            ``results/<id>/kg/outputs/passage_offsets.json``. ``None``
+            (or non-existent) is tolerated when only BM25 arms ran.
+        transcription_dir: ``results/<id>/transcription/outputs/`` —
+            holds the source :class:`EnrichedRecord` files whose
+            ``transcription_text`` is sliced by both BM25 chunks and
+            the atlas-rag sidecar offsets.
+
+    Returns:
+        A flat ``chunk_id → text`` dict. Unresolvable references
+        (missing source transcription, missing sidecar entry, …) are
+        omitted; downstream packing simply drops them.
+    """
+    text_by_file_id = _load_transcriptions(transcription_dir)
+
+    out: dict[str, str] = {}
+    for chunk_dir in chunk_dirs:
+        if not chunk_dir.exists():
+            logger.debug("Chunk dir absent: %s; skipping for BM25 resolution.", chunk_dir)
+            continue
+        out.update(_bm25_chunks_to_text(chunk_dir, text_by_file_id))
+
+    if passage_offsets_path is not None and passage_offsets_path.exists():
+        out.update(_atlas_passages_to_text(passage_offsets_path, text_by_file_id))
+    else:
+        logger.debug(
+            "passage_offsets.json absent (%s); atlas-rag / khop_passage chunk_ids "
+            "won't resolve to text.",
+            passage_offsets_path,
+        )
+
+    return out
+
+
+def _load_transcriptions(transcription_dir: Path) -> dict[str, str]:
+    """Build ``file_id → transcription_text`` from a transcription outputs dir."""
+    if not transcription_dir.exists():
+        logger.warning(
+            "Transcription outputs absent at %s; no passage text will resolve.",
+            transcription_dir,
+        )
+        return {}
+    out: dict[str, str] = {}
+    for path in sorted(transcription_dir.glob("*.json")):
+        try:
+            record = EnrichedRecord.model_validate_json(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError) as exc:
+            logger.warning("Skipping unreadable transcription %s: %s", path, exc)
+            continue
+        out[record.file_id] = record.transcription_text
+    return out
+
+
+def _bm25_chunks_to_text(chunk_dir: Path, text_by_file_id: dict[str, str]) -> dict[str, str]:
+    """Resolve every chunk in ``chunk_dir`` to its substring of the source transcription."""
+    out: dict[str, str] = {}
+    for path in sorted(chunk_dir.glob("*.json")):
+        try:
+            chunk_set = ChunkSet.model_validate_json(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError) as exc:
+            logger.warning("Skipping unreadable ChunkSet %s: %s", path, exc)
+            continue
+        full_text = text_by_file_id.get(chunk_set.source_file_id)
+        if full_text is None:
+            logger.debug(
+                "No transcription for ChunkSet %s (file_id=%s); skipping its chunks.",
+                path,
+                chunk_set.source_file_id,
+            )
+            continue
+        for chunks in chunk_set.views.values():
+            for chunk in chunks:
+                out[chunk.chunk_id] = full_text[chunk.start_char : chunk.end_char]
+    return out
+
+
+def _atlas_passages_to_text(
+    passage_offsets_path: Path, text_by_file_id: dict[str, str]
+) -> dict[str, str]:
+    """Resolve atlas-rag/khop_passage passage_ids to their source-text substrings."""
+    try:
+        sidecar = PassageOffsetSidecar.load(passage_offsets_path)
+    except (OSError, ValueError) as exc:
+        logger.warning("Skipping unreadable passage_offsets %s: %s", passage_offsets_path, exc)
+        return {}
+    out: dict[str, str] = {}
+    for offset in sidecar.offsets:
+        full_text = text_by_file_id.get(offset.source_file_id)
+        if full_text is None:
+            continue
+        out[offset.passage_id] = full_text[offset.start_char : offset.end_char]
+    return out

--- a/src/arandu/shared/rag/answer/schemas.py
+++ b/src/arandu/shared/rag/answer/schemas.py
@@ -1,0 +1,48 @@
+"""Schemas for the answerer module.
+
+:class:`AnswererOutput` is what the LLM produces (the raw JSON shape).
+It's distinct from :class:`arandu.shared.rag.schemas.AnswerRecord`,
+which is the persisted record that combines this output with the
+upstream :class:`RetrievalRecord` provenance.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, Field, model_validator
+
+if TYPE_CHECKING:
+    from typing import Self
+
+
+class AnswererOutput(BaseModel):
+    """Structured output from the Answerer LLM (spec §5.2).
+
+    The Answerer is asked to return JSON with three fields. The
+    consistency validator enforces the spec's mutual-exclusion rule:
+    when the model abstains, ``answer`` must be ``None``; when it
+    answers, ``answer`` must be non-empty.
+
+    Attributes:
+        abstained: Whether the model refused to answer (insufficient
+            evidence in the passages, or the question is out of scope).
+        answer: Verbatim answer text. ``None`` iff ``abstained`` is
+            True; non-empty otherwise.
+        rationale: Always populated. When ``abstained`` is False, this
+            justifies the answer; when True, it explains what was
+            missing from the passages.
+    """
+
+    abstained: bool
+    answer: str | None = Field(default=None)
+    rationale: str = Field(..., min_length=1)
+
+    @model_validator(mode="after")
+    def _consistency(self) -> Self:
+        """Enforce ``answer is None iff abstained is True``."""
+        if self.abstained and self.answer is not None:
+            raise ValueError("abstained=True requires answer=None")
+        if not self.abstained and (self.answer is None or not self.answer.strip()):
+            raise ValueError("abstained=False requires a non-empty answer")
+        return self

--- a/src/arandu/shared/rag/answer/settings.py
+++ b/src/arandu/shared/rag/answer/settings.py
@@ -1,0 +1,63 @@
+"""Pydantic settings for the answerer (env prefix ``ARANDU_ANSWERER_``)."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import Field, field_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class AnswererSettings(BaseSettings):
+    """LLM + budget settings for the Answerer (spec §5.7).
+
+    Held constant across retrieval arms in a single run — this is what
+    isolates retrieval-quality from generation-quality in the
+    cross-arm comparison (spec §5.1).
+
+    Attributes:
+        provider: LLM provider for the answerer. Defaults to ``"ollama"``
+            because the project's primary thesis runs use a local
+            qwen3:14b; flip to ``"openai"`` for cloud runs.
+        model_id: Model identifier; defaults to ``"qwen3:14b"``.
+        api_key_env: Env var holding the API key. Ignored for ollama.
+        base_url: Base URL override. When ``None``, the per-provider
+            default in :class:`LLMClient` is used.
+        temperature: Sampling temperature. Default 0.2 — low for
+            deterministic answers across reruns (the benchmark must
+            be reproducible).
+        max_tokens: Max tokens in the answerer's response. Default 1024.
+        language: ``"pt"`` or ``"en"``. Selects the prompt template.
+        top_k: Maximum passages to consider per question. Defaults to
+            10; the actual count may be smaller after token-budget
+            packing.
+        max_context_tokens: Total context window for the answerer.
+            Default 8192. Used by :func:`pack_passages` to compute the
+            passage budget.
+        prompt_overhead_tokens: Reserved budget for the rendered
+            prompt template (everything except the passage list). The
+            spec's default of 350 is an empirical estimate for the
+            project's prompt; tune downward if larger questions blow
+            the budget.
+    """
+
+    provider: str = Field(default="ollama")
+    model_id: str = Field(default="qwen3:14b")
+    api_key_env: str = Field(default="OPENAI_API_KEY")
+    base_url: str | None = Field(default=None)
+    temperature: float = Field(default=0.2, ge=0.0, le=2.0)
+    max_tokens: int = Field(default=1024, gt=0)
+    language: Literal["pt", "en"] = Field(default="pt")
+    top_k: int = Field(default=10, ge=1)
+    max_context_tokens: int = Field(default=8192, gt=0)
+    prompt_overhead_tokens: int = Field(default=350, ge=0)
+
+    model_config = SettingsConfigDict(env_prefix="ARANDU_ANSWERER_", extra="ignore")
+
+    @field_validator("provider", mode="before")
+    @classmethod
+    def _normalize_provider(cls, v: str) -> str:
+        """Lowercase the provider so env-var case (Ollama, OPENAI) doesn't break dispatch."""
+        if isinstance(v, str):
+            return v.lower()
+        return v

--- a/src/arandu/shared/schemas.py
+++ b/src/arandu/shared/schemas.py
@@ -196,6 +196,7 @@ class PipelineType(StrEnum):
     CEP = "cep"
     KG = "kg"
     RETRIEVE = "retrieve"
+    ANSWERS = "answers"
     EVALUATION = "evaluation"
 
 

--- a/tests/shared/rag/answer/test_answerer.py
+++ b/tests/shared/rag/answer/test_answerer.py
@@ -1,0 +1,75 @@
+"""Tests for ``AnswererClient`` — the retry-with-temperature-bump contract."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from arandu.shared.llm_client import StructuredOutputError
+from arandu.shared.rag.answer.answerer import AnswererClient
+from arandu.shared.rag.answer.schemas import AnswererOutput
+from arandu.shared.rag.answer.settings import AnswererSettings
+
+
+def _settings(temperature: float = 0.2) -> AnswererSettings:
+    return AnswererSettings(temperature=temperature, _env_file=None)
+
+
+class TestAnswererClient:
+    def test_first_attempt_success(self) -> None:
+        # Happy path: LLM returns valid structured output on the first try.
+        client = MagicMock()
+        client.generate_structured.return_value = AnswererOutput(
+            abstained=False, answer="Maria mora em Itaqui.", rationale="Per P1."
+        )
+        ac = AnswererClient(llm_client=client, settings=_settings())
+
+        output, meta = ac.answer(question="Onde Maria mora?", passage_texts=["P1: Itaqui."])
+
+        assert output.abstained is False
+        assert output.answer == "Maria mora em Itaqui."
+        assert meta["attempts"] == 1
+        assert meta["final_temperature"] == 0.2
+        assert "fallback_reason" not in meta
+        client.generate_structured.assert_called_once()
+
+    def test_retries_with_bumped_temperature(self) -> None:
+        # First two attempts raise StructuredOutputError; third succeeds.
+        # Verify each call's temperature increases by 0.1 per the spec.
+        client = MagicMock()
+        client.generate_structured.side_effect = [
+            StructuredOutputError("malformed"),
+            StructuredOutputError("malformed"),
+            AnswererOutput(abstained=True, answer=None, rationale="insufficient evidence"),
+        ]
+        ac = AnswererClient(llm_client=client, settings=_settings(temperature=0.2))
+
+        output, meta = ac.answer(question="q", passage_texts=[])
+
+        assert output.abstained is True
+        assert meta["attempts"] == 3
+        # Third attempt = 0.2 + 0.1 + 0.1 = 0.4.
+        assert meta["final_temperature"] == pytest.approx(0.4)
+        # Each call seen the cumulative bump.
+        temps = [c.kwargs["temperature"] for c in client.generate_structured.call_args_list]
+        assert temps == pytest.approx([0.2, 0.3, 0.4])
+
+    def test_fallback_after_three_failed_attempts(self) -> None:
+        # All three attempts fail. Spec §5.6 says return the abstained
+        # fallback with `fallback_reason` recorded in meta.
+        client = MagicMock()
+        client.generate_structured.side_effect = StructuredOutputError("malformed")
+        ac = AnswererClient(llm_client=client, settings=_settings())
+
+        output, meta = ac.answer(question="q", passage_texts=[])
+
+        assert output.abstained is True
+        assert output.answer is None
+        assert "3 retries" in output.rationale
+        assert meta["attempts"] == 3
+        assert meta["fallback_reason"] == output.rationale
+        assert client.generate_structured.call_count == 3
+
+
+# `pytest.approx` is imported lazily so the rest of the module can use
+# plain `assert ==`; placing this near the bottom keeps test reads focused.
+import pytest  # noqa: E402

--- a/tests/shared/rag/answer/test_batch.py
+++ b/tests/shared/rag/answer/test_batch.py
@@ -1,0 +1,194 @@
+"""Integration test for the answerer batch runner.
+
+Stubs the LLMClient + the embedder factory so the test doesn't actually
+hit a model — verifies the read/write contract end-to-end against a
+fixture run that mimics what ``arandu retrieve`` produces.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from arandu.shared.rag.answer.batch import run_answer_batch
+from arandu.shared.rag.answer.schemas import AnswererOutput
+from arandu.shared.rag.answer.settings import AnswererSettings
+from arandu.shared.rag.schemas import AnswerRecord, RetrievalRecord, RetrievedPassage
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _seed_retrieve_outputs(base: Path, pipeline_id: str = "run_x") -> None:
+    """Lay out a minimal retrieve stage with one record under the null arm."""
+    out_dir = base / pipeline_id / "retrieve" / "outputs" / "null" / "cep"
+    out_dir.mkdir(parents=True)
+    record = RetrievalRecord(
+        qa_pair_id="src_a:chk_00:0",
+        question="Onde Maria mora?",
+        retriever_id="null",
+        chunker_id="cep_4k",
+        top_k=5,
+        passages=[],
+        elapsed_ms=1.5,
+        is_answerable=True,
+    )
+    record.save(out_dir / "src_a__chk_00__0.json")
+
+
+class TestRunAnswerBatch:
+    def test_end_to_end_with_mocked_llm(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The answerer's only network seam is `LLMClient.generate_structured`.
+        # Stub it via the unified LLMClient patch — confirms the batch runner
+        # reads retrieval records, runs the answerer, writes AnswerRecords
+        # with the right layout, and updates the checkpoint.
+        _seed_retrieve_outputs(tmp_path)
+        # Need an api_key for the runtime check, but we patch the LLMClient
+        # construction so the value doesn't matter.
+        monkeypatch.setenv("OPENAI_API_KEY", "test")
+        settings = AnswererSettings(provider="ollama")  # no api key needed
+
+        with patch("arandu.shared.rag.answer.batch.LLMClient") as mock_llm_cls:
+            inner = MagicMock()
+            inner.generate_structured.return_value = AnswererOutput(
+                abstained=True,
+                answer=None,
+                rationale="No passages retrieved (null arm).",
+            )
+            mock_llm_cls.return_value = inner
+
+            result = run_answer_batch(
+                pipeline_id="run_x",
+                settings=settings,
+                base_dir=tmp_path,
+            )
+
+        assert result.answers_written == 1
+        assert result.answers_failed == 0
+
+        # Layout mirror: <outputs>/null/cep/<file>.json
+        answer_path = (
+            tmp_path / "run_x" / "answers" / "outputs" / "null" / "cep" / "src_a__chk_00__0.json"
+        )
+        assert answer_path.exists()
+
+        # Round-trip via AnswerRecord schema.
+        rec = AnswerRecord.load(answer_path)
+        assert rec.qa_pair_id == "src_a:chk_00:0"
+        assert rec.retriever_id == "null"
+        assert rec.abstained is True
+        assert rec.answer_text is None
+        assert rec.rationale.startswith("No passages")
+        # answerer_meta carries the audit trail.
+        assert rec.answerer_meta["attempts"] == 1
+        assert rec.answerer_meta["language"] == "pt"
+        assert rec.answerer_meta["packed_passages"] == 0
+        assert rec.answerer_model == "qwen3:14b"
+
+    def test_missing_retrieve_dir_raises(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        with pytest.raises(FileNotFoundError, match="Retrieve outputs not found"):
+            run_answer_batch(
+                pipeline_id="never_retrieved",
+                settings=AnswererSettings(provider="ollama"),
+                base_dir=tmp_path,
+            )
+
+    def test_resume_skips_completed_records(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _seed_retrieve_outputs(tmp_path)
+        settings = AnswererSettings(provider="ollama")
+
+        with patch("arandu.shared.rag.answer.batch.LLMClient") as mock_llm_cls:
+            inner = MagicMock()
+            inner.generate_structured.return_value = AnswererOutput(
+                abstained=True, answer=None, rationale="r"
+            )
+            mock_llm_cls.return_value = inner
+
+            first = run_answer_batch(pipeline_id="run_x", settings=settings, base_dir=tmp_path)
+            assert first.answers_written == 1
+
+            second = run_answer_batch(pipeline_id="run_x", settings=settings, base_dir=tmp_path)
+            assert second.answers_written == 0
+            assert second.answers_resumed == 1
+
+
+class TestBuildLlmClientFailures:
+    def test_unknown_provider_raises(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        _seed_retrieve_outputs(tmp_path)
+        settings = AnswererSettings.model_construct(
+            provider="not_a_real_provider",
+            model_id="x",
+            api_key_env="OPENAI_API_KEY",
+            base_url=None,
+            temperature=0.2,
+            max_tokens=1024,
+            language="pt",
+            top_k=10,
+            max_context_tokens=8192,
+            prompt_overhead_tokens=350,
+        )
+        with pytest.raises(ValueError, match="Unknown answerer provider"):
+            run_answer_batch(pipeline_id="run_x", settings=settings, base_dir=tmp_path)
+
+    def test_cloud_provider_without_api_key_raises(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _seed_retrieve_outputs(tmp_path)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        settings = AnswererSettings(provider="openai", api_key_env="OPENAI_API_KEY")
+        with pytest.raises(RuntimeError, match="OPENAI_API_KEY"):
+            run_answer_batch(pipeline_id="run_x", settings=settings, base_dir=tmp_path)
+
+
+class TestPayloadPassThrough:
+    def test_triple_payload_routed_to_answerer(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Triple-arm records carry passage content in `payload`. The
+        # batch runner's pack_passages call must surface it to the
+        # answerer prompt without consulting the chunk_id resolver.
+        out_dir = tmp_path / "run_x" / "retrieve" / "outputs" / "khop_triple" / "cep"
+        out_dir.mkdir(parents=True)
+        passage = RetrievedPassage(
+            chunk_id="triple:abc123",
+            rank=0,
+            score=1.0,
+            payload="Maria --[vive_em]--> Itaqui",
+        )
+        record = RetrievalRecord(
+            qa_pair_id="src_a:chk_00:0",
+            question="Onde Maria mora?",
+            retriever_id="khop_triple",
+            chunker_id="cep_4k",
+            top_k=5,
+            passages=[passage],
+            elapsed_ms=2.5,
+            is_answerable=True,
+        )
+        record.save(out_dir / "src_a__chk_00__0.json")
+        settings = AnswererSettings(provider="ollama")
+
+        with patch("arandu.shared.rag.answer.batch.LLMClient") as mock_llm_cls:
+            inner = MagicMock()
+            inner.generate_structured.return_value = AnswererOutput(
+                abstained=False,
+                answer="Maria mora em Itaqui.",
+                rationale="Triple says vive_em → Itaqui.",
+            )
+            mock_llm_cls.return_value = inner
+            run_answer_batch(
+                pipeline_id="run_x",
+                settings=settings,
+                base_dir=tmp_path,
+            )
+            # Verify the answerer saw the triple's payload in its prompt.
+            prompt = inner.generate_structured.call_args.kwargs["prompt"]
+            assert "Maria --[vive_em]--> Itaqui" in prompt

--- a/tests/shared/rag/answer/test_batch.py
+++ b/tests/shared/rag/answer/test_batch.py
@@ -1,8 +1,8 @@
 """Integration test for the answerer batch runner.
 
-Stubs the LLMClient + the embedder factory so the test doesn't actually
-hit a model — verifies the read/write contract end-to-end against a
-fixture run that mimics what ``arandu retrieve`` produces.
+Stubs ``LLMClient`` so the tests never actually hit a model — verifies
+the read/write contract end-to-end against a fixture run that mimics
+what ``arandu retrieve`` produces.
 """
 
 from __future__ import annotations
@@ -83,10 +83,18 @@ class TestRunAnswerBatch:
         assert rec.abstained is True
         assert rec.answer_text is None
         assert rec.rationale.startswith("No passages")
-        # answerer_meta carries the audit trail.
+        # answerer_meta carries the audit trail + settings snapshot.
         assert rec.answerer_meta["attempts"] == 1
         assert rec.answerer_meta["language"] == "pt"
         assert rec.answerer_meta["packed_passages"] == 0
+        assert rec.answerer_meta["passages_after_top_k"] == 0
+        # Settings snapshot persisted per-record so attribution survives
+        # even if run-level metadata is later moved or split.
+        assert rec.answerer_meta["provider"] == "ollama"
+        assert rec.answerer_meta["top_k"] == 10
+        assert rec.answerer_meta["max_tokens"] == 1024
+        assert rec.answerer_meta["max_context_tokens"] == 8192
+        assert rec.answerer_meta["prompt_overhead_tokens"] == 350
         assert rec.answerer_model == "qwen3:14b"
 
     def test_missing_retrieve_dir_raises(
@@ -146,6 +154,68 @@ class TestBuildLlmClientFailures:
         settings = AnswererSettings(provider="openai", api_key_env="OPENAI_API_KEY")
         with pytest.raises(RuntimeError, match="OPENAI_API_KEY"):
             run_answer_batch(pipeline_id="run_x", settings=settings, base_dir=tmp_path)
+
+
+class TestTopKCap:
+    def test_settings_top_k_caps_passages_before_packing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Retrieval returned 5 passages; answerer settings top_k=2 must
+        # cap to the first 2 BEFORE the token-budget pack runs. Without
+        # this cap, the answerer would consider every passage the
+        # retriever returned regardless of the per-run constant from
+        # spec §5.7's ARANDU_ANSWERER_TOP_K.
+        out_dir = tmp_path / "run_x" / "retrieve" / "outputs" / "khop_triple" / "cep"
+        out_dir.mkdir(parents=True)
+        passages = [
+            RetrievedPassage(
+                chunk_id=f"triple:{i}",
+                rank=i,
+                score=1.0 - i * 0.1,
+                payload=f"triple_payload_{i}",
+            )
+            for i in range(5)
+        ]
+        record = RetrievalRecord(
+            qa_pair_id="src_a:chk_00:0",
+            question="q",
+            retriever_id="khop_triple",
+            chunker_id="cep_4k",
+            top_k=5,
+            passages=passages,
+            elapsed_ms=1.0,
+            is_answerable=True,
+        )
+        record.save(out_dir / "src_a__chk_00__0.json")
+        settings = AnswererSettings(provider="ollama", top_k=2)
+
+        with patch("arandu.shared.rag.answer.batch.LLMClient") as mock_llm_cls:
+            inner = MagicMock()
+            inner.generate_structured.return_value = AnswererOutput(
+                abstained=False, answer="a", rationale="r"
+            )
+            mock_llm_cls.return_value = inner
+            run_answer_batch(pipeline_id="run_x", settings=settings, base_dir=tmp_path)
+
+        # Inspect what the answerer saw — only the first 2 payloads.
+        prompt = inner.generate_structured.call_args.kwargs["prompt"]
+        assert "triple_payload_0" in prompt
+        assert "triple_payload_1" in prompt
+        assert "triple_payload_2" not in prompt
+        assert "triple_payload_3" not in prompt
+
+        # And the persisted record reflects the cap.
+        rec = AnswerRecord.load(
+            tmp_path
+            / "run_x"
+            / "answers"
+            / "outputs"
+            / "khop_triple"
+            / "cep"
+            / "src_a__chk_00__0.json"
+        )
+        assert rec.answerer_meta["passages_after_top_k"] == 2
+        assert rec.answerer_meta["top_k"] == 2
 
 
 class TestPayloadPassThrough:

--- a/tests/shared/rag/answer/test_batch.py
+++ b/tests/shared/rag/answer/test_batch.py
@@ -155,6 +155,20 @@ class TestBuildLlmClientFailures:
         with pytest.raises(RuntimeError, match="OPENAI_API_KEY"):
             run_answer_batch(pipeline_id="run_x", settings=settings, base_dir=tmp_path)
 
+    def test_custom_provider_without_base_url_raises(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The 'custom' provider exists to point LLMClient at a
+        # non-default OpenAI-compatible endpoint. Without an explicit
+        # base_url, LLMClient would silently fall back to OpenAI proper —
+        # potentially leaking benchmark data to the wrong provider.
+        # Mirrors the guard in transcription/judge.py.
+        _seed_retrieve_outputs(tmp_path)
+        monkeypatch.setenv("OPENAI_API_KEY", "test")
+        settings = AnswererSettings(provider="custom", base_url=None)
+        with pytest.raises(ValueError, match="provider='custom' requires a base URL"):
+            run_answer_batch(pipeline_id="run_x", settings=settings, base_dir=tmp_path)
+
 
 class TestTopKCap:
     def test_settings_top_k_caps_passages_before_packing(

--- a/tests/shared/rag/answer/test_packer.py
+++ b/tests/shared/rag/answer/test_packer.py
@@ -1,0 +1,113 @@
+"""Tests for ``pack_passages`` — token-budget passage packing."""
+
+from __future__ import annotations
+
+import pytest
+
+from arandu.shared.rag.answer.packer import estimate_tokens, pack_passages
+from arandu.shared.rag.schemas import RetrievedPassage
+
+
+def _passage(chunk_id: str, rank: int = 0, payload: str | None = None) -> RetrievedPassage:
+    return RetrievedPassage(chunk_id=chunk_id, rank=rank, score=1.0, payload=payload)
+
+
+class TestEstimateTokens:
+    def test_empty_string_zero_tokens(self) -> None:
+        assert estimate_tokens("") == 0
+
+    def test_non_empty_at_least_one(self) -> None:
+        # Floor-division could yield 0 for tiny strings; the helper
+        # guards against that so a long list of one-char passages
+        # doesn't get a free pass through the budget.
+        assert estimate_tokens("a") == 1
+
+    def test_chars_per_token_heuristic(self) -> None:
+        # 30 chars / 3 chars-per-token = 10 tokens.
+        text = "x" * 30
+        assert estimate_tokens(text) == 10
+
+
+class TestPackPassages:
+    def test_packs_within_budget(self) -> None:
+        passages = [_passage("c1"), _passage("c2"), _passage("c3")]
+        passage_text = {"c1": "x" * 30, "c2": "x" * 30, "c3": "x" * 30}
+        # budget = 100 - 30 - 30 = 40 → fits one passage (10 tokens),
+        # the second would push to 20 ≤ 40 so it fits too, the third
+        # pushes to 30 ≤ 40 so all three fit.
+        result = pack_passages(
+            passages,
+            passage_text=passage_text,
+            max_context_tokens=100,
+            prompt_overhead_tokens=30,
+            max_answer_tokens=30,
+        )
+        assert [p.chunk_id for p, _ in result] == ["c1", "c2", "c3"]
+
+    def test_stops_when_budget_exhausted(self) -> None:
+        # Each passage = 30 chars = 10 tokens. Budget = 15. First fits
+        # (used=10); second would push to 20 > 15 → break (NOT truncated).
+        passages = [_passage("c1"), _passage("c2"), _passage("c3")]
+        passage_text = {"c1": "x" * 30, "c2": "x" * 30, "c3": "x" * 30}
+        result = pack_passages(
+            passages,
+            passage_text=passage_text,
+            max_context_tokens=100,
+            prompt_overhead_tokens=80,
+            max_answer_tokens=5,
+        )
+        assert [p.chunk_id for p, _ in result] == ["c1"]
+
+    def test_payload_overrides_chunk_id_lookup(self) -> None:
+        # khop_triple-style passage: payload set, chunk_id is opaque.
+        # The map doesn't carry the chunk_id; packer falls back to payload.
+        p = _passage("triple:abc", payload="Maria --[vive_em]--> Itaqui")
+        result = pack_passages(
+            [p],
+            passage_text={},  # no chunk_id resolution available
+            max_context_tokens=100,
+            prompt_overhead_tokens=10,
+            max_answer_tokens=10,
+        )
+        assert len(result) == 1
+        assert result[0][1] == "Maria --[vive_em]--> Itaqui"
+
+    def test_unresolvable_chunk_id_silently_skipped(self) -> None:
+        # Passage points at a chunk_id the resolver doesn't know about
+        # (corpus drift, missing sidecar, etc.). Packer drops it without
+        # raising — downstream count just reflects fewer packed passages.
+        passages = [_passage("missing"), _passage("present")]
+        passage_text = {"present": "x" * 30}
+        result = pack_passages(
+            passages,
+            passage_text=passage_text,
+            max_context_tokens=100,
+            prompt_overhead_tokens=10,
+            max_answer_tokens=10,
+        )
+        assert [p.chunk_id for p, _ in result] == ["present"]
+
+    def test_non_positive_budget_raises(self) -> None:
+        # Catches operator misconfig (e.g. prompt_overhead so large that
+        # nothing fits) at the entry point with a clear error.
+        with pytest.raises(ValueError, match="Token budget exhausted before packing"):
+            pack_passages(
+                [_passage("c1")],
+                passage_text={"c1": "x" * 30},
+                max_context_tokens=50,
+                prompt_overhead_tokens=40,
+                max_answer_tokens=20,
+            )
+
+    def test_empty_passages_returns_empty(self) -> None:
+        # The "no passages retrieved" path (Null arm, empty entity-link)
+        # must produce a clean empty list — the answerer's prompt
+        # template handles that branch separately.
+        result = pack_passages(
+            [],
+            passage_text={},
+            max_context_tokens=100,
+            prompt_overhead_tokens=10,
+            max_answer_tokens=10,
+        )
+        assert result == []

--- a/tests/shared/rag/answer/test_prompts.py
+++ b/tests/shared/rag/answer/test_prompts.py
@@ -1,0 +1,51 @@
+"""Tests for the answerer Jinja prompt loader."""
+
+from __future__ import annotations
+
+import pytest
+
+from arandu.shared.rag.answer.prompts import render_prompt
+
+
+class TestRenderPrompt:
+    def test_pt_renders_question(self) -> None:
+        out = render_prompt("pt", question="Onde Maria mora?", passages=[])
+        assert "Onde Maria mora?" in out
+        assert "REGRAS:" in out
+
+    def test_en_renders_question(self) -> None:
+        out = render_prompt("en", question="Where does Maria live?", passages=[])
+        assert "Where does Maria live?" in out
+        assert "RULES:" in out
+
+    def test_no_passages_branch(self) -> None:
+        # The template's else-branch tells the model no passages were
+        # retrieved (so it knows to abstain). Lock the wording.
+        pt = render_prompt("pt", question="q", passages=[])
+        assert "nenhuma passagem foi recuperada" in pt
+        en = render_prompt("en", question="q", passages=[])
+        assert "no passages were retrieved" in en
+
+    def test_passages_enumerated_in_order(self) -> None:
+        # Jinja loop renders ranked passages in order with 1-indexed
+        # labels. Lock that ordering so future template edits don't
+        # silently shuffle them.
+        out = render_prompt(
+            "pt",
+            question="q",
+            passages=["primeira passagem", "segunda passagem", "terceira passagem"],
+        )
+        idx_p1 = out.index("primeira passagem")
+        idx_p2 = out.index("segunda passagem")
+        idx_p3 = out.index("terceira passagem")
+        assert idx_p1 < idx_p2 < idx_p3
+        assert "[Passagem 1]" in out
+        assert "[Passagem 2]" in out
+        assert "[Passagem 3]" in out
+
+    def test_unknown_language_raises(self) -> None:
+        # The Literal type covers this at typecheck time, but at runtime
+        # we want the StrictUndefined / TemplateNotFound path to fire
+        # cleanly rather than silently rendering an empty body.
+        with pytest.raises(Exception, match="answerer_fr"):
+            render_prompt("fr", question="q", passages=[])  # type: ignore[arg-type]

--- a/tests/shared/rag/answer/test_schemas.py
+++ b/tests/shared/rag/answer/test_schemas.py
@@ -1,0 +1,36 @@
+"""Tests for ``AnswererOutput`` — locks the spec §5.2 consistency invariant."""
+
+from __future__ import annotations
+
+import pytest
+
+from arandu.shared.rag.answer.schemas import AnswererOutput
+
+
+class TestAnswererOutputConsistency:
+    def test_abstained_with_answer_rejected(self) -> None:
+        with pytest.raises(ValueError, match="abstained=True requires answer=None"):
+            AnswererOutput(abstained=True, answer="something", rationale="r")
+
+    def test_not_abstained_without_answer_rejected(self) -> None:
+        with pytest.raises(ValueError, match="abstained=False requires a non-empty answer"):
+            AnswererOutput(abstained=False, answer=None, rationale="r")
+
+    def test_not_abstained_with_whitespace_answer_rejected(self) -> None:
+        with pytest.raises(ValueError, match="abstained=False requires a non-empty answer"):
+            AnswererOutput(abstained=False, answer="   \n  ", rationale="r")
+
+    def test_abstained_with_null_answer_valid(self) -> None:
+        out = AnswererOutput(abstained=True, answer=None, rationale="not enough evidence")
+        assert out.abstained is True
+        assert out.answer is None
+
+    def test_not_abstained_with_text_answer_valid(self) -> None:
+        out = AnswererOutput(abstained=False, answer="Maria mora em Itaqui.", rationale="P1")
+        assert out.abstained is False
+        assert out.answer == "Maria mora em Itaqui."
+
+    def test_rationale_required(self) -> None:
+        # Always populated per spec — even when answering.
+        with pytest.raises(ValueError):
+            AnswererOutput(abstained=False, answer="x", rationale="")

--- a/tests/shared/rag/answer/test_settings.py
+++ b/tests/shared/rag/answer/test_settings.py
@@ -1,0 +1,42 @@
+"""Tests for ``AnswererSettings`` — env-var parsing + provider normalization."""
+
+from __future__ import annotations
+
+import pytest
+
+from arandu.shared.rag.answer.settings import AnswererSettings
+
+
+class TestAnswererSettings:
+    def test_defaults(self) -> None:
+        # Defaults match the spec §5.7: ollama provider, qwen3:14b, low
+        # temperature for deterministic answers, Portuguese prompt.
+        s = AnswererSettings(_env_file=None)
+        assert s.provider == "ollama"
+        assert s.model_id == "qwen3:14b"
+        assert s.temperature == 0.2
+        assert s.max_tokens == 1024
+        assert s.language == "pt"
+        assert s.top_k == 10
+        assert s.max_context_tokens == 8192
+        assert s.prompt_overhead_tokens == 350
+
+    def test_provider_lowercased(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Env-var case doesn't trip up LLMProvider() dispatch.
+        monkeypatch.setenv("ARANDU_ANSWERER_PROVIDER", "OpenAI")
+        assert AnswererSettings().provider == "openai"
+
+    def test_env_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ARANDU_ANSWERER_MODEL_ID", "gpt-4o-mini")
+        monkeypatch.setenv("ARANDU_ANSWERER_TEMPERATURE", "0.5")
+        monkeypatch.setenv("ARANDU_ANSWERER_LANGUAGE", "en")
+        s = AnswererSettings()
+        assert s.model_id == "gpt-4o-mini"
+        assert s.temperature == 0.5
+        assert s.language == "en"
+
+    def test_temperature_bounds(self) -> None:
+        with pytest.raises(ValueError):
+            AnswererSettings(temperature=-0.1)
+        with pytest.raises(ValueError):
+            AnswererSettings(temperature=2.5)

--- a/tests/shared/test_results_manager.py
+++ b/tests/shared/test_results_manager.py
@@ -770,7 +770,16 @@ class TestPipelineType:
 
     def test_all_pipeline_types(self) -> None:
         """Test all pipeline types are defined."""
-        expected = {"transcription", "chunk", "qa", "cep", "kg", "retrieve", "evaluation"}
+        expected = {
+            "transcription",
+            "chunk",
+            "qa",
+            "cep",
+            "kg",
+            "retrieve",
+            "answers",
+            "evaluation",
+        }
         actual = {p.value for p in PipelineType}
         assert actual == expected
 


### PR DESCRIPTION
## Summary

Phase C's generation stage. Reads \`RetrievalRecord\` artifacts produced by \`arandu retrieve\` and emits \`AnswerRecord\` artifacts under \`results/<id>/answers/outputs/<arm>/<source>/\`. Same LLM, same prompt, same temperature across every arm in a single run — the methodological constant from spec §5.1 that isolates retrieval-quality from generation-quality in the cross-arm comparison.

\`arandu retrieve\` + \`arandu answer\` together produce the per-arm answer records the judges will consume.

## Module layout (\`arandu.shared.rag.answer\`)

| File | Purpose |
| --- | --- |
| \`schemas.py\` | \`AnswererOutput\` LLM response with spec §5.2 mutual-exclusion (\`abstained ⇔ answer is None\`) |
| \`prompts/answerer_{pt,en}.j2\` | Jinja templates per spec §5.3/§5.4 |
| \`prompts.py\` | Jinja loader with StrictUndefined |
| \`packer.py\` | \`pack_passages()\` per §5.5: greedy by rank, drop-at-boundary, chars/3 token heuristic, honours \`payload\` for triple-arm |
| \`resolver.py\` | Builds run-wide \`chunk_id → text\` map by unioning ChunkSets + \`passage_offsets.json\` sidecar |
| \`answerer.py\` | \`AnswererClient\` wraps \`LLMClient.generate_structured\` with §5.6 retry: 3 attempts, temperature += 0.1 each, fallback to abstained=True |
| \`settings.py\` | \`AnswererSettings\` (env prefix \`ARANDU_ANSWERER_\`) per §5.7 |
| \`batch.py\` | \`run_answer_batch()\` with ResultsManager + composite checkpoint keys |

Plus \`src/arandu/cli/answer.py\` (Typer CLI) and a new \`PipelineType.ANSWERS\` enum value.

## Usage

\`\`\`bash
# Prerequisites
arandu retrieve --id my-run [--arm null --arm bm25 ...]

# Defaults: ollama / qwen3:14b / temp 0.2 / pt / top_k 10
arandu answer --id my-run

# Or switch to a cloud provider
ARANDU_ANSWERER_PROVIDER=openai \\
ARANDU_ANSWERER_MODEL_ID=gpt-4o-mini \\
OPENAI_API_KEY=... \\
arandu answer --id my-run
\`\`\`

## Spec contracts locked

- **§5.1 Held constant**: a single \`AnswererSettings\` snapshot drives every record in a run; recorded on each \`AnswerRecord\` for reruns to attribute outputs back to configuration.
- **§5.2 Mutual exclusion**: validator on \`AnswererOutput\` rejects both \`abstained=True with answer\` and \`abstained=False with empty answer\`.
- **§5.5 Budget**: \`pack_passages()\` enforces \`max_context_tokens - prompt_overhead_tokens - max_answer_tokens\` budget; non-positive budget raises with clear hint.
- **§5.6 Retry-bump-fallback**: 3 attempts at temperatures \`t, t+0.1, t+0.2\`; on exhaustion, return abstained=True with \`fallback_reason\` in \`answerer_meta\`.
- **§5.7 Env vars**: \`ARANDU_ANSWERER_PROVIDER/MODEL_ID/TEMPERATURE/MAX_TOKENS/LANGUAGE/TOP_K/MAX_CONTEXT_TOKENS/PROMPT_OVERHEAD_TOKENS\`.

## Coverage

**37 new tests**, 6 modules:
- \`schemas\` (6): consistency invariant, whitespace rejection, rationale required
- \`packer\` (8): chars-per-token, payload override, unresolvable skip, budget exhaustion, empty inputs
- \`prompts\` (5): PT/EN render, no-passages branch, enumeration order, unknown-language failure
- \`answerer\` (3): happy path, retry-with-bumped-temperature, fallback-after-3-fails
- \`settings\` (4): defaults, provider lowercase, env override, temperature bounds
- \`batch\` (8): end-to-end with mocked LLM, missing retrieve dir, resume, provider validation, missing API key, triple-payload pass-through

**1336 passed, 1 skipped** locally. Lint + format clean.

## Out of scope (follow-ups)

- A real tokenizer (tiktoken / transformers AutoTokenizer) instead of the chars/3 heuristic — sufficient for thesis budget estimation, can tighten if it proves loose
- Concurrent workers (defaults to sequential per Phase B convention)
- The atlas-rag arm's prompt-overhead may need separate tuning since its retrieved passages are atlas-rag-formatted (headers); revisit if the answerer truncates too aggressively in practice

## Test plan

- [ ] \`uv run pytest tests/shared/rag/answer/\` — green (33 tests)
- [ ] \`uv run pytest\` — full suite green (1336 + 1 skipped)
- [ ] \`uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/\` — clean
- [ ] CLI registered: \`uv run arandu answer --help\`
- [ ] End-to-end smoke against test-kg-04 (manual): \`arandu retrieve --id test-kg-04 --arm null --top-k 5 && arandu answer --id test-kg-04\` produces \`AnswerRecord\` files under \`results/test-kg-04/answers/outputs/null/cep/\`