### PR TITLE
feat(rag): rag-analysis CLI - cross-arm KC table (spec §8)

### DIFF
--- a/docs/user-guide/rag-analysis.md
+++ b/docs/user-guide/rag-analysis.md
@@ -1,0 +1,230 @@
+# RAG Analysis Guide
+
+Interpret the cross-arm comparison report produced by `arandu rag-analysis`.
+
+This is the **last** stage of the Phase C RAG-evaluation pipeline. It reads
+the judged answers from `arandu judge-answers` and emits per-arm tables you
+can compare across retrieval strategies (BM25, atlas-rag, NetworkX subgraph,
+NetworkX triple, Null).
+
+> **What changed (2026-05-26)**: Phase C replaces the legacy QA / KG
+> evaluation tables ([evaluation.md](evaluation.md)) for retrieval comparison.
+> Use `rag-analysis` when you want to compare retrievers; use `evaluation.md`
+> for QA-dataset and KG-graph quality (unchanged).
+
+---
+
+## Quick start
+
+```bash
+# Prerequisite: judge_answers must be populated
+arandu judge-answers --id <pipeline_id>
+
+# Aggregate and report
+arandu rag-analysis --id <pipeline_id>
+```
+
+Outputs land under `results/<pipeline_id>/analysis/outputs/`:
+
+```
+analysis/
+└── outputs/
+    ├── report.json    # Typed AnalysisReport (programmatic)
+    └── tables.md      # Thesis-ready Markdown tables
+```
+
+The CEP outputs (`results/<pipeline_id>/cep/outputs/`) are consulted for
+Bloom-level and question-type cross-cuts. If they're absent the run still
+succeeds — you get the joint table only and a warning in the log.
+
+---
+
+## The four classes (TA / TC / FA / FC)
+
+Every judged answer is sorted into one of four cells by crossing two binary
+signals: the question's ground-truth `is_answerable` flag and a unified
+"abstained" signal that combines the answerer's `abstained` field with the
+abstention judge's verdict.
+
+|                      | **Answerable**                             | **Non-answerable**                |
+|----------------------|--------------------------------------------|-----------------------------------|
+| **Abstained**        | False Abstention (**FA**) — over-cautious  | True Abstention (**TA**) — correct |
+| **Committed**        | True Commitment (**TC**) — scored by KC    | False Commitment (**FC**) — **hallucination** |
+
+A record is "abstained for analysis" only when **both** the answerer and the
+judge agree. If they disagree the record is treated as committed (the
+disagreement is independently logged by `judge-answers` in
+`abstention_audit.jsonl`).
+
+**`unknown`** is a fifth class for records where the abstention judge errored
+or did not run. Unknown records are kept in the confusion-matrix count but
+excluded from rate and mean denominators — they would otherwise skew the
+headline numbers from a single judge failure.
+
+---
+
+## Reading Table 1 (per-arm joint metrics)
+
+This is the headline thesis table. Each row is one retrieval arm; columns
+are the per-arm rates and means.
+
+| Column | Direction | Formula | What it tells you |
+|---|---|---|---|
+| **n_TA+TC** | — | TC + FA count | Size of the answerable subset that produced data (TC) plus over-caution (FA). |
+| **n_TA+FC** | — | TA + FC count | Size of the non-answerable subset that produced data. |
+| **KC ↑** | higher is better | `mean(correctness × faithfulness)` over TC | Knowledge coverage — does the system get the *right* answer using the *retrieved* context? |
+| **Hallucination ↓** | lower is better | `FC / (FC + TA)` | When the question is unanswerable, how often does the system fabricate an answer? |
+| **Over-caution ↓** | lower is better | `FA / (FA + TC)` | When the question is answerable, how often does the system refuse? |
+| **Abstention F1 ↑** | higher is better | F1 over TA / FA / FC | One number summarising "how well does this arm know when to abstain?" |
+| **Passage cov ↑** | higher is better | `mean(passage_coverage)` | LLM-judged: do the retrieved passages contain the supporting evidence? |
+
+Each proportion cell is rendered as `value [lower, upper]` — the Wilson 95%
+confidence interval. `n/a` means the denominator was zero (e.g. an arm with
+no non-answerable items has no hallucination rate to compute).
+
+### What "good" looks like
+
+| Metric | Strong | Weak |
+|---|---|---|
+| KC | > 0.65 | < 0.40 |
+| Hallucination | < 0.10 | > 0.30 |
+| Over-caution | < 0.15 | > 0.40 |
+| Abstention F1 | > 0.75 | < 0.50 |
+| Passage coverage | > 0.65 | < 0.40 |
+
+These ranges are heuristic targets for the ethnographic corpus — they are
+**not** thresholds for accepting an arm. The thesis claim is comparative
+(arm A vs arm B on the same benchmark), not absolute.
+
+### Knowledge Coverage (KC) deep dive
+
+`KC = correctness × faithfulness` is the multiplicative form preserved from
+methodology §6. The product means **both factors must be high** to score
+well:
+
+- Correctness 0.9, faithfulness 0.4 → KC 0.36 (faithful retrieval, wrong answer).
+- Correctness 0.5, faithfulness 0.9 → KC 0.45 (close answer, supported by passages).
+- Correctness 0.9, faithfulness 0.9 → KC 0.81 (the target).
+
+The mean is taken over **TC records only** — abstained records don't contribute
+to KC because there's no answer to score.
+
+### The hallucination / over-caution trade-off
+
+These two rates are in tension. An arm that abstains aggressively will have
+**low hallucination** (almost no FC) but **high over-caution** (lots of FA).
+An arm that never abstains will have the opposite. **Abstention F1 ↑**
+balances them into one number; use the individual rates when you care about
+the underlying behaviour.
+
+---
+
+## Reading confidence intervals
+
+The Wilson 95% CI tells you the range in which the true proportion likely
+sits given the sample size. Two rules of thumb:
+
+1. **Overlapping CIs ≈ no significant difference.** If arm A reports
+   `0.12 [0.08, 0.17]` and arm B reports `0.15 [0.10, 0.20]`, the bands
+   overlap — you can't conclude A < B from this run.
+2. **Narrow CIs require many records.** If `n_TA+FC = 50` the bands will
+   be wide regardless of how low the rate is. Don't read precision into
+   small strata.
+
+For rigorous pairwise testing the spec calls for paired McNemar's tests
+(§8.4), which is deferred to a follow-up PR (needs `statsmodels`). For now,
+treat CI overlap as the test.
+
+---
+
+## Bloom-stratified KC (Table 2)
+
+The same KC metric, re-computed per Bloom-taxonomy level
+(`remember`, `understand`, `apply`, `analyze`, `evaluate`, `create`).
+
+Use this table to answer questions like:
+
+- *Does the triple-arm retriever underperform on lower-Bloom (factual recall) questions?*
+- *Does atlas-rag's advantage concentrate on multi-hop (`analyze` / `evaluate`) items?*
+
+Cells are scalar KC means — no confidence intervals here. With small per-stratum
+`n`, single-cell comparisons are suggestive, not conclusive.
+
+---
+
+## Question-type-stratified KC (Table 3)
+
+Same idea, stratified by `question_type` (`factual`, `conceptual`,
+`temporal`, `entity`). Useful when the thesis claim concerns *what kind* of
+question favours which retrieval paradigm.
+
+---
+
+## Output schema (`report.json`)
+
+```python
+from arandu.shared.rag.analysis.report import AnalysisReport
+
+report = AnalysisReport.model_validate_json(
+    open("results/<id>/analysis/outputs/report.json").read()
+)
+
+for arm_id, metrics in report.joint.items():
+    print(arm_id, metrics.confusion, metrics.knowledge_coverage.mean)
+    # metrics.hallucination_rate.{value, ci_lower, ci_upper, numerator, denominator}
+    # metrics.over_cautiousness_rate.*
+    # metrics.abstention_precision.*  /  abstention_recall.*  /  abstention_f1
+    # metrics.answer_correctness.{mean, n}  /  answer_faithfulness  /  passage_coverage
+
+# Cross-cuts
+report.by_bloom["bm25"]["remember"].knowledge_coverage.mean
+report.by_question_type["atlas_rag"]["conceptual"].knowledge_coverage.mean
+```
+
+`ProportionMetric.value` is `None` when the denominator is zero (rendered as
+`n/a` in `tables.md`). `MeanMetric.mean` is `None` when no records contributed.
+
+---
+
+## When something looks wrong
+
+| Symptom | Likely cause | What to check |
+|---|---|---|
+| All `n/a` in a row | The arm produced no judged records | `results/<id>/judge_answers/outputs/<arm>/` exists and is non-empty |
+| Many `unknown` records | Abstention judge errored frequently | Inspect `judge_answers/outputs/abstention_audit.jsonl` and the judge logs |
+| Bloom / question-type tables missing | CEP outputs absent | `results/<id>/cep/outputs/` should hold the `QARecordCEP` files |
+| KC near 0 for every arm | Either correctness or faithfulness collapsed | Sample a few judged records and inspect their `validation.stage_results` |
+| Hallucination = 0 but over-caution = 1.0 | Answerer abstaining on everything | Check the Answerer prompt and the abstention threshold (`ARANDU_JUDGE_ANSWERS_*`) |
+| All arms tie within CI | Either sample too small or arms truly indistinguishable | Raise the benchmark size; check `n_TA+TC` and `n_TA+FC` in Table 1 |
+
+---
+
+## Known limitations
+
+These are intentional first-cut scope — tracked for follow-up PRs:
+
+- **Paired McNemar's tests** for arm-vs-arm significance (spec §8.4). Needs
+  `statsmodels`; today, use CI overlap as a heuristic.
+- **Paired bootstrap CIs** for continuous metrics (spec §8.5). Same
+  dependency story.
+- **Methodology §6 composite score** (`0.40·KC + 0.20·D_e + 0.20·RD + 0.20·CR`).
+  Needs KG structural metrics joined onto the analysis report.
+- **`--compare-runs run_a run_b`** for cross-run composite-score comparison.
+- **Matplotlib figures.**
+- **Non-answerable item handling**: the benchmark currently includes
+  non-answerable items only when the CEP / non-answerable source provides
+  them; the wider experiment is tracked under the `nonanswerable-experiment` task.
+- **Deterministic offset-overlap** (`offset_coverage`) was dropped from the
+  judge stage during PR #110 review — the thesis question is semantic, not
+  extractive, and the triple-arm retriever has no character offsets. The
+  judge LLM scores passage coverage instead; `passage_coverage` in the
+  report comes from that judge.
+
+---
+
+## Related
+
+- [CLI reference](cli-reference.md) — full command list.
+- [Evaluation](evaluation.md) — legacy QA + KG evaluation (unchanged).
+- [`docs/superpowers/specs/2026-05-08-phase-c-rag-evaluation-design.md`](../superpowers/specs/2026-05-08-phase-c-rag-evaluation-design.md)
+  — Phase C design spec; §8 is the analysis-stage methodology.

--- a/docs/user-guide/rag-analysis.md
+++ b/docs/user-guide/rag-analysis.md
@@ -70,8 +70,8 @@ are the per-arm rates and means.
 
 | Column | Direction | Formula | What it tells you |
 |---|---|---|---|
-| **n_TA+TC** | — | TC + FA count | Size of the answerable subset that produced data (TC) plus over-caution (FA). |
-| **n_TA+FC** | — | TA + FC count | Size of the non-answerable subset that produced data. |
+| **n_answerable** | — | `TC + FA` | Number of judged answerable items for this arm (whether the system committed or abstained). |
+| **n_nonanswerable** | — | `TA + FC` | Number of judged non-answerable items for this arm. |
 | **KC ↑** | higher is better | `mean(correctness × faithfulness)` over TC | Knowledge coverage — does the system get the *right* answer using the *retrieved* context? |
 | **Hallucination ↓** | lower is better | `FC / (FC + TA)` | When the question is unanswerable, how often does the system fabricate an answer? |
 | **Over-caution ↓** | lower is better | `FA / (FA + TC)` | When the question is answerable, how often does the system refuse? |
@@ -127,7 +127,7 @@ sits given the sample size. Two rules of thumb:
 1. **Overlapping CIs ≈ no significant difference.** If arm A reports
    `0.12 [0.08, 0.17]` and arm B reports `0.15 [0.10, 0.20]`, the bands
    overlap — you can't conclude A < B from this run.
-2. **Narrow CIs require many records.** If `n_TA+FC = 50` the bands will
+2. **Narrow CIs require many records.** If `n_nonanswerable = 50` the bands will
    be wide regardless of how low the rate is. Don't read precision into
    small strata.
 

--- a/docs/user-guide/rag-analysis.md
+++ b/docs/user-guide/rag-analysis.md
@@ -35,7 +35,7 @@ analysis/
 
 The CEP outputs (`results/<pipeline_id>/cep/outputs/`) are consulted for
 Bloom-level and question-type cross-cuts. If they're absent the run still
-succeeds — you get the joint table only and a warning in the log.
+succeeds - you get the joint table only and a warning in the log.
 
 ---
 
@@ -48,8 +48,8 @@ abstention judge's verdict.
 
 |                      | **Answerable**                             | **Non-answerable**                |
 |----------------------|--------------------------------------------|-----------------------------------|
-| **Abstained**        | False Abstention (**FA**) — over-cautious  | True Abstention (**TA**) — correct |
-| **Committed**        | True Commitment (**TC**) — scored by KC    | False Commitment (**FC**) — **hallucination** |
+| **Abstained**        | False Abstention (**FA**) - over-cautious  | True Abstention (**TA**) - correct |
+| **Committed**        | True Commitment (**TC**) - scored by KC    | False Commitment (**FC**) - **hallucination** |
 
 A record is "abstained for analysis" only when **both** the answerer and the
 judge agree. If they disagree the record is treated as committed (the
@@ -58,7 +58,7 @@ disagreement is independently logged by `judge-answers` in
 
 **`unknown`** is a fifth class for records where the abstention judge errored
 or did not run. Unknown records are kept in the confusion-matrix count but
-excluded from rate and mean denominators — they would otherwise skew the
+excluded from rate and mean denominators - they would otherwise skew the
 headline numbers from a single judge failure.
 
 ---
@@ -70,15 +70,15 @@ are the per-arm rates and means.
 
 | Column | Direction | Formula | What it tells you |
 |---|---|---|---|
-| **n_answerable** | — | `TC + FA` | Number of judged answerable items for this arm (whether the system committed or abstained). |
-| **n_nonanswerable** | — | `TA + FC` | Number of judged non-answerable items for this arm. |
-| **KC ↑** | higher is better | `mean(correctness × faithfulness)` over TC | Knowledge coverage — does the system get the *right* answer using the *retrieved* context? |
+| **n_answerable** | - | `TC + FA` | Number of judged answerable items for this arm (whether the system committed or abstained). |
+| **n_nonanswerable** | - | `TA + FC` | Number of judged non-answerable items for this arm. |
+| **KC ↑** | higher is better | `mean(correctness × faithfulness)` over TC | Knowledge coverage - does the system get the *right* answer using the *retrieved* context? |
 | **Hallucination ↓** | lower is better | `FC / (FC + TA)` | When the question is unanswerable, how often does the system fabricate an answer? |
 | **Over-caution ↓** | lower is better | `FA / (FA + TC)` | When the question is answerable, how often does the system refuse? |
 | **Abstention F1 ↑** | higher is better | F1 over TA / FA / FC | One number summarising "how well does this arm know when to abstain?" |
 | **Passage cov ↑** | higher is better | `mean(passage_coverage)` | LLM-judged: do the retrieved passages contain the supporting evidence? |
 
-Each proportion cell is rendered as `value [lower, upper]` — the Wilson 95%
+Each proportion cell is rendered as `value [lower, upper]` - the Wilson 95%
 confidence interval. `n/a` means the denominator was zero (e.g. an arm with
 no non-answerable items has no hallucination rate to compute).
 
@@ -92,7 +92,7 @@ no non-answerable items has no hallucination rate to compute).
 | Abstention F1 | > 0.75 | < 0.50 |
 | Passage coverage | > 0.65 | < 0.40 |
 
-These ranges are heuristic targets for the ethnographic corpus — they are
+These ranges are heuristic targets for the ethnographic corpus - they are
 **not** thresholds for accepting an arm. The thesis claim is comparative
 (arm A vs arm B on the same benchmark), not absolute.
 
@@ -106,7 +106,7 @@ well:
 - Correctness 0.5, faithfulness 0.9 → KC 0.45 (close answer, supported by passages).
 - Correctness 0.9, faithfulness 0.9 → KC 0.81 (the target).
 
-The mean is taken over **TC records only** — abstained records don't contribute
+The mean is taken over **TC records only** - abstained records don't contribute
 to KC because there's no answer to score.
 
 ### The hallucination / over-caution trade-off
@@ -126,7 +126,7 @@ sits given the sample size. Two rules of thumb:
 
 1. **Overlapping CIs ≈ no significant difference.** If arm A reports
    `0.12 [0.08, 0.17]` and arm B reports `0.15 [0.10, 0.20]`, the bands
-   overlap — you can't conclude A < B from this run.
+   overlap - you can't conclude A < B from this run.
 2. **Narrow CIs require many records.** If `n_nonanswerable = 50` the bands will
    be wide regardless of how low the rate is. Don't read precision into
    small strata.
@@ -147,7 +147,7 @@ Use this table to answer questions like:
 - *Does the triple-arm retriever underperform on lower-Bloom (factual recall) questions?*
 - *Does atlas-rag's advantage concentrate on multi-hop (`analyze` / `evaluate`) items?*
 
-Cells are scalar KC means — no confidence intervals here. With small per-stratum
+Cells are scalar KC means - no confidence intervals here. With small per-stratum
 `n`, single-cell comparisons are suggestive, not conclusive.
 
 ---
@@ -201,7 +201,7 @@ report.by_question_type["atlas_rag"]["conceptual"].knowledge_coverage.mean
 
 ## Known limitations
 
-These are intentional first-cut scope — tracked for follow-up PRs:
+These are intentional first-cut scope - tracked for follow-up PRs:
 
 - **Paired McNemar's tests** for arm-vs-arm significance (spec §8.4). Needs
   `statsmodels`; today, use CI overlap as a heuristic.
@@ -215,7 +215,7 @@ These are intentional first-cut scope — tracked for follow-up PRs:
   non-answerable items only when the CEP / non-answerable source provides
   them; the wider experiment is tracked under the `nonanswerable-experiment` task.
 - **Deterministic offset-overlap** (`offset_coverage`) was dropped from the
-  judge stage during PR #110 review — the thesis question is semantic, not
+  judge stage during PR #110 review - the thesis question is semantic, not
   extractive, and the triple-arm retriever has no character offsets. The
   judge LLM scores passage coverage instead; `passage_coverage` in the
   report comes from that judge.
@@ -224,7 +224,7 @@ These are intentional first-cut scope — tracked for follow-up PRs:
 
 ## Related
 
-- [CLI reference](cli-reference.md) — full command list.
-- [Evaluation](evaluation.md) — legacy QA + KG evaluation (unchanged).
+- [CLI reference](cli-reference.md) - full command list.
+- [Evaluation](evaluation.md) - legacy QA + KG evaluation (unchanged).
 - [`docs/superpowers/specs/2026-05-08-phase-c-rag-evaluation-design.md`](../superpowers/specs/2026-05-08-phase-c-rag-evaluation-design.md)
-  — Phase C design spec; §8 is the analysis-stage methodology.
+  - Phase C design spec; §8 is the analysis-stage methodology.

--- a/src/arandu/cli/app.py
+++ b/src/arandu/cli/app.py
@@ -62,6 +62,7 @@ from arandu.cli.manage import (  # noqa: E402
     run_info,
 )
 from arandu.cli.qa import generate_cep_qa, judge_qa  # noqa: E402
+from arandu.cli.rag_analysis import rag_analysis  # noqa: E402
 from arandu.cli.report import report, serve_report  # noqa: E402
 from arandu.cli.retrieve import retrieve  # noqa: E402
 from arandu.cli.transcribe import (  # noqa: E402
@@ -85,6 +86,7 @@ app.command()(kg_build_retriever_index)
 app.command()(retrieve)
 app.command()(answer)
 app.command()(judge_answers)
+app.command()(rag_analysis)
 app.command()(replicate)
 app.command()(info)
 app.command()(list_runs)

--- a/src/arandu/cli/rag_analysis.py
+++ b/src/arandu/cli/rag_analysis.py
@@ -1,4 +1,4 @@
-"""CLI command: ``arandu rag-analysis`` — emit cross-arm comparison tables.
+"""CLI command: ``arandu rag-analysis`` - emit cross-arm comparison tables.
 
 Aggregates judged :class:`AnswerRecord` artifacts produced by ``arandu
 judge-answers`` into per-arm TA/TC/FA/FC counts, Wilson-95% CIs, and
@@ -37,9 +37,9 @@ def rag_analysis(
 
     Output structure under ``results/<id>/analysis/outputs/``:
 
-    - ``report.json`` — :class:`AnalysisReport` with per-arm
+    - ``report.json`` - :class:`AnalysisReport` with per-arm
       confusion matrices, Wilson CIs, and stratified breakdowns.
-    - ``tables.md`` — human-readable Markdown tables matching the
+    - ``tables.md`` - human-readable Markdown tables matching the
       thesis chapter's reporting layout.
     """
     print_info(f"Run: {pipeline_id}")

--- a/src/arandu/cli/rag_analysis.py
+++ b/src/arandu/cli/rag_analysis.py
@@ -1,0 +1,59 @@
+"""CLI command: ``arandu rag-analysis`` — emit cross-arm comparison tables.
+
+Aggregates judged :class:`AnswerRecord` artifacts produced by ``arandu
+judge-answers`` into per-arm TA/TC/FA/FC counts, Wilson-95% CIs, and
+Bloom + question-type cross-cuts; writes ``report.json`` and
+``tables.md`` under ``results/<id>/analysis/outputs/``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Annotated
+
+import typer
+
+from arandu.shared.rag.analysis.batch import run_rag_analysis_batch
+from arandu.utils.logger import print_error, print_info, print_success, print_warning
+
+logger = logging.getLogger(__name__)
+
+
+def rag_analysis(
+    pipeline_id: Annotated[
+        str,
+        typer.Option(
+            "--id",
+            help=(
+                "Pipeline ID for the run. The judge_answers/ stage must be "
+                "populated. The cep/ stage outputs are consulted for Bloom + "
+                "question-type cross-cuts; absence is non-fatal (joint table "
+                "only)."
+            ),
+        ),
+    ],
+) -> None:
+    """Aggregate judged answers and emit ``report.json`` + ``tables.md``.
+
+    Output structure under ``results/<id>/analysis/outputs/``:
+
+    - ``report.json`` — :class:`AnalysisReport` with per-arm
+      confusion matrices, Wilson CIs, and stratified breakdowns.
+    - ``tables.md`` — human-readable Markdown tables matching the
+      thesis chapter's reporting layout.
+    """
+    print_info(f"Run: {pipeline_id}")
+    try:
+        result = run_rag_analysis_batch(pipeline_id=pipeline_id)
+    except FileNotFoundError as exc:
+        print_error(str(exc))
+        raise typer.Exit(code=1) from exc
+
+    if result.records_unreadable:
+        print_warning(
+            f"Skipped {result.records_unreadable} unreadable judged record(s); check logs."
+        )
+    print_info(f"Arms aggregated: {', '.join(result.arms) or '(none)'}")
+    print_info(f"Judged records loaded: {result.records_loaded}")
+    print_success(f"Wrote {result.report_json}")
+    print_success(f"Wrote {result.tables_md}")

--- a/src/arandu/shared/rag/analysis/__init__.py
+++ b/src/arandu/shared/rag/analysis/__init__.py
@@ -1,0 +1,22 @@
+"""``arandu rag-analysis`` machinery — confusion-matrix + per-arm metrics over judged AnswerRecords.
+
+Spec §8. Public entry points:
+
+- :func:`run_rag_analysis_batch` — CLI driver.
+- :func:`classify_record` — TA/TC/FA/FC labelling per spec §8.1.
+- :func:`wilson_ci` — Wilson 95% confidence interval for a binary proportion.
+
+Out of scope in this PR's first cut (deferred to follow-ups):
+
+- Paired McNemar's tests (needs ``statsmodels`` dep).
+- Paired bootstrap CIs.
+- Methodology §6 composite score (needs KG structural metrics integration).
+- ``--compare-runs`` cross-run hook.
+- Matplotlib figures.
+"""
+
+from arandu.shared.rag.analysis.batch import run_rag_analysis_batch
+from arandu.shared.rag.analysis.classifier import classify_record
+from arandu.shared.rag.analysis.wilson import wilson_ci
+
+__all__ = ["classify_record", "run_rag_analysis_batch", "wilson_ci"]

--- a/src/arandu/shared/rag/analysis/__init__.py
+++ b/src/arandu/shared/rag/analysis/__init__.py
@@ -1,10 +1,10 @@
-"""``arandu rag-analysis`` machinery — confusion-matrix + per-arm metrics over judged AnswerRecords.
+"""``arandu rag-analysis`` machinery - confusion-matrix + per-arm metrics over judged AnswerRecords.
 
 Spec §8. Public entry points:
 
-- :func:`run_rag_analysis_batch` — CLI driver.
-- :func:`classify_record` — TA/TC/FA/FC labelling per spec §8.1.
-- :func:`wilson_ci` — Wilson 95% confidence interval for a binary proportion.
+- :func:`run_rag_analysis_batch` - CLI driver.
+- :func:`classify_record` - TA/TC/FA/FC labelling per spec §8.1.
+- :func:`wilson_ci` - Wilson 95% confidence interval for a binary proportion.
 
 Out of scope in this PR's first cut (deferred to follow-ups):
 

--- a/src/arandu/shared/rag/analysis/batch.py
+++ b/src/arandu/shared/rag/analysis/batch.py
@@ -143,7 +143,7 @@ def _build_cross_cut_metrics(
     """Aggregate per-arm metrics keyed by ``attr`` (bloom_level | question_type).
 
     Records without a cross-cut entry are skipped from the stratified
-    tables — they still appear in the joint aggregator because the
+    tables - they still appear in the joint aggregator because the
     joint slice has no strata dependency.
     """
     nested: dict[str, dict[str, list[AnswerRecord]]] = defaultdict(lambda: defaultdict(list))

--- a/src/arandu/shared/rag/analysis/batch.py
+++ b/src/arandu/shared/rag/analysis/batch.py
@@ -1,0 +1,163 @@
+"""Batch driver for ``arandu rag-analysis`` (spec §8).
+
+Loads every judged :class:`AnswerRecord` under
+``results/<id>/judge_answers/outputs/``, groups by retriever arm,
+joins with CEP cross-cut metadata, and writes ``report.json`` +
+``tables.md`` under ``results/<id>/analysis/outputs/`` via
+:class:`ResultsManager`.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, ValidationError
+
+from arandu.shared.config import ResultsConfig
+from arandu.shared.rag.analysis.loader import CrossCutMeta, build_cross_cut_map
+from arandu.shared.rag.analysis.metrics import ArmMetrics, aggregate_arm
+from arandu.shared.rag.analysis.report import AnalysisReport, write_report
+from arandu.shared.rag.schemas import AnswerRecord
+from arandu.shared.results_manager import ResultsManager
+from arandu.shared.schemas import PipelineType
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+class AnalysisBatchConfig(BaseModel):
+    """Run-metadata snapshot for the analysis stage."""
+
+    pipeline_id: str
+
+
+class AnalysisBatchResult(BaseModel):
+    """Summary of a completed analysis run."""
+
+    pipeline_id: str
+    run_dir: str
+    report_json: str
+    tables_md: str
+    arms: list[str]
+    records_loaded: int
+    records_unreadable: int
+
+
+def run_rag_analysis_batch(
+    pipeline_id: str,
+    *,
+    base_dir: Path | None = None,
+) -> AnalysisBatchResult:
+    """Aggregate judged answers and write the analysis report.
+
+    Args:
+        pipeline_id: Run identifier. The ``judge_answers`` stage must
+            be populated under this id; the ``cep`` stage outputs are
+            consulted for Bloom + question-type cross-cuts and are
+            silently skipped (with a logged warning) when absent.
+        base_dir: Override the project ``results/`` root.
+
+    Returns:
+        :class:`AnalysisBatchResult` summary.
+
+    Raises:
+        FileNotFoundError: ``judge_answers`` outputs are absent.
+    """
+    base = base_dir if base_dir is not None else ResultsConfig().base_dir
+    judged_dir = base / pipeline_id / "judge_answers" / "outputs"
+    if not judged_dir.exists():
+        raise FileNotFoundError(
+            f"judge_answers outputs not found for pipeline_id {pipeline_id!r}: "
+            f"{judged_dir}. Run `arandu judge-answers --id {pipeline_id}` first."
+        )
+
+    cross_cut = build_cross_cut_map(cep_dir=base / pipeline_id / "cep" / "outputs")
+
+    results_mgr = ResultsManager(base, PipelineType.ANALYSIS, pipeline_id=pipeline_id)
+    results_mgr.create_run(
+        AnalysisBatchConfig(pipeline_id=pipeline_id),
+        input_source=str(judged_dir),
+    )
+
+    by_arm, records_loaded, unreadable = _group_by_arm(judged_dir)
+    joint = {
+        arm: aggregate_arm(arm, records, slice_name="joint") for arm, records in by_arm.items()
+    }
+    by_bloom = _build_cross_cut_metrics(by_arm, cross_cut, attr="bloom_level")
+    by_question_type = _build_cross_cut_metrics(by_arm, cross_cut, attr="question_type")
+
+    report = AnalysisReport(
+        pipeline_id=pipeline_id,
+        joint=joint,
+        by_bloom=by_bloom,
+        by_question_type=by_question_type,
+    )
+    json_path, tables_path = write_report(results_mgr.outputs_dir, report)
+
+    results_mgr.update_progress(records_loaded, unreadable, records_loaded + unreadable)
+    results_mgr.complete_run(success=True)
+
+    return AnalysisBatchResult(
+        pipeline_id=pipeline_id,
+        run_dir=str(results_mgr.run_dir),
+        report_json=str(json_path),
+        tables_md=str(tables_path),
+        arms=sorted(by_arm),
+        records_loaded=records_loaded,
+        records_unreadable=unreadable,
+    )
+
+
+def _group_by_arm(judged_dir: Path) -> tuple[dict[str, list[AnswerRecord]], int, int]:
+    """Walk ``<judged_dir>/<arm>/<source>/<file>.json`` → ``{arm: [records]}``.
+
+    Returns the groupings plus ``(records_loaded, unreadable)`` counts so the
+    batch summary can flag corrupted artifacts without failing the whole
+    analysis.
+    """
+    by_arm: dict[str, list[AnswerRecord]] = defaultdict(list)
+    loaded = 0
+    unreadable = 0
+    for path in sorted(judged_dir.glob("*/*/*.json")):
+        try:
+            record = AnswerRecord.load(path)
+        except (OSError, ValidationError) as exc:
+            logger.warning("Skipping unreadable judged AnswerRecord %s: %s", path, exc)
+            unreadable += 1
+            continue
+        by_arm[record.retriever_id].append(record)
+        loaded += 1
+    return dict(by_arm), loaded, unreadable
+
+
+def _build_cross_cut_metrics(
+    by_arm: dict[str, list[AnswerRecord]],
+    cross_cut: dict[str, CrossCutMeta],
+    *,
+    attr: str,
+) -> dict[str, dict[str, ArmMetrics]]:
+    """Aggregate per-arm metrics keyed by ``attr`` (bloom_level | question_type).
+
+    Records without a cross-cut entry are skipped from the stratified
+    tables — they still appear in the joint aggregator because the
+    joint slice has no strata dependency.
+    """
+    nested: dict[str, dict[str, list[AnswerRecord]]] = defaultdict(lambda: defaultdict(list))
+    for arm, records in by_arm.items():
+        for record in records:
+            meta = cross_cut.get(record.qa_pair_id)
+            if meta is None:
+                continue
+            stratum = getattr(meta, attr)
+            nested[arm][stratum].append(record)
+    return {
+        arm: {
+            stratum: aggregate_arm(arm, records, slice_name=f"{attr}={stratum}")
+            for stratum, records in strata.items()
+        }
+        for arm, strata in nested.items()
+    }

--- a/src/arandu/shared/rag/analysis/classifier.py
+++ b/src/arandu/shared/rag/analysis/classifier.py
@@ -21,7 +21,7 @@ The unified abstention rule from spec §6.4:
 
 i.e. both signals must agree to classify a record as abstained. When
 they disagree the record is treated as committed for the confusion
-matrix — that's conservative for hallucination scoring, and the
+matrix - that's conservative for hallucination scoring, and the
 disagreement is independently recorded by the judge_answers stage's
 abstention audit.
 """

--- a/src/arandu/shared/rag/analysis/classifier.py
+++ b/src/arandu/shared/rag/analysis/classifier.py
@@ -1,0 +1,93 @@
+"""Per-record TA/TC/FA/FC classification (spec §8.1).
+
+The joint benchmark labels every record by crossing two binary signals:
+the question's ground-truth ``is_answerable`` flag (set by the
+retrieve stage from the CEP / non-answerable source) and a unified
+"abstained" signal that combines the answerer's structured
+``abstained`` flag with the abstention judge's verdict.
+
+Four classes:
+
+- **TA** (True Abstention): non-answerable + abstained → correct refusal.
+- **FA** (False Abstention): answerable + abstained → over-cautious.
+- **TC** (True Commitment): answerable + committed → quality scored by
+  ``answer_correctness``.
+- **FC** (False Commitment): non-answerable + committed → hallucination.
+
+The unified abstention rule from spec §6.4:
+
+    abstained_for_analysis = answer_record.abstained
+                             and judge.abstention.score >= threshold
+
+i.e. both signals must agree to classify a record as abstained. When
+they disagree the record is treated as committed for the confusion
+matrix — that's conservative for hallucination scoring, and the
+disagreement is independently recorded by the judge_answers stage's
+abstention audit.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+    from arandu.shared.rag.schemas import AnswerRecord
+
+
+ConfusionLabel = Literal["TA", "TC", "FA", "FC", "unknown"]
+
+
+_ABSTENTION_CRITERION = "abstention"
+
+
+def classify_record(
+    record: AnswerRecord, *, threshold_override: float | None = None
+) -> ConfusionLabel:
+    """Classify one judged :class:`AnswerRecord` into TA/TC/FA/FC.
+
+    Args:
+        record: An :class:`AnswerRecord` that has been judged. Its
+            ``validation`` must be populated with the abstention
+            criterion's score.
+        threshold_override: Optional explicit τ_abstention. When
+            ``None`` (default), the threshold is read from the
+            criterion's own :attr:`CriterionScore.threshold` so a
+            single source of truth governs both judge-stage flagging
+            AND analysis-stage classification (mirrors the
+            judge_answers audit).
+
+    Returns:
+        ``"TA"``, ``"TC"``, ``"FA"``, ``"FC"``, or ``"unknown"`` when
+        the abstention judge couldn't run (validation absent or
+        criterion errored). The analysis stage skips ``"unknown"``
+        records from per-arm metric denominators and counts them in
+        the report's ``unknown`` field instead.
+    """
+    abstention_score = _abstention_score(record)
+    if abstention_score is None:
+        return "unknown"
+    threshold = threshold_override if threshold_override is not None else abstention_score[1]
+    judge_says_abstain = abstention_score[0] >= threshold
+    abstained_for_analysis = record.abstained and judge_says_abstain
+
+    if record.is_answerable:
+        return "FA" if abstained_for_analysis else "TC"
+    return "TA" if abstained_for_analysis else "FC"
+
+
+def _abstention_score(record: AnswerRecord) -> tuple[float, float] | None:
+    """Return ``(score, threshold)`` from the abstention criterion, or ``None``.
+
+    Returns ``None`` when:
+    - ``record.validation`` is None (unjudged), OR
+    - the abstention criterion didn't run (not in scores dict), OR
+    - the criterion errored (its ``score`` field is ``None``).
+    """
+    if record.validation is None:
+        return None
+    for step in record.validation.stage_results.values():
+        criterion_score = step.criterion_scores.get(_ABSTENTION_CRITERION)
+        if criterion_score is None or criterion_score.score is None:
+            continue
+        return criterion_score.score, criterion_score.threshold
+    return None

--- a/src/arandu/shared/rag/analysis/loader.py
+++ b/src/arandu/shared/rag/analysis/loader.py
@@ -38,8 +38,9 @@ def build_cross_cut_map(cep_dir: Path) -> dict[str, CrossCutMeta]:
             fields.
 
     Returns:
-        Flat dict. Empty if ``cep_dir`` is absent (analysis falls back
-        to an "all" pseudo-stratum in that case, with a warning).
+        Flat dict. Empty if ``cep_dir`` is absent or no files parse;
+        the batch layer then emits the joint table only (no Bloom or
+        question-type sub-tables) and logs a warning.
     """
     out: dict[str, CrossCutMeta] = {}
     if not cep_dir.exists():

--- a/src/arandu/shared/rag/analysis/loader.py
+++ b/src/arandu/shared/rag/analysis/loader.py
@@ -1,0 +1,62 @@
+"""Bloom + question-type lookup for analysis cross-cuts (spec §8.6).
+
+The CEP stage's :class:`QAPairCEP` records carry ``bloom_level`` and
+``question_type`` per pair. The analysis stage needs to join those
+back onto judged :class:`AnswerRecord` instances by ``qa_pair_id`` to
+produce Bloom-stratified and type-stratified metric tables.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, ValidationError
+
+from arandu.qa.schemas import QARecordCEP
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+class CrossCutMeta(BaseModel):
+    """Per-``qa_pair_id`` Bloom + question_type for stratified analysis."""
+
+    qa_pair_id: str
+    bloom_level: str
+    question_type: str
+
+
+def build_cross_cut_map(cep_dir: Path) -> dict[str, CrossCutMeta]:
+    """Build ``qa_pair_id → (bloom_level, question_type)`` from CEP outputs.
+
+    Args:
+        cep_dir: ``results/<id>/cep/outputs/``. Each ``*.json`` is a
+            :class:`QARecordCEP` whose ``qa_pairs`` carry the strata
+            fields.
+
+    Returns:
+        Flat dict. Empty if ``cep_dir`` is absent (analysis falls back
+        to an "all" pseudo-stratum in that case, with a warning).
+    """
+    out: dict[str, CrossCutMeta] = {}
+    if not cep_dir.exists():
+        logger.warning("CEP outputs absent at %s; cross-cut strata will be unavailable.", cep_dir)
+        return out
+    for path in sorted(cep_dir.glob("*.json")):
+        try:
+            record = QARecordCEP.model_validate_json(path.read_text(encoding="utf-8"))
+        except (OSError, ValidationError) as exc:
+            logger.warning("Skipping unreadable CEP file %s: %s", path, exc)
+            continue
+        for idx, pair in enumerate(record.qa_pairs):
+            chunk_id_segment = pair.chunk_id or "none"
+            qa_pair_id = f"{record.source_file_id}:{chunk_id_segment}:{idx}"
+            out[qa_pair_id] = CrossCutMeta(
+                qa_pair_id=qa_pair_id,
+                bloom_level=str(pair.bloom_level),
+                question_type=str(pair.question_type),
+            )
+    return out

--- a/src/arandu/shared/rag/analysis/metrics.py
+++ b/src/arandu/shared/rag/analysis/metrics.py
@@ -143,7 +143,7 @@ def _proportion(numerator: int, denominator: int) -> ProportionMetric:
     """Build a :class:`ProportionMetric` with Wilson 95% CI.
 
     Empty denominator yields ``value=None`` and a ``(0.0, 0.0)`` band
-    — the report layer renders these as "n/a" rather than misleading
+    - the report layer renders these as "n/a" rather than misleading
     zero rates.
     """
     if denominator == 0:

--- a/src/arandu/shared/rag/analysis/metrics.py
+++ b/src/arandu/shared/rag/analysis/metrics.py
@@ -1,0 +1,197 @@
+"""Per-arm metrics over judged AnswerRecords (spec §8.2 + §8.6).
+
+Aggregates a per-arm set of judged records into the confusion-matrix
+counts (TA/TC/FA/FC), the headline rates (hallucination,
+over-cautiousness, abstention F1, KC), and Wilson 95% CIs for each
+proportion.
+
+Per-Bloom + per-question-type cross-cuts are computed by re-running
+the same aggregator over filtered subsets.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, Field
+
+from arandu.shared.rag.analysis.classifier import classify_record
+from arandu.shared.rag.analysis.wilson import wilson_ci
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from arandu.shared.rag.schemas import AnswerRecord
+
+
+# Criterion names persisted by the judge_answers stage.
+_CORRECTNESS = "answer_correctness"
+_FAITHFULNESS = "answer_faithfulness"
+_PASSAGE_COVERAGE = "passage_coverage"
+
+
+class ProportionMetric(BaseModel):
+    """A binary proportion with Wilson 95% CI."""
+
+    numerator: int = Field(..., ge=0)
+    denominator: int = Field(..., ge=0)
+    value: float | None
+    ci_lower: float
+    ci_upper: float
+
+
+class MeanMetric(BaseModel):
+    """A scalar mean over a population, with sample size."""
+
+    mean: float | None
+    n: int = Field(..., ge=0)
+
+
+class ArmMetrics(BaseModel):
+    """Per-arm metric block for one slice (joint / Bloom / type)."""
+
+    arm: str
+    slice_name: str
+    confusion: dict[str, int]  # {"TA","TC","FA","FC","unknown"} → counts
+    hallucination_rate: ProportionMetric
+    over_cautiousness_rate: ProportionMetric
+    abstention_precision: ProportionMetric
+    abstention_recall: ProportionMetric
+    abstention_f1: float | None
+    answer_correctness: MeanMetric
+    answer_faithfulness: MeanMetric
+    knowledge_coverage: MeanMetric
+    passage_coverage: MeanMetric
+
+
+def aggregate_arm(
+    arm: str,
+    records: Iterable[AnswerRecord],
+    *,
+    slice_name: str = "joint",
+) -> ArmMetrics:
+    """Aggregate one arm's judged records into a :class:`ArmMetrics` block.
+
+    Args:
+        arm: Retriever id (``"bm25"``, ``"atlas_rag"``, …). Pure label;
+            used as ``ArmMetrics.arm``.
+        records: Judged :class:`AnswerRecord` instances for this arm.
+            Records whose abstention judge errored or didn't run are
+            counted as ``"unknown"`` in the confusion matrix and
+            EXCLUDED from rate/mean denominators (so a single judge
+            failure doesn't skew the headline numbers).
+        slice_name: Slice label (``"joint"``, ``"bloom=remember"``,
+            …). Echoed onto the result so tables can group by it.
+
+    Returns:
+        Populated :class:`ArmMetrics` block. All rate metrics carry
+        Wilson 95% CIs; means use record-count denominators.
+    """
+    confusion: Counter[str] = Counter()
+    correctness: list[float] = []
+    faithfulness: list[float] = []
+    kc_values: list[float] = []
+    passage_cov: list[float] = []
+
+    for record in records:
+        label = classify_record(record)
+        confusion[label] += 1
+        if label == "unknown":
+            continue
+        if label == "TC":
+            corr = _criterion_score(record, _CORRECTNESS)
+            faith = _criterion_score(record, _FAITHFULNESS)
+            if corr is not None:
+                correctness.append(corr)
+            if faith is not None:
+                faithfulness.append(faith)
+            if corr is not None and faith is not None:
+                kc_values.append(corr * faith)
+        cov = _criterion_score(record, _PASSAGE_COVERAGE)
+        if cov is not None:
+            passage_cov.append(cov)
+
+    ta = confusion.get("TA", 0)
+    tc = confusion.get("TC", 0)
+    fa = confusion.get("FA", 0)
+    fc = confusion.get("FC", 0)
+
+    return ArmMetrics(
+        arm=arm,
+        slice_name=slice_name,
+        confusion={
+            "TA": ta,
+            "TC": tc,
+            "FA": fa,
+            "FC": fc,
+            "unknown": confusion.get("unknown", 0),
+        },
+        hallucination_rate=_proportion(fc, fc + ta),
+        over_cautiousness_rate=_proportion(fa, fa + tc),
+        abstention_precision=_proportion(ta, ta + fa),
+        abstention_recall=_proportion(ta, ta + fc),
+        abstention_f1=_f1(ta=ta, fa=fa, fc=fc),
+        answer_correctness=_mean(correctness),
+        answer_faithfulness=_mean(faithfulness),
+        knowledge_coverage=_mean(kc_values),
+        passage_coverage=_mean(passage_cov),
+    )
+
+
+def _proportion(numerator: int, denominator: int) -> ProportionMetric:
+    """Build a :class:`ProportionMetric` with Wilson 95% CI.
+
+    Empty denominator yields ``value=None`` and a ``(0.0, 0.0)`` band
+    — the report layer renders these as "n/a" rather than misleading
+    zero rates.
+    """
+    if denominator == 0:
+        return ProportionMetric(
+            numerator=numerator,
+            denominator=0,
+            value=None,
+            ci_lower=0.0,
+            ci_upper=0.0,
+        )
+    value = numerator / denominator
+    lower, upper = wilson_ci(numerator, denominator)
+    return ProportionMetric(
+        numerator=numerator,
+        denominator=denominator,
+        value=value,
+        ci_lower=lower,
+        ci_upper=upper,
+    )
+
+
+def _mean(values: list[float]) -> MeanMetric:
+    """Build a :class:`MeanMetric`; empty input → ``mean=None``."""
+    if not values:
+        return MeanMetric(mean=None, n=0)
+    return MeanMetric(mean=sum(values) / len(values), n=len(values))
+
+
+def _f1(*, ta: int, fa: int, fc: int) -> float | None:
+    """Abstention F1 from TA/FA/FC counts; ``None`` when undefined."""
+    precision_denom = ta + fa
+    recall_denom = ta + fc
+    if precision_denom == 0 or recall_denom == 0:
+        return None
+    precision = ta / precision_denom
+    recall = ta / recall_denom
+    if precision + recall == 0:
+        return None
+    return 2 * precision * recall / (precision + recall)
+
+
+def _criterion_score(record: AnswerRecord, name: str) -> float | None:
+    """Pull ``name``'s score from the record's validation, or ``None`` on miss."""
+    if record.validation is None:
+        return None
+    for step in record.validation.stage_results.values():
+        criterion_score = step.criterion_scores.get(name)
+        if criterion_score is None:
+            continue
+        return criterion_score.score
+    return None

--- a/src/arandu/shared/rag/analysis/metrics.py
+++ b/src/arandu/shared/rag/analysis/metrics.py
@@ -81,7 +81,7 @@ def aggregate_arm(
             counted as ``"unknown"`` in the confusion matrix and
             EXCLUDED from rate/mean denominators (so a single judge
             failure doesn't skew the headline numbers).
-        slice_name: Slice label (``"joint"``, ``"bloom=remember"``,
+        slice_name: Slice label (``"joint"``, ``"bloom_level=remember"``,
             …). Echoed onto the result so tables can group by it.
 
     Returns:

--- a/src/arandu/shared/rag/analysis/report.py
+++ b/src/arandu/shared/rag/analysis/report.py
@@ -47,7 +47,7 @@ def write_report(outputs_dir: Path, report: AnalysisReport) -> tuple[Path, Path]
 def _render_markdown(report: AnalysisReport) -> str:
     """Render Markdown tables matching the spec §8.8 mock layout."""
     parts: list[str] = [
-        f"# RAG Analysis Report — {report.pipeline_id}",
+        f"# RAG Analysis Report - {report.pipeline_id}",
         "",
         _table_1_joint(report.joint),
     ]
@@ -59,9 +59,9 @@ def _render_markdown(report: AnalysisReport) -> str:
 
 
 def _table_1_joint(joint: dict[str, ArmMetrics]) -> str:
-    """Table 1 — per-arm joint-benchmark metrics."""
+    """Table 1 - per-arm joint-benchmark metrics."""
     header = (
-        "## Table 1 — Per-arm joint-benchmark metrics\n"
+        "## Table 1 - Per-arm joint-benchmark metrics\n"
         "\n"
         "| Arm | n_answerable | n_nonanswerable | KC ↑ | Hallucination ↓ "
         "| Over-caution ↓ | Abstention F1 ↑ | Passage cov (judge) ↑ |\n"
@@ -85,9 +85,9 @@ def _table_1_joint(joint: dict[str, ArmMetrics]) -> str:
 
 
 def _table_2_bloom(by_bloom: dict[str, dict[str, ArmMetrics]]) -> str:
-    """Table 2 — Bloom-stratified KC."""
+    """Table 2 - Bloom-stratified KC."""
     all_levels = sorted({level for arm in by_bloom.values() for level in arm})
-    header = "## Table 2 — Bloom-stratified Knowledge Coverage (KC)\n\n"
+    header = "## Table 2 - Bloom-stratified Knowledge Coverage (KC)\n\n"
     header += "| Arm | " + " | ".join(all_levels) + " |\n"
     header += "|" + "-----|" * (len(all_levels) + 1)
     rows = [header]
@@ -101,9 +101,9 @@ def _table_2_bloom(by_bloom: dict[str, dict[str, ArmMetrics]]) -> str:
 
 
 def _table_question_type(by_type: dict[str, dict[str, ArmMetrics]]) -> str:
-    """Table — question-type-stratified KC."""
+    """Table - question-type-stratified KC."""
     all_types = sorted({qt for arm in by_type.values() for qt in arm})
-    header = "## Table 3 — Question-type-stratified Knowledge Coverage (KC)\n\n"
+    header = "## Table 3 - Question-type-stratified Knowledge Coverage (KC)\n\n"
     header += "| Arm | " + " | ".join(all_types) + " |\n"
     header += "|" + "-----|" * (len(all_types) + 1)
     rows = [header]

--- a/src/arandu/shared/rag/analysis/report.py
+++ b/src/arandu/shared/rag/analysis/report.py
@@ -63,10 +63,10 @@ def _table_1_joint(joint: dict[str, ArmMetrics]) -> str:
     header = (
         "## Table 1 — Per-arm joint-benchmark metrics\n"
         "\n"
-        "| Arm | n_TA+TC | n_TA+FC | KC ↑ | Hallucination ↓ | Over-caution ↓ "
-        "| Abstention F1 ↑ | Passage cov (judge) ↑ |\n"
-        "|-----|---------|---------|------|-----------------|----------------"
-        "|-----------------|-----------------------|"
+        "| Arm | n_answerable | n_nonanswerable | KC ↑ | Hallucination ↓ "
+        "| Over-caution ↓ | Abstention F1 ↑ | Passage cov (judge) ↑ |\n"
+        "|-----|--------------|-----------------|------|-----------------"
+        "|----------------|-----------------|-----------------------|"
     )
     rows = [header]
     for arm in sorted(joint):

--- a/src/arandu/shared/rag/analysis/report.py
+++ b/src/arandu/shared/rag/analysis/report.py
@@ -1,0 +1,147 @@
+"""Emit ``report.json`` + ``tables.md`` for an analysis run (spec §8.8)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, Field
+
+from arandu.shared.rag.analysis.metrics import ArmMetrics, MeanMetric, ProportionMetric
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class AnalysisReport(BaseModel):
+    """Top-level run report.
+
+    Attributes:
+        pipeline_id: The run id this analysis was computed against.
+        joint: Per-arm joint-benchmark metrics keyed by arm id.
+        by_bloom: ``{arm: {bloom_level: ArmMetrics}}`` cross-cut.
+        by_question_type: ``{arm: {question_type: ArmMetrics}}`` cross-cut.
+    """
+
+    pipeline_id: str
+    joint: dict[str, ArmMetrics] = Field(default_factory=dict)
+    by_bloom: dict[str, dict[str, ArmMetrics]] = Field(default_factory=dict)
+    by_question_type: dict[str, dict[str, ArmMetrics]] = Field(default_factory=dict)
+
+
+def write_report(outputs_dir: Path, report: AnalysisReport) -> tuple[Path, Path]:
+    """Write ``report.json`` and ``tables.md`` under ``outputs_dir``.
+
+    Returns ``(json_path, tables_path)``. The two file paths align so
+    downstream consumers (thesis chapter, dashboards) can read either
+    form without separate config.
+    """
+    outputs_dir.mkdir(parents=True, exist_ok=True)
+    json_path = outputs_dir / "report.json"
+    tables_path = outputs_dir / "tables.md"
+
+    json_path.write_text(report.model_dump_json(indent=2), encoding="utf-8")
+    tables_path.write_text(_render_markdown(report), encoding="utf-8")
+    return json_path, tables_path
+
+
+def _render_markdown(report: AnalysisReport) -> str:
+    """Render Markdown tables matching the spec §8.8 mock layout."""
+    parts: list[str] = [
+        f"# RAG Analysis Report — {report.pipeline_id}",
+        "",
+        _table_1_joint(report.joint),
+    ]
+    if report.by_bloom:
+        parts.extend(["", _table_2_bloom(report.by_bloom)])
+    if report.by_question_type:
+        parts.extend(["", _table_question_type(report.by_question_type)])
+    return "\n".join(parts) + "\n"
+
+
+def _table_1_joint(joint: dict[str, ArmMetrics]) -> str:
+    """Table 1 — per-arm joint-benchmark metrics."""
+    header = (
+        "## Table 1 — Per-arm joint-benchmark metrics\n"
+        "\n"
+        "| Arm | n_TA+TC | n_TA+FC | KC ↑ | Hallucination ↓ | Over-caution ↓ "
+        "| Abstention F1 ↑ | Passage cov (judge) ↑ |\n"
+        "|-----|---------|---------|------|-----------------|----------------"
+        "|-----------------|-----------------------|"
+    )
+    rows = [header]
+    for arm in sorted(joint):
+        m = joint[arm]
+        n_answerable = m.confusion.get("TC", 0) + m.confusion.get("FA", 0)
+        n_nonanswerable = m.confusion.get("TA", 0) + m.confusion.get("FC", 0)
+        rows.append(
+            f"| {arm} | {n_answerable} | {n_nonanswerable} "
+            f"| {_fmt_mean(m.knowledge_coverage.mean)} "
+            f"| {_fmt_prop_ci(m.hallucination_rate)} "
+            f"| {_fmt_prop_ci(m.over_cautiousness_rate)} "
+            f"| {_fmt_mean(m.abstention_f1)} "
+            f"| {_fmt_mean(m.passage_coverage.mean)} |"
+        )
+    return "\n".join(rows)
+
+
+def _table_2_bloom(by_bloom: dict[str, dict[str, ArmMetrics]]) -> str:
+    """Table 2 — Bloom-stratified KC."""
+    all_levels = sorted({level for arm in by_bloom.values() for level in arm})
+    header = "## Table 2 — Bloom-stratified Knowledge Coverage (KC)\n\n"
+    header += "| Arm | " + " | ".join(all_levels) + " |\n"
+    header += "|" + "-----|" * (len(all_levels) + 1)
+    rows = [header]
+    for arm in sorted(by_bloom):
+        cells = [
+            _fmt_mean(by_bloom[arm].get(level, _empty()).knowledge_coverage.mean)
+            for level in all_levels
+        ]
+        rows.append(f"| {arm} | " + " | ".join(cells) + " |")
+    return "\n".join(rows)
+
+
+def _table_question_type(by_type: dict[str, dict[str, ArmMetrics]]) -> str:
+    """Table — question-type-stratified KC."""
+    all_types = sorted({qt for arm in by_type.values() for qt in arm})
+    header = "## Table 3 — Question-type-stratified Knowledge Coverage (KC)\n\n"
+    header += "| Arm | " + " | ".join(all_types) + " |\n"
+    header += "|" + "-----|" * (len(all_types) + 1)
+    rows = [header]
+    for arm in sorted(by_type):
+        cells = [
+            _fmt_mean(by_type[arm].get(qt, _empty()).knowledge_coverage.mean) for qt in all_types
+        ]
+        rows.append(f"| {arm} | " + " | ".join(cells) + " |")
+    return "\n".join(rows)
+
+
+def _fmt_prop_ci(p: ProportionMetric) -> str:
+    """Render a ProportionMetric as ``value [lo, hi]`` or ``n/a``."""
+    if p.value is None:
+        return "n/a"
+    return f"{p.value:.3f} [{p.ci_lower:.3f}, {p.ci_upper:.3f}]"
+
+
+def _fmt_mean(v: float | None) -> str:
+    """Render a scalar mean as 3 decimals or ``n/a``."""
+    return "n/a" if v is None else f"{v:.3f}"
+
+
+def _empty() -> ArmMetrics:
+    """Empty ArmMetrics fallback used for missing strata."""
+    zero_prop = ProportionMetric(numerator=0, denominator=0, value=None, ci_lower=0.0, ci_upper=0.0)
+    zero_mean = MeanMetric(mean=None, n=0)
+    return ArmMetrics(
+        arm="",
+        slice_name="",
+        confusion={"TA": 0, "TC": 0, "FA": 0, "FC": 0, "unknown": 0},
+        hallucination_rate=zero_prop,
+        over_cautiousness_rate=zero_prop,
+        abstention_precision=zero_prop,
+        abstention_recall=zero_prop,
+        abstention_f1=None,
+        answer_correctness=zero_mean,
+        answer_faithfulness=zero_mean,
+        knowledge_coverage=zero_mean,
+        passage_coverage=zero_mean,
+    )

--- a/src/arandu/shared/rag/analysis/wilson.py
+++ b/src/arandu/shared/rag/analysis/wilson.py
@@ -1,0 +1,56 @@
+"""Wilson 95% confidence interval for a binary proportion (spec §8.3).
+
+Pure-math implementation; no ``statsmodels`` / ``scipy`` dependency. The
+spec calls for ``statsmodels.stats.proportion.proportion_confint(method="wilson")``
+which uses exactly this closed form — keeping it inline avoids dragging
+in a heavy stats dep for a 6-line formula.
+
+Wilson is preferred over the normal-approximation CI for small ``n``
+and for proportions near 0 or 1, where the normal approximation breaks
+down (the thesis cares about both — abstention rates can be near zero;
+strata can be small per Bloom level).
+"""
+
+from __future__ import annotations
+
+from math import sqrt
+
+# z-score for 95% confidence (two-sided normal).
+_Z_95 = 1.96
+
+
+def wilson_ci(k: int, n: int, *, z: float = _Z_95) -> tuple[float, float]:
+    """Compute the Wilson confidence interval for ``k`` successes out of ``n``.
+
+    Args:
+        k: Number of successes (must satisfy ``0 <= k <= n``).
+        n: Total trials. ``n == 0`` returns ``(0.0, 0.0)`` defensively
+            (a stratum with no items can't anchor a CI; surfaces as
+            an empty band in the report instead of a ZeroDivisionError).
+        z: z-score for the desired confidence level. Defaults to 1.96
+            (95% confidence).
+
+    Returns:
+        ``(lower, upper)`` bounds in ``[0.0, 1.0]``. Returns
+        ``(0.0, 0.0)`` for ``n == 0``.
+
+    Raises:
+        ValueError: If ``k < 0``, ``n < 0``, or ``k > n``.
+    """
+    if k < 0:
+        raise ValueError(f"k must be >= 0, got {k}")
+    if n < 0:
+        raise ValueError(f"n must be >= 0, got {n}")
+    if k > n:
+        raise ValueError(f"k ({k}) must be <= n ({n})")
+    if n == 0:
+        return 0.0, 0.0
+
+    p = k / n
+    z2 = z * z
+    denom = 1 + z2 / n
+    center = (p + z2 / (2 * n)) / denom
+    half = z * sqrt(p * (1 - p) / n + z2 / (4 * n * n)) / denom
+    lower = max(0.0, center - half)
+    upper = min(1.0, center + half)
+    return lower, upper

--- a/src/arandu/shared/rag/analysis/wilson.py
+++ b/src/arandu/shared/rag/analysis/wilson.py
@@ -2,12 +2,12 @@
 
 Pure-math implementation; no ``statsmodels`` / ``scipy`` dependency. The
 spec calls for ``statsmodels.stats.proportion.proportion_confint(method="wilson")``
-which uses exactly this closed form — keeping it inline avoids dragging
+which uses exactly this closed form - keeping it inline avoids dragging
 in a heavy stats dep for a 6-line formula.
 
 Wilson is preferred over the normal-approximation CI for small ``n``
 and for proportions near 0 or 1, where the normal approximation breaks
-down (the thesis cares about both — abstention rates can be near zero;
+down (the thesis cares about both - abstention rates can be near zero;
 strata can be small per Bloom level).
 """
 

--- a/src/arandu/shared/schemas.py
+++ b/src/arandu/shared/schemas.py
@@ -198,6 +198,7 @@ class PipelineType(StrEnum):
     RETRIEVE = "retrieve"
     ANSWERS = "answers"
     JUDGE_ANSWERS = "judge_answers"
+    ANALYSIS = "analysis"
     EVALUATION = "evaluation"
 
 

--- a/tests/shared/rag/analysis/conftest.py
+++ b/tests/shared/rag/analysis/conftest.py
@@ -1,0 +1,100 @@
+"""Shared fixtures for analysis-stage tests."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from arandu.qa.schemas import QAPairCEP, QARecordCEP
+from arandu.shared.judge.schemas import (
+    CriterionScore,
+    JudgePipelineResult,
+    JudgeStepResult,
+)
+from arandu.shared.rag.schemas import AnswerRecord
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def make_answer(
+    *,
+    qa_pair_id: str = "src:chk_00:0",
+    retriever_id: str = "bm25",
+    is_answerable: bool = True,
+    abstained: bool = False,
+    abstention_score: float | None = 0.1,
+    correctness_score: float | None = 0.9,
+    faithfulness_score: float | None = 0.8,
+    passage_coverage_score: float | None = 0.7,
+) -> AnswerRecord:
+    """Build a fully judged :class:`AnswerRecord` for analysis tests."""
+    criterion_scores: dict[str, CriterionScore] = {
+        "abstention": CriterionScore(score=abstention_score, threshold=0.7, rationale="r"),
+        "answer_correctness": CriterionScore(score=correctness_score, threshold=0.6, rationale="r"),
+        "answer_faithfulness": CriterionScore(
+            score=faithfulness_score, threshold=0.6, rationale="r"
+        ),
+        "passage_coverage": CriterionScore(
+            score=passage_coverage_score, threshold=0.5, rationale="r"
+        ),
+    }
+    validation = JudgePipelineResult(
+        stage_results={"answer_judge": JudgeStepResult(criterion_scores=criterion_scores)},
+        passed=True,
+    )
+    return AnswerRecord(
+        qa_pair_id=qa_pair_id,
+        question="q",
+        retriever_id=retriever_id,
+        chunker_id="cep_4k",
+        top_k=5,
+        passages=[],
+        elapsed_ms=1.0,
+        is_answerable=is_answerable,
+        answer_text=None if abstained else "answer",
+        abstained=abstained,
+        rationale="r",
+        answerer_model="qwen3:14b",
+        answerer_temperature=0.2,
+        validation=validation,
+    )
+
+
+@pytest.fixture
+def cep_outputs_dir(tmp_path: Path) -> Path:
+    """A CEP outputs dir with one record carrying mixed Bloom + types."""
+    out = tmp_path / "cep" / "outputs"
+    out.mkdir(parents=True)
+    pairs = [
+        QAPairCEP(
+            question="q1",
+            answer="a1",
+            context="c",
+            question_type="factual",
+            confidence=0.9,
+            bloom_level="remember",
+            chunk_id="chk_00",
+        ),
+        QAPairCEP(
+            question="q2",
+            answer="a2",
+            context="c",
+            question_type="conceptual",
+            confidence=0.9,
+            bloom_level="analyze",
+            chunk_id="chk_00",
+        ),
+    ]
+    record = QARecordCEP(
+        source_gdrive_id="src",
+        source_filename="src.wav",
+        transcription_text="…",
+        qa_pairs=pairs,
+        model_id="qwen3:14b",
+        provider="ollama",
+        total_pairs=len(pairs),
+    )
+    record.save(out / "src.json")
+    return out

--- a/tests/shared/rag/analysis/test_batch.py
+++ b/tests/shared/rag/analysis/test_batch.py
@@ -1,0 +1,108 @@
+"""End-to-end test of the rag-analysis batch driver."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from arandu.shared.rag.analysis.batch import run_rag_analysis_batch
+
+from .conftest import make_answer
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _seed_judged_record(
+    *,
+    base: Path,
+    pipeline_id: str,
+    arm: str,
+    source: str,
+    file_stem: str,
+    qa_pair_id: str,
+    is_answerable: bool,
+    abstained: bool,
+    abstention_score: float | None,
+) -> None:
+    """Write a judged AnswerRecord under the canonical layout."""
+    target = base / pipeline_id / "judge_answers" / "outputs" / arm / source
+    target.mkdir(parents=True, exist_ok=True)
+    record = make_answer(
+        qa_pair_id=qa_pair_id,
+        retriever_id=arm,
+        is_answerable=is_answerable,
+        abstained=abstained,
+        abstention_score=abstention_score,
+    )
+    record.save(target / f"{file_stem}.json")
+
+
+def test_missing_judge_outputs_raises(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError, match="judge_answers outputs not found"):
+        run_rag_analysis_batch("nope", base_dir=tmp_path)
+
+
+def test_runs_end_to_end_and_writes_report(tmp_path: Path, cep_outputs_dir: Path) -> None:
+    pipeline_id = "run-x"
+    base = tmp_path / "results"
+
+    # Reuse the cep_outputs_dir fixture's records via a quick copy into the run.
+    target_cep = base / pipeline_id / "cep" / "outputs"
+    target_cep.mkdir(parents=True)
+    for src in cep_outputs_dir.glob("*.json"):
+        (target_cep / src.name).write_text(src.read_text(encoding="utf-8"), encoding="utf-8")
+
+    # Seed two arms with one judged answer each.
+    _seed_judged_record(
+        base=base,
+        pipeline_id=pipeline_id,
+        arm="bm25",
+        source="src",
+        file_stem="rec_0",
+        qa_pair_id="src:chk_00:0",
+        is_answerable=True,
+        abstained=False,
+        abstention_score=0.1,
+    )
+    _seed_judged_record(
+        base=base,
+        pipeline_id=pipeline_id,
+        arm="atlas_rag",
+        source="src",
+        file_stem="rec_0",
+        qa_pair_id="src:chk_00:1",
+        is_answerable=True,
+        abstained=False,
+        abstention_score=0.1,
+    )
+
+    result = run_rag_analysis_batch(pipeline_id, base_dir=base)
+
+    assert result.records_loaded == 2
+    assert result.records_unreadable == 0
+    assert set(result.arms) == {"bm25", "atlas_rag"}
+
+    payload = json.loads(
+        (base / pipeline_id / "analysis" / "outputs" / "report.json").read_text(encoding="utf-8")
+    )
+    assert payload["pipeline_id"] == pipeline_id
+    assert set(payload["joint"].keys()) == {"bm25", "atlas_rag"}
+    # Each arm should produce a remember stratum or analyze stratum
+    # because the seeded qa_pair_ids match the fixture pairs.
+    assert payload["by_bloom"]["bm25"].get("remember") is not None
+    assert payload["by_bloom"]["atlas_rag"].get("analyze") is not None
+
+
+def test_unreadable_records_counted_not_raised(tmp_path: Path) -> None:
+    pipeline_id = "run-x"
+    base = tmp_path / "results"
+    target = base / pipeline_id / "judge_answers" / "outputs" / "bm25" / "src"
+    target.mkdir(parents=True)
+    (target / "rec_0.json").write_text("not json", encoding="utf-8")
+
+    result = run_rag_analysis_batch(pipeline_id, base_dir=base)
+    assert result.records_loaded == 0
+    assert result.records_unreadable == 1

--- a/tests/shared/rag/analysis/test_classifier.py
+++ b/tests/shared/rag/analysis/test_classifier.py
@@ -1,0 +1,98 @@
+"""Tests for TA/TC/FA/FC labelling (spec §8.1)."""
+
+from __future__ import annotations
+
+from arandu.shared.judge.schemas import (
+    CriterionScore,
+    JudgePipelineResult,
+    JudgeStepResult,
+)
+from arandu.shared.rag.analysis.classifier import classify_record
+from arandu.shared.rag.schemas import AnswerRecord
+
+
+def _record(
+    *,
+    is_answerable: bool,
+    abstained: bool,
+    judge_abstention_score: float | None,
+    threshold: float = 0.7,
+) -> AnswerRecord:
+    """Build a minimal judged AnswerRecord for classifier tests.
+
+    ``judge_abstention_score=None`` simulates a judge-error row (the
+    criterion ran but errored — score field is None).
+    """
+    validation = JudgePipelineResult(
+        stage_results={
+            "answer_judge": JudgeStepResult(
+                criterion_scores={
+                    "abstention": CriterionScore(
+                        score=judge_abstention_score,
+                        threshold=threshold,
+                        rationale="r",
+                    )
+                }
+            )
+        },
+        passed=True,
+    )
+    return AnswerRecord(
+        qa_pair_id="src:chk:0",
+        question="q",
+        retriever_id="bm25",
+        chunker_id="cep_4k",
+        top_k=5,
+        passages=[],
+        elapsed_ms=1.0,
+        is_answerable=is_answerable,
+        answer_text=None if abstained else "answer",
+        abstained=abstained,
+        rationale="r",
+        answerer_model="qwen3:14b",
+        answerer_temperature=0.2,
+        validation=validation,
+    )
+
+
+class TestClassifyRecord:
+    def test_answerable_committed_is_tc(self) -> None:
+        record = _record(is_answerable=True, abstained=False, judge_abstention_score=0.1)
+        assert classify_record(record) == "TC"
+
+    def test_answerable_both_say_abstain_is_fa(self) -> None:
+        record = _record(is_answerable=True, abstained=True, judge_abstention_score=0.9)
+        assert classify_record(record) == "FA"
+
+    def test_nonanswerable_both_say_abstain_is_ta(self) -> None:
+        record = _record(is_answerable=False, abstained=True, judge_abstention_score=0.9)
+        assert classify_record(record) == "TA"
+
+    def test_nonanswerable_committed_is_fc(self) -> None:
+        record = _record(is_answerable=False, abstained=False, judge_abstention_score=0.1)
+        assert classify_record(record) == "FC"
+
+    def test_disagreement_treats_as_committed(self) -> None:
+        """answerer abstained but judge says commit → committed for analysis."""
+        record = _record(is_answerable=True, abstained=True, judge_abstention_score=0.1)
+        assert classify_record(record) == "TC"
+
+    def test_disagreement_other_direction_treats_as_committed(self) -> None:
+        """answerer committed but judge says abstain → committed for analysis."""
+        record = _record(is_answerable=False, abstained=False, judge_abstention_score=0.9)
+        assert classify_record(record) == "FC"
+
+    def test_judge_error_returns_unknown(self) -> None:
+        record = _record(is_answerable=True, abstained=False, judge_abstention_score=None)
+        assert classify_record(record) == "unknown"
+
+    def test_unjudged_returns_unknown(self) -> None:
+        record = _record(is_answerable=True, abstained=False, judge_abstention_score=0.1)
+        record = record.model_copy(update={"validation": None})
+        assert classify_record(record) == "unknown"
+
+    def test_threshold_override_changes_label(self) -> None:
+        """Override τ=0.05 → score 0.1 now counts as abstain, flipping TC → FA."""
+        record = _record(is_answerable=True, abstained=True, judge_abstention_score=0.1)
+        assert classify_record(record) == "TC"  # default τ=0.7
+        assert classify_record(record, threshold_override=0.05) == "FA"

--- a/tests/shared/rag/analysis/test_classifier.py
+++ b/tests/shared/rag/analysis/test_classifier.py
@@ -21,7 +21,7 @@ def _record(
     """Build a minimal judged AnswerRecord for classifier tests.
 
     ``judge_abstention_score=None`` simulates a judge-error row (the
-    criterion ran but errored — score field is None).
+    criterion ran but errored - score field is None).
     """
     validation = JudgePipelineResult(
         stage_results={

--- a/tests/shared/rag/analysis/test_loader.py
+++ b/tests/shared/rag/analysis/test_loader.py
@@ -1,0 +1,34 @@
+"""Tests for the CEP cross-cut metadata loader."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from arandu.shared.rag.analysis.loader import build_cross_cut_map
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class TestBuildCrossCutMap:
+    def test_indexes_by_composite_qa_pair_id(self, cep_outputs_dir: Path) -> None:
+        mapping = build_cross_cut_map(cep_outputs_dir)
+        assert set(mapping.keys()) == {"src:chk_00:0", "src:chk_00:1"}
+
+    def test_carries_bloom_and_question_type(self, cep_outputs_dir: Path) -> None:
+        mapping = build_cross_cut_map(cep_outputs_dir)
+        first = mapping["src:chk_00:0"]
+        assert first.bloom_level == "remember"
+        assert first.question_type == "factual"
+        second = mapping["src:chk_00:1"]
+        assert second.bloom_level == "analyze"
+        assert second.question_type == "conceptual"
+
+    def test_absent_dir_returns_empty(self, tmp_path: Path) -> None:
+        assert build_cross_cut_map(tmp_path / "does-not-exist") == {}
+
+    def test_unreadable_files_skipped(self, tmp_path: Path) -> None:
+        bad_dir = tmp_path / "cep" / "outputs"
+        bad_dir.mkdir(parents=True)
+        (bad_dir / "garbage.json").write_text("not json", encoding="utf-8")
+        assert build_cross_cut_map(bad_dir) == {}

--- a/tests/shared/rag/analysis/test_metrics.py
+++ b/tests/shared/rag/analysis/test_metrics.py
@@ -1,0 +1,121 @@
+"""Tests for per-arm metric aggregation."""
+
+from __future__ import annotations
+
+from arandu.shared.rag.analysis.metrics import aggregate_arm
+
+from .conftest import make_answer
+
+
+class TestAggregateArm:
+    def test_all_tc_records(self) -> None:
+        records = [
+            make_answer(qa_pair_id=f"src:c:{i}", is_answerable=True, abstained=False)
+            for i in range(4)
+        ]
+        metrics = aggregate_arm("bm25", records)
+        assert metrics.confusion["TC"] == 4
+        assert metrics.confusion["FA"] == 0
+        assert metrics.knowledge_coverage.n == 4
+        assert metrics.knowledge_coverage.mean is not None
+        assert 0.0 < metrics.knowledge_coverage.mean <= 1.0
+
+    def test_hallucination_rate_uses_fc_over_fc_plus_ta(self) -> None:
+        # 2 FC + 1 TA → hallucination = 2/3
+        records = [
+            make_answer(
+                qa_pair_id="r:c:0",
+                is_answerable=False,
+                abstained=False,
+                abstention_score=0.1,
+            ),
+            make_answer(
+                qa_pair_id="r:c:1",
+                is_answerable=False,
+                abstained=False,
+                abstention_score=0.1,
+            ),
+            make_answer(
+                qa_pair_id="r:c:2",
+                is_answerable=False,
+                abstained=True,
+                abstention_score=0.9,
+            ),
+        ]
+        metrics = aggregate_arm("bm25", records)
+        assert metrics.confusion["FC"] == 2
+        assert metrics.confusion["TA"] == 1
+        assert metrics.hallucination_rate.value is not None
+        assert abs(metrics.hallucination_rate.value - 2 / 3) < 1e-9
+
+    def test_abstention_f1_uses_ta_fa_fc(self) -> None:
+        # TA=2, FA=1, FC=1 → precision=2/3, recall=2/3, F1=2/3
+        records = [
+            make_answer(  # TA
+                qa_pair_id="r:c:0",
+                is_answerable=False,
+                abstained=True,
+                abstention_score=0.9,
+            ),
+            make_answer(  # TA
+                qa_pair_id="r:c:1",
+                is_answerable=False,
+                abstained=True,
+                abstention_score=0.9,
+            ),
+            make_answer(  # FA
+                qa_pair_id="r:c:2",
+                is_answerable=True,
+                abstained=True,
+                abstention_score=0.9,
+            ),
+            make_answer(  # FC
+                qa_pair_id="r:c:3",
+                is_answerable=False,
+                abstained=False,
+                abstention_score=0.1,
+            ),
+        ]
+        metrics = aggregate_arm("bm25", records)
+        assert metrics.abstention_f1 is not None
+        assert abs(metrics.abstention_f1 - 2 / 3) < 1e-9
+        assert metrics.abstention_precision.value == 2 / 3
+        assert metrics.abstention_recall.value == 2 / 3
+
+    def test_unknown_skipped_from_means(self) -> None:
+        records = [
+            make_answer(qa_pair_id="r:c:0", abstention_score=None),  # unknown
+            make_answer(
+                qa_pair_id="r:c:1",
+                is_answerable=True,
+                abstained=False,
+                abstention_score=0.1,
+            ),
+        ]
+        metrics = aggregate_arm("bm25", records)
+        assert metrics.confusion["unknown"] == 1
+        assert metrics.confusion["TC"] == 1
+        assert metrics.knowledge_coverage.n == 1  # only the TC counts
+
+    def test_empty_denominator_yields_none_value(self) -> None:
+        # All TC → hallucination denominator (FC+TA) = 0
+        records = [
+            make_answer(qa_pair_id="r:c:0", is_answerable=True, abstained=False),
+        ]
+        metrics = aggregate_arm("bm25", records)
+        assert metrics.hallucination_rate.value is None
+        assert metrics.hallucination_rate.denominator == 0
+
+    def test_kc_is_correctness_times_faithfulness(self) -> None:
+        records = [
+            make_answer(
+                qa_pair_id="r:c:0",
+                is_answerable=True,
+                abstained=False,
+                correctness_score=0.8,
+                faithfulness_score=0.5,
+            ),
+        ]
+        metrics = aggregate_arm("bm25", records)
+        assert metrics.knowledge_coverage.mean is not None
+        assert abs(metrics.knowledge_coverage.mean - 0.4) < 1e-9

--- a/tests/shared/rag/analysis/test_report.py
+++ b/tests/shared/rag/analysis/test_report.py
@@ -1,0 +1,67 @@
+"""Tests for report.json + tables.md emission."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from arandu.shared.rag.analysis.metrics import aggregate_arm
+from arandu.shared.rag.analysis.report import AnalysisReport, write_report
+
+from .conftest import make_answer
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_write_report_produces_both_files(tmp_path: Path) -> None:
+    records = [
+        make_answer(
+            qa_pair_id="r:c:0",
+            retriever_id="bm25",
+            is_answerable=True,
+            abstained=False,
+        ),
+        make_answer(
+            qa_pair_id="r:c:1",
+            retriever_id="bm25",
+            is_answerable=False,
+            abstained=True,
+            abstention_score=0.9,
+        ),
+    ]
+    joint = {"bm25": aggregate_arm("bm25", records)}
+    report = AnalysisReport(pipeline_id="run-x", joint=joint)
+
+    json_path, md_path = write_report(tmp_path, report)
+    assert json_path.exists()
+    assert md_path.exists()
+
+    payload = json.loads(json_path.read_text(encoding="utf-8"))
+    assert payload["pipeline_id"] == "run-x"
+    assert "bm25" in payload["joint"]
+
+    md = md_path.read_text(encoding="utf-8")
+    assert "Table 1" in md
+    assert "bm25" in md
+    assert "run-x" in md
+
+
+def test_render_handles_bloom_and_question_type_tables(tmp_path: Path) -> None:
+    records = [
+        make_answer(qa_pair_id="r:c:0", retriever_id="bm25"),
+    ]
+    metrics = aggregate_arm("bm25", records, slice_name="bloom=remember")
+    report = AnalysisReport(
+        pipeline_id="run-x",
+        joint={"bm25": metrics},
+        by_bloom={"bm25": {"remember": metrics}},
+        by_question_type={"bm25": {"factual": metrics}},
+    )
+
+    _, md_path = write_report(tmp_path, report)
+    md = md_path.read_text(encoding="utf-8")
+    assert "Table 2" in md
+    assert "Table 3" in md
+    assert "remember" in md
+    assert "factual" in md

--- a/tests/shared/rag/analysis/test_report.py
+++ b/tests/shared/rag/analysis/test_report.py
@@ -51,7 +51,7 @@ def test_render_handles_bloom_and_question_type_tables(tmp_path: Path) -> None:
     records = [
         make_answer(qa_pair_id="r:c:0", retriever_id="bm25"),
     ]
-    metrics = aggregate_arm("bm25", records, slice_name="bloom=remember")
+    metrics = aggregate_arm("bm25", records, slice_name="bloom_level=remember")
     report = AnalysisReport(
         pipeline_id="run-x",
         joint={"bm25": metrics},

--- a/tests/shared/rag/analysis/test_wilson.py
+++ b/tests/shared/rag/analysis/test_wilson.py
@@ -1,0 +1,40 @@
+"""Tests for the Wilson 95% confidence interval helper."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from arandu.shared.rag.analysis.wilson import wilson_ci
+
+
+class TestWilsonCI:
+    def test_zero_denominator_returns_zero_band(self) -> None:
+        assert wilson_ci(0, 0) == (0.0, 0.0)
+
+    def test_all_successes_upper_at_one(self) -> None:
+        lower, upper = wilson_ci(10, 10)
+        assert lower < upper == 1.0 or upper == pytest.approx(1.0)
+        assert lower < 1.0
+        assert lower > 0.5
+
+    def test_no_successes_lower_at_zero(self) -> None:
+        lower, upper = wilson_ci(0, 10)
+        assert lower == 0.0
+        assert 0.0 < upper < 1.0
+
+    def test_half_proportion_centers_on_half(self) -> None:
+        lower, upper = wilson_ci(50, 100)
+        assert lower < 0.5 < upper
+        assert math.isclose(lower + upper, 1.0, abs_tol=0.001)
+
+    def test_negative_inputs_rejected(self) -> None:
+        with pytest.raises(ValueError, match="must be >= 0"):
+            wilson_ci(-1, 10)
+        with pytest.raises(ValueError, match="must be >= 0"):
+            wilson_ci(0, -1)
+
+    def test_excess_successes_rejected(self) -> None:
+        with pytest.raises(ValueError, match="must be <="):
+            wilson_ci(11, 10)

--- a/tests/shared/test_results_manager.py
+++ b/tests/shared/test_results_manager.py
@@ -779,6 +779,7 @@ class TestPipelineType:
             "retrieve",
             "answers",
             "judge_answers",
+            "analysis",
             "evaluation",
         }
         actual = {p.value for p in PipelineType}


### PR DESCRIPTION
## Summary

- Adds `arandu rag-analysis --id <pipeline_id>` - the analysis stage that consumes judged `AnswerRecord` artifacts from `arandu judge-answers` and emits the cross-arm comparison tables the thesis chapter reports. Closes the Phase C critical path.
- Per-arm aggregator (`aggregate_arm`) computes TA/TC/FA/FC confusion matrices plus headline rates with Wilson 95% CIs: hallucination, over-cautiousness, abstention precision/recall/F1, and KC = answer_correctness × answer_faithfulness.
- Bloom + question-type cross-cuts are produced by re-running the same aggregator over CEP-joined subsets. CEP absence is non-fatal (joint-only table).
- Output: `results/<id>/analysis/outputs/{report.json,tables.md}`. Wilson CI is a pure-math closed form (no `statsmodels` dep).
- Adds user-guide doc at `docs/user-guide/rag-analysis.md` covering TA/TC/FA/FC interpretation, KC, Wilson CIs, cross-cuts, troubleshooting, and known limitations.
- 30 new tests; full suite **1390 passed, 1 skipped** locally.

## Out of scope (deferred)

- Paired McNemar's + bootstrap CIs (need `statsmodels`).
- Methodology §6 composite score (`Overall = 0.40·KC + 0.20·D_e + 0.20·RD + 0.20·CR`) - needs KG structural metrics integration.
- `--compare-runs` cross-run hook.
- Matplotlib figures.
- Non-answerable item handling - depends on the open `nonanswerable-experiment` task.

## Test plan

- [x] `uv run ruff check src/ tests/` -> clean
- [x] `uv run ruff format --check src/ tests/` -> clean
- [x] `uv run pytest` -> 1390 passed, 1 skipped
- [ ] `arandu rag-analysis --help` smoke (post-merge)