### PR TITLE
feat(qa): generate-non-answerable entity-swap benchmark builder (spec §7)

### DIFF
--- a/prompts/qa/non_answerable/pt.j2
+++ b/prompts/qa/non_answerable/pt.j2
@@ -1,0 +1,19 @@
+Você é um construtor de benchmarks adversariais para avaliação de RAG. Sua tarefa é
+reescrever uma pergunta substituindo UMA entidade nomeada por outra plausível do mesmo
+tipo, de forma que a pergunta resultante não seja respondível a partir do corpus original.
+
+REGRAS:
+1. Escolha UMA entidade nomeada na pergunta original (pessoa, local, ano, espécie, evento).
+2. Proponha uma substituição PLAUSÍVEL do mesmo tipo (e.g., outro nome de pessoa
+   ribeirinha, outro ano de enchente, outra espécie de peixe). NÃO escolha algo absurdo.
+3. A pergunta reescrita deve ler-se naturalmente em português brasileiro.
+4. NÃO modifique o restante da pergunta.
+
+PERGUNTA ORIGINAL:
+{{ question }}
+
+Responda em JSON com os campos:
+- original_entity: a entidade original (string)
+- entity_type: o tipo (person | place | year | species | event)
+- replacement_entity: a substituição plausível (string)
+- new_question: a pergunta reescrita (string)

--- a/src/arandu/cli/app.py
+++ b/src/arandu/cli/app.py
@@ -61,6 +61,7 @@ from arandu.cli.manage import (  # noqa: E402
     replicate,
     run_info,
 )
+from arandu.cli.non_answerable import generate_non_answerable  # noqa: E402
 from arandu.cli.qa import generate_cep_qa, judge_qa  # noqa: E402
 from arandu.cli.rag_analysis import rag_analysis  # noqa: E402
 from arandu.cli.report import report, serve_report  # noqa: E402
@@ -87,6 +88,7 @@ app.command()(retrieve)
 app.command()(answer)
 app.command()(judge_answers)
 app.command()(rag_analysis)
+app.command()(generate_non_answerable)
 app.command()(replicate)
 app.command()(info)
 app.command()(list_runs)

--- a/src/arandu/cli/non_answerable.py
+++ b/src/arandu/cli/non_answerable.py
@@ -1,0 +1,104 @@
+"""CLI command: ``arandu generate-non-answerable`` - build the non-answerable benchmark.
+
+Samples validated CEP pairs, perturbs each into a non-answerable twin via
+one LLM entity-swap call + code-side verification, and writes a
+``NonAnswerableDataset`` under ``results/<id>/non_answerable/outputs/dataset.json``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Annotated
+
+import typer
+
+from arandu.qa.non_answerable.batch import run_generate_non_answerable_batch
+from arandu.qa.non_answerable.settings import NonAnswerableSettings
+from arandu.utils.logger import print_error, print_info, print_success, print_warning
+
+logger = logging.getLogger(__name__)
+
+
+def generate_non_answerable(
+    pipeline_id: Annotated[
+        str,
+        typer.Option(
+            "--id",
+            help=(
+                "Pipeline ID for the run. The cep/ stage must be populated "
+                "(post judge-qa); kg/ and transcription/ outputs are consulted "
+                "for the entity absence checks."
+            ),
+        ),
+    ],
+    seeds_per_bloom: Annotated[
+        int | None,
+        typer.Option("--seeds-per-bloom", help="Target seeds per Bloom level. Default 100."),
+    ] = None,
+    rng_seed: Annotated[
+        int | None,
+        typer.Option("--rng-seed", help="Sampler seed for reproducibility. Default 42."),
+    ] = None,
+    regenerate: Annotated[
+        bool,
+        typer.Option(
+            "--regenerate",
+            help="Discard checkpoint + prior items and re-perturb every seed.",
+        ),
+    ] = False,
+) -> None:
+    """Generate a non-answerable benchmark from validated CEP + KG.
+
+    Each item keeps a ``parent_qa_pair_id`` link to its answerable twin so
+    the analysis stage can run paired comparisons. Generation is fully
+    automated (no hand-curation); the LLM proposes a same-type entity swap
+    and code verifies the replacement is absent from both the KG and the
+    source corpus.
+
+    LLM + sampling config comes from ``ARANDU_NONANSWERABLE_*`` env vars
+    (see :class:`NonAnswerableSettings`); ``--seeds-per-bloom`` / ``--rng-seed``
+    override the corresponding settings for this run.
+    """
+    settings = NonAnswerableSettings()
+    if seeds_per_bloom is not None:
+        settings.seeds_per_bloom = seeds_per_bloom
+    if rng_seed is not None:
+        settings.rng_seed = rng_seed
+
+    print_info(f"Run: {pipeline_id}")
+    print_info(
+        f"Perturbation LLM: provider={settings.provider}, model={settings.model_id}, "
+        f"language={settings.language}"
+    )
+    print_info(
+        f"Sampling: {settings.seeds_per_bloom}/Bloom level, rng_seed={settings.rng_seed}, "
+        f"retries={settings.retry_max}"
+    )
+    if regenerate:
+        print_warning("--regenerate: clearing checkpoint; every seed will be re-perturbed.")
+
+    try:
+        result = run_generate_non_answerable_batch(
+            pipeline_id=pipeline_id, settings=settings, regenerate=regenerate
+        )
+    except FileNotFoundError as exc:
+        print_error(str(exc))
+        raise typer.Exit(code=1) from exc
+    except (RuntimeError, ValueError) as exc:
+        print_error(f"Invalid non_answerable configuration: {exc}")
+        raise typer.Exit(code=1) from exc
+
+    if result.seeds_skipped_resumed:
+        print_info(f"Resumed: {result.seeds_skipped_resumed} seed(s) already processed.")
+    if result.seeds_failed:
+        print_warning(
+            f"Skipped {result.seeds_failed} seed(s) with no valid swap after retries "
+            f"(no perturbable entity, or all candidates collided)."
+        )
+    if result.items_built:
+        print_info(f"Newly perturbed this run: {result.items_built} item(s).")
+    print_info(
+        f"Dataset: {result.dataset_items} item(s) from {result.seed_count} seed(s) "
+        f"(success rate {result.success_rate:.1%})."
+    )
+    print_success(f"Wrote {result.dataset_path}")

--- a/src/arandu/cli/retrieve.py
+++ b/src/arandu/cli/retrieve.py
@@ -79,7 +79,7 @@ def retrieve(
     """Run Phase C retrievers over a populated run.
 
     Reads QA pairs from ``results/<id>/cep/outputs/`` and (when present)
-    non-answerable items from ``results/<id>/nonanswerable/outputs/``;
+    non-answerable items from ``results/<id>/non_answerable/outputs/``;
     emits one ``RetrievalRecord`` per (arm, question) tuple under
     ``results/<id>/retrieve/outputs/<arm>/<source>/<safe_qa_pair_id>.json``.
 

--- a/src/arandu/qa/non_answerable/__init__.py
+++ b/src/arandu/qa/non_answerable/__init__.py
@@ -1,0 +1,15 @@
+"""Non-answerable benchmark construction (spec §7).
+
+Derives non-answerable QA items from validated CEP pairs by swapping one
+named entity for a plausible alternative that is absent from both the KG
+and the source corpus. Each item keeps a ``parent_qa_pair_id`` link to
+its answerable twin so the analysis stage can run paired comparisons.
+
+Public entry point:
+
+- :func:`run_generate_non_answerable_batch` - CLI driver.
+"""
+
+from arandu.qa.non_answerable.batch import run_generate_non_answerable_batch
+
+__all__ = ["run_generate_non_answerable_batch"]

--- a/src/arandu/qa/non_answerable/batch.py
+++ b/src/arandu/qa/non_answerable/batch.py
@@ -39,6 +39,11 @@ logger = logging.getLogger(__name__)
 CHECKPOINT_FILENAME = "non_answerable_checkpoint.json"
 _ITEMS_SUBDIR = "items"
 
+# One perturbation per seed is the design (spec §7.7): ~400 seeds already
+# give sufficient power, and a second swap on the same seed yields a
+# near-duplicate. Recorded in the dataset for provenance; not configurable.
+_PERTURBATIONS_PER_SEED = 1
+
 
 class NonAnswerableBatchConfig(BaseModel):
     """Run-metadata snapshot for the non_answerable stage."""
@@ -48,7 +53,6 @@ class NonAnswerableBatchConfig(BaseModel):
     model_id: str
     language: str
     seeds_per_bloom: int
-    perturbations_per_seed: int
     rng_seed: int
 
 
@@ -103,7 +107,8 @@ def run_generate_non_answerable_batch(
             f"Run `arandu generate-cep-qa` + `arandu judge-qa` first."
         )
 
-    kg_node_set = _load_kg_nodes(base / pipeline_id / "kg" / "outputs" / "kg_graphml")
+    kg_graphml_dir = base / pipeline_id / "kg" / "outputs" / "atlas_output" / "kg_graphml"
+    kg_node_set = _load_kg_nodes(kg_graphml_dir)
     corpus_index = SourceCorpusIndex(base / pipeline_id / "transcription" / "outputs")
     logger.info("Absence gates: %d KG nodes, %d corpus spans.", len(kg_node_set), len(corpus_index))
 
@@ -115,7 +120,6 @@ def run_generate_non_answerable_batch(
         model_id=resolved.model_id,
         language=resolved.language,
         seeds_per_bloom=resolved.seeds_per_bloom,
-        perturbations_per_seed=resolved.perturbations_per_seed,
         rng_seed=resolved.rng_seed,
     )
     results_mgr = ResultsManager(base, PipelineType.NON_ANSWERABLE, pipeline_id=pipeline_id)
@@ -166,9 +170,9 @@ def run_generate_non_answerable_batch(
     dataset = NonAnswerableDataset(
         items=items,
         seed_cep_dataset=str(cep_dir),
-        kg_artifact=str(base / pipeline_id / "kg" / "outputs" / "kg_graphml"),
+        kg_artifact=str(kg_graphml_dir),
         seed_count=len(seeds),
-        perturbations_per_seed=resolved.perturbations_per_seed,
+        perturbations_per_seed=_PERTURBATIONS_PER_SEED,
         success_rate=success_rate,
         rng_seed=resolved.rng_seed,
     )

--- a/src/arandu/qa/non_answerable/batch.py
+++ b/src/arandu/qa/non_answerable/batch.py
@@ -1,0 +1,261 @@
+"""Batch driver for ``arandu generate-non-answerable`` (spec §7).
+
+Samples validated CEP pairs (stratified by Bloom level), perturbs each
+into a non-answerable twin via one LLM call + code-side verification,
+and writes a :class:`NonAnswerableDataset` under
+``results/<id>/non_answerable/outputs/dataset.json``.
+
+Per-seed checkpointing (keyed by ``parent_qa_pair_id``) makes the ~400
+LLM calls cost-safe to resume: a killed or re-run job skips seeds that
+already succeeded or were already attempted-and-collided.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel
+
+from arandu.qa.non_answerable.corpus_index import SourceCorpusIndex, load_kg_node_set
+from arandu.qa.non_answerable.perturbation import (
+    perturb_to_non_answerable,
+    stratified_seed_sample,
+)
+from arandu.qa.non_answerable.schemas import NonAnswerableDataset, NonAnswerableItem
+from arandu.qa.non_answerable.settings import NonAnswerableSettings
+from arandu.shared.checkpoint import CheckpointManager
+from arandu.shared.config import ResultsConfig
+from arandu.shared.llm_client import LLMClient, LLMProvider
+from arandu.shared.results_manager import ResultsManager
+from arandu.shared.schemas import PipelineType
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+CHECKPOINT_FILENAME = "non_answerable_checkpoint.json"
+_ITEMS_SUBDIR = "items"
+
+
+class NonAnswerableBatchConfig(BaseModel):
+    """Run-metadata snapshot for the non_answerable stage."""
+
+    pipeline_id: str
+    provider: str
+    model_id: str
+    language: str
+    seeds_per_bloom: int
+    perturbations_per_seed: int
+    rng_seed: int
+
+
+class NonAnswerableBatchResult(BaseModel):
+    """Summary of a completed non-answerable generation run."""
+
+    pipeline_id: str
+    run_dir: str
+    dataset_path: str
+    seed_count: int
+    items_built: int  # newly perturbed this invocation
+    dataset_items: int  # total items in dataset.json (incl. resumed)
+    seeds_skipped_resumed: int
+    seeds_failed: int
+    success_rate: float
+
+
+def run_generate_non_answerable_batch(
+    pipeline_id: str,
+    *,
+    settings: NonAnswerableSettings | None = None,
+    base_dir: Path | None = None,
+    regenerate: bool = False,
+) -> NonAnswerableBatchResult:
+    """Generate the non-answerable benchmark for ``pipeline_id``.
+
+    Args:
+        pipeline_id: Run identifier. The ``cep`` stage must be populated;
+            ``kg`` and ``transcription`` outputs are consulted for the
+            absence checks (their absence weakens, but does not abort,
+            verification - logged as a warning).
+        settings: Generation config. Defaults to
+            :class:`NonAnswerableSettings` (reads ``ARANDU_NONANSWERABLE_*``).
+        base_dir: Override the project ``results/`` root.
+        regenerate: If True, clear the checkpoint + previously written
+            items before running so every seed is re-perturbed.
+
+    Returns:
+        :class:`NonAnswerableBatchResult` summary.
+
+    Raises:
+        FileNotFoundError: If the CEP stage outputs aren't present.
+        RuntimeError: If a cloud-provider API key env var is unset.
+    """
+    resolved = settings if settings is not None else NonAnswerableSettings()
+    base = base_dir if base_dir is not None else ResultsConfig().base_dir
+
+    cep_dir = base / pipeline_id / "cep" / "outputs"
+    if not cep_dir.exists():
+        raise FileNotFoundError(
+            f"CEP outputs not found for pipeline_id {pipeline_id!r}: {cep_dir}. "
+            f"Run `arandu generate-cep-qa` + `arandu judge-qa` first."
+        )
+
+    kg_node_set = _load_kg_nodes(base / pipeline_id / "kg" / "outputs" / "kg_graphml")
+    corpus_index = SourceCorpusIndex(base / pipeline_id / "transcription" / "outputs")
+    logger.info("Absence gates: %d KG nodes, %d corpus spans.", len(kg_node_set), len(corpus_index))
+
+    llm_client = _build_llm_client(resolved)
+
+    config = NonAnswerableBatchConfig(
+        pipeline_id=pipeline_id,
+        provider=resolved.provider,
+        model_id=resolved.model_id,
+        language=resolved.language,
+        seeds_per_bloom=resolved.seeds_per_bloom,
+        perturbations_per_seed=resolved.perturbations_per_seed,
+        rng_seed=resolved.rng_seed,
+    )
+    results_mgr = ResultsManager(base, PipelineType.NON_ANSWERABLE, pipeline_id=pipeline_id)
+    results_mgr.create_run(
+        config, input_source=str(cep_dir), checkpoint_filename=CHECKPOINT_FILENAME
+    )
+
+    items_dir = results_mgr.outputs_dir / _ITEMS_SUBDIR
+    checkpoint_path = results_mgr.run_dir / CHECKPOINT_FILENAME
+    if regenerate:
+        _reset_state(checkpoint_path, items_dir)
+    items_dir.mkdir(parents=True, exist_ok=True)
+    checkpoint = CheckpointManager(checkpoint_path)
+
+    seeds = stratified_seed_sample(
+        cep_dir, seeds_per_bloom=resolved.seeds_per_bloom, rng_seed=resolved.rng_seed
+    )
+    checkpoint.set_total_files(len(seeds))
+
+    built = 0
+    resumed = 0
+    failed = 0
+    for seed in seeds:
+        key = seed.parent_qa_pair_id
+        if checkpoint.is_completed(key) or key in checkpoint.state.failed_files:
+            resumed += 1
+            continue
+        item = perturb_to_non_answerable(
+            seed,
+            kg_node_set=kg_node_set,
+            corpus_index=corpus_index,
+            llm=llm_client,
+            language=resolved.language,
+            base_temperature=resolved.base_temperature,
+            max_retries=resolved.retry_max,
+        )
+        if item is None:
+            checkpoint.mark_failed(key, "no valid swap after retries")
+            failed += 1
+            continue
+        item_path = items_dir / f"{_safe_name(key)}.json"
+        item_path.write_text(item.model_dump_json(indent=2), encoding="utf-8")
+        checkpoint.mark_completed(key)
+        built += 1
+
+    items = _collect_items(items_dir)
+    success_rate = len(items) / len(seeds) if seeds else 0.0
+    dataset = NonAnswerableDataset(
+        items=items,
+        seed_cep_dataset=str(cep_dir),
+        kg_artifact=str(base / pipeline_id / "kg" / "outputs" / "kg_graphml"),
+        seed_count=len(seeds),
+        perturbations_per_seed=resolved.perturbations_per_seed,
+        success_rate=success_rate,
+        rng_seed=resolved.rng_seed,
+    )
+    dataset_path = results_mgr.outputs_dir / "dataset.json"
+    dataset.save(dataset_path)
+
+    results_mgr.update_progress(built + resumed, failed, len(seeds))
+    results_mgr.complete_run(success=True)
+
+    return NonAnswerableBatchResult(
+        pipeline_id=pipeline_id,
+        run_dir=str(results_mgr.run_dir),
+        dataset_path=str(dataset_path),
+        seed_count=len(seeds),
+        items_built=built,
+        dataset_items=len(items),
+        seeds_skipped_resumed=resumed,
+        seeds_failed=failed,
+        success_rate=success_rate,
+    )
+
+
+def _load_kg_nodes(kg_graphml_dir: Path) -> set[str]:
+    """Union the normalized node labels across every ``*.graphml`` in the dir."""
+    if not kg_graphml_dir.exists():
+        logger.warning(
+            "KG graphml dir absent at %s; KG absence gate will be empty.", kg_graphml_dir
+        )
+        return set()
+    nodes: set[str] = set()
+    for path in sorted(kg_graphml_dir.glob("*.graphml")):
+        nodes |= load_kg_node_set(path)
+    return nodes
+
+
+def _collect_items(items_dir: Path) -> list[NonAnswerableItem]:
+    """Load every persisted item, sorted by ``qa_pair_id`` for determinism."""
+    items: list[NonAnswerableItem] = []
+    for path in sorted(items_dir.glob("*.json")):
+        try:
+            items.append(NonAnswerableItem.model_validate_json(path.read_text(encoding="utf-8")))
+        except (OSError, ValueError) as exc:
+            logger.warning("Skipping unreadable item %s: %s", path, exc)
+    items.sort(key=lambda it: it.qa_pair_id)
+    return items
+
+
+def _reset_state(checkpoint_path: Path, items_dir: Path) -> None:
+    """Clear checkpoint + previously written items for a clean regenerate."""
+    if checkpoint_path.exists():
+        checkpoint_path.unlink()
+    if items_dir.exists():
+        for path in items_dir.glob("*.json"):
+            path.unlink()
+
+
+def _safe_name(qa_pair_id: str) -> str:
+    """Turn a composite id into a filesystem-safe stem (colons → underscores)."""
+    return qa_pair_id.replace(":", "_").replace("/", "_")
+
+
+def _build_llm_client(settings: NonAnswerableSettings) -> LLMClient:
+    """Construct the unified LLMClient from settings (mirrors the judge stage)."""
+    try:
+        provider_enum = LLMProvider(settings.provider)
+    except ValueError as exc:
+        raise ValueError(
+            f"Unknown non_answerable provider {settings.provider!r}. "
+            f"Valid: {[p.value for p in LLMProvider]}."
+        ) from exc
+
+    api_key = os.environ.get(settings.api_key_env)
+    if not api_key and provider_enum is not LLMProvider.OLLAMA:
+        raise RuntimeError(
+            f"non_answerable provider {settings.provider!r} requires "
+            f"{settings.api_key_env} to be set. Either set it, or switch "
+            f"ARANDU_NONANSWERABLE_PROVIDER to 'ollama'."
+        )
+    if provider_enum is LLMProvider.CUSTOM and not settings.base_url:
+        raise ValueError(
+            "provider='custom' requires a base URL. Set ARANDU_NONANSWERABLE_BASE_URL "
+            "or pass base_url=... explicitly."
+        )
+
+    return LLMClient(
+        provider=provider_enum,
+        model_id=settings.model_id,
+        api_key=api_key,
+        base_url=settings.base_url,
+    )

--- a/src/arandu/qa/non_answerable/batch.py
+++ b/src/arandu/qa/non_answerable/batch.py
@@ -96,6 +96,8 @@ def run_generate_non_answerable_batch(
     Raises:
         FileNotFoundError: If the CEP stage outputs aren't present.
         RuntimeError: If a cloud-provider API key env var is unset.
+        ValueError: If the configured provider is unknown, or
+            ``provider='custom'`` is set without a ``base_url``.
     """
     resolved = settings if settings is not None else NonAnswerableSettings()
     base = base_dir if base_dir is not None else ResultsConfig().base_dir
@@ -141,32 +143,48 @@ def run_generate_non_answerable_batch(
 
     built = 0
     resumed = 0
-    failed = 0
     for seed in seeds:
         key = seed.parent_qa_pair_id
         if checkpoint.is_completed(key) or key in checkpoint.state.failed_files:
             resumed += 1
             continue
-        item = perturb_to_non_answerable(
-            seed,
-            kg_node_set=kg_node_set,
-            corpus_index=corpus_index,
-            llm=llm_client,
-            language=resolved.language,
-            base_temperature=resolved.base_temperature,
-            max_retries=resolved.retry_max,
-        )
+        try:
+            item = perturb_to_non_answerable(
+                seed,
+                kg_node_set=kg_node_set,
+                corpus_index=corpus_index,
+                llm=llm_client,
+                language=resolved.language,
+                base_temperature=resolved.base_temperature,
+                max_retries=resolved.retry_max,
+            )
+        except Exception as exc:
+            # Per-seed isolation (mirrors the answer/judge batch loops): a
+            # transient LLM/network failure on one seed must not abort the
+            # whole ~400-call run. Record it and move on; resume re-attempts.
+            logger.exception("Perturbation crashed for %s: %s", key, exc)
+            checkpoint.mark_failed(key, f"perturbation error: {exc}")
+            continue
         if item is None:
             checkpoint.mark_failed(key, "no valid swap after retries")
-            failed += 1
             continue
         item_path = items_dir / f"{_safe_name(key)}.json"
         item_path.write_text(item.model_dump_json(indent=2), encoding="utf-8")
         checkpoint.mark_completed(key)
         built += 1
 
+    # Derive the headline counts from the checkpoint over THIS run's seed
+    # set, so a resume reports the same completed/failed split as the
+    # original run (rather than folding prior failures into "resumed").
+    seed_keys = [seed.parent_qa_pair_id for seed in seeds]
+    completed_keys = {key for key in seed_keys if checkpoint.is_completed(key)}
+    failed_count = sum(1 for key in seed_keys if key in checkpoint.state.failed_files)
+    # success_rate is over the current seed set; completed_keys is a subset
+    # of seed_keys, so it can never exceed 1.0 even when items/ on disk
+    # holds extras from a larger prior run.
+    success_rate = len(completed_keys) / len(seeds) if seeds else 0.0
+
     items = _collect_items(items_dir)
-    success_rate = len(items) / len(seeds) if seeds else 0.0
     dataset = NonAnswerableDataset(
         items=items,
         seed_cep_dataset=str(cep_dir),
@@ -179,7 +197,7 @@ def run_generate_non_answerable_batch(
     dataset_path = results_mgr.outputs_dir / "dataset.json"
     dataset.save(dataset_path)
 
-    results_mgr.update_progress(built + resumed, failed, len(seeds))
+    results_mgr.update_progress(len(completed_keys), failed_count, len(seeds))
     results_mgr.complete_run(success=True)
 
     return NonAnswerableBatchResult(
@@ -190,7 +208,7 @@ def run_generate_non_answerable_batch(
         items_built=built,
         dataset_items=len(items),
         seeds_skipped_resumed=resumed,
-        seeds_failed=failed,
+        seeds_failed=failed_count,
         success_rate=success_rate,
     )
 

--- a/src/arandu/qa/non_answerable/corpus_index.py
+++ b/src/arandu/qa/non_answerable/corpus_index.py
@@ -1,0 +1,130 @@
+"""Absence-check structures for perturbation verification (spec §7.5).
+
+A swap is only valid if the replacement entity is absent from BOTH:
+
+- the KG node set (:func:`load_kg_node_set`) - entities the extractor saw, and
+- the source corpus (:class:`SourceCorpusIndex`) - a broader bag of NER
+  spans + alpha tokens straight from the transcriptions.
+
+Both use lower-cased, whitespace-stripped normalization so case and
+spacing differences don't leak a present entity through as "absent".
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from arandu.shared.schemas import EnrichedRecord
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_MIN_ALPHA_TOKEN_LEN = 3
+
+
+def _normalize(text: str) -> str:
+    """Lower-case + strip; the single normalization used on both sides."""
+    return text.strip().lower()
+
+
+def load_kg_node_set(graphml_path: Path) -> set[str]:
+    """Load the lower-cased label set from a KG GraphML file.
+
+    Falls back to the node id when a node carries no ``label`` attribute.
+    Returns an empty set (with a warning) if NetworkX or the file is
+    unavailable - the corpus index still provides an absence check.
+
+    Args:
+        graphml_path: Path to ``kg_graphml/<keyword>_graph.graphml``.
+
+    Returns:
+        Set of normalized node labels.
+    """
+    try:
+        import networkx as nx
+    except ImportError:
+        logger.warning("networkx unavailable; KG node absence check disabled.")
+        return set()
+    if not graphml_path.exists():
+        logger.warning("KG GraphML absent at %s; KG node absence check disabled.", graphml_path)
+        return set()
+    graph = nx.read_graphml(str(graphml_path))
+    return {_normalize(data.get("label") or node_id) for node_id, data in graph.nodes(data=True)}
+
+
+class SourceCorpusIndex:
+    """Bag of named entities + alpha tokens drawn from the source corpus.
+
+    Built once per run over every :class:`EnrichedRecord` transcription.
+    Membership is the second absence gate for a candidate replacement
+    entity. Uses spaCy ``pt_core_news_sm`` with NER enabled; when the
+    model is unavailable it degrades to an alpha-token-only bag (logged)
+    so generation still runs, just with a weaker corpus gate.
+    """
+
+    def __init__(self, transcription_dir: Path) -> None:
+        """Build the index from every ``EnrichedRecord`` under ``transcription_dir``."""
+        self._spans: set[str] = set()
+        self._nlp = _portuguese_nlp()
+        self._build(transcription_dir)
+
+    def __contains__(self, candidate: str) -> bool:
+        """True if ``candidate`` (normalized) appears anywhere in the corpus."""
+        return _normalize(candidate) in self._spans
+
+    def __len__(self) -> int:
+        """Number of distinct spans indexed."""
+        return len(self._spans)
+
+    def _build(self, transcription_dir: Path) -> None:
+        if not transcription_dir.exists():
+            logger.warning(
+                "Transcription dir absent at %s; corpus absence check will be empty.",
+                transcription_dir,
+            )
+            return
+        for path in sorted(transcription_dir.glob("*.json")):
+            try:
+                record = EnrichedRecord.model_validate_json(path.read_text(encoding="utf-8"))
+            except (OSError, ValueError) as exc:
+                logger.warning("Skipping unreadable transcription %s: %s", path, exc)
+                continue
+            self._index_text(record.transcription_text)
+
+    def _index_text(self, text: str) -> None:
+        if self._nlp is not None:
+            doc = self._nlp(text)
+            self._spans |= {_normalize(ent.text) for ent in doc.ents}
+            self._spans |= {
+                _normalize(tok.text)
+                for tok in doc
+                if tok.is_alpha and len(tok.text) > _MIN_ALPHA_TOKEN_LEN
+            }
+            return
+        # Fallback: whitespace alpha-token bag (no NER).
+        self._spans |= {
+            _normalize(tok)
+            for tok in text.split()
+            if tok.isalpha() and len(tok) > _MIN_ALPHA_TOKEN_LEN
+        }
+
+
+def _portuguese_nlp() -> Callable[[str], object] | None:
+    """Load spaCy ``pt_core_news_sm`` with NER; return None if unavailable."""
+    try:
+        import spacy
+    except ImportError:
+        logger.warning("spaCy unavailable; corpus index falls back to token-only bag.")
+        return None
+    try:
+        # Keep NER; drop the parser (unused) to save time on long transcripts.
+        return spacy.load("pt_core_news_sm", disable=["parser", "lemmatizer"])
+    except OSError:
+        logger.warning(
+            "spaCy 'pt_core_news_sm' unavailable; corpus index falls back to token-only bag."
+        )
+        return None

--- a/src/arandu/qa/non_answerable/corpus_index.py
+++ b/src/arandu/qa/non_answerable/corpus_index.py
@@ -23,7 +23,10 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-_MIN_ALPHA_TOKEN_LEN = 3
+# Tokens shorter than this are skipped (drops articles/prepositions like
+# "de", "em", "as"). Applied inclusively: a token of exactly this length
+# is kept.
+_MIN_ALPHA_TOKEN_LEN = 4
 
 
 def _normalize(text: str) -> str:
@@ -102,14 +105,14 @@ class SourceCorpusIndex:
             self._spans |= {
                 _normalize(tok.text)
                 for tok in doc
-                if tok.is_alpha and len(tok.text) > _MIN_ALPHA_TOKEN_LEN
+                if tok.is_alpha and len(tok.text) >= _MIN_ALPHA_TOKEN_LEN
             }
             return
         # Fallback: whitespace alpha-token bag (no NER).
         self._spans |= {
             _normalize(tok)
             for tok in text.split()
-            if tok.isalpha() and len(tok) > _MIN_ALPHA_TOKEN_LEN
+            if tok.isalpha() and len(tok) >= _MIN_ALPHA_TOKEN_LEN
         }
 
 

--- a/src/arandu/qa/non_answerable/perturbation.py
+++ b/src/arandu/qa/non_answerable/perturbation.py
@@ -45,6 +45,7 @@ class SeedPair(BaseModel):
 
     parent_qa_pair_id: str
     source_file_id: str
+    chunker_id: str
     pair: QAPairCEP
 
 
@@ -86,6 +87,7 @@ def stratified_seed_sample(
                 SeedPair(
                     parent_qa_pair_id=parent_id,
                     source_file_id=record.source_file_id,
+                    chunker_id=record.chunker_id,
                     pair=pair,
                 )
             )
@@ -172,6 +174,7 @@ def _build_item(seed: SeedPair, output: PerturbationOutput) -> NonAnswerableItem
         bloom_level=seed.pair.bloom_level,
         question_type=seed.pair.question_type,
         source_file_id=seed.source_file_id,
+        chunker_id=seed.chunker_id,
         parent_qa_pair_id=seed.parent_qa_pair_id,
         swapped_entity=SwapRecord(
             original_entity=output.original_entity,

--- a/src/arandu/qa/non_answerable/perturbation.py
+++ b/src/arandu/qa/non_answerable/perturbation.py
@@ -1,0 +1,181 @@
+"""Entity-swap perturbation + stratified seeding (spec §7.3, §7.6).
+
+One LLM call rewrites a CEP question by swapping a single named entity
+for a plausible same-type alternative. The LLM never sees the KG node
+list; verification is entirely code-side: the replacement must be absent
+from both the KG and the source corpus, and the claimed original entity
+must really appear in the question.
+"""
+
+from __future__ import annotations
+
+import logging
+import random
+from collections import defaultdict
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel
+
+from arandu.qa.non_answerable.prompts import render_perturbation_prompt
+from arandu.qa.non_answerable.schemas import (
+    NonAnswerableItem,
+    PerturbationOutput,
+    SwapRecord,
+)
+from arandu.qa.schemas import QAPairCEP, QARecordCEP
+from arandu.shared.llm_client import StructuredOutputError
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from arandu.qa.non_answerable.corpus_index import SourceCorpusIndex
+    from arandu.shared.llm_client import LLMClient
+
+logger = logging.getLogger(__name__)
+
+
+class SeedPair(BaseModel):
+    """A sampled CEP pair plus the provenance needed to build its twin.
+
+    ``parent_qa_pair_id`` is constructed the same way the gold lookup and
+    analysis loader build it (``<source_file_id>:<chunk_id|none>:<idx>``)
+    so the non-answerable item's ``parent_qa_pair_id`` joins cleanly to
+    the answerable pair in the analysis stage.
+    """
+
+    parent_qa_pair_id: str
+    source_file_id: str
+    pair: QAPairCEP
+
+
+def stratified_seed_sample(
+    cep_dir: Path,
+    *,
+    seeds_per_bloom: int = 100,
+    rng_seed: int = 42,
+) -> list[SeedPair]:
+    """Sample up to ``seeds_per_bloom`` validated CEP pairs per Bloom level.
+
+    Only pairs whose judge validation passed are eligible (spec §7.6) -
+    perturbing an already-rejected pair would compound noise. Sampling is
+    seeded so the benchmark is reproducible.
+
+    Args:
+        cep_dir: ``results/<id>/cep/outputs/`` holding ``QARecordCEP`` files.
+        seeds_per_bloom: Target seeds per Bloom level. Strata smaller than
+            this contribute their whole eligible pool.
+        rng_seed: Seed for the sampler (reproducibility).
+
+    Returns:
+        Flat list of :class:`SeedPair`, grouped-then-flattened by Bloom level.
+    """
+    rng = random.Random(rng_seed)
+    by_bloom: dict[str, list[SeedPair]] = defaultdict(list)
+    for path in sorted(cep_dir.glob("*.json")):
+        try:
+            record = QARecordCEP.model_validate_json(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError) as exc:
+            logger.warning("Skipping unreadable CEP file %s: %s", path, exc)
+            continue
+        for idx, pair in enumerate(record.qa_pairs):
+            if pair.validation is None or not pair.validation.passed:
+                continue
+            chunk_id_segment = pair.chunk_id or "none"
+            parent_id = f"{record.source_file_id}:{chunk_id_segment}:{idx}"
+            by_bloom[str(pair.bloom_level)].append(
+                SeedPair(
+                    parent_qa_pair_id=parent_id,
+                    source_file_id=record.source_file_id,
+                    pair=pair,
+                )
+            )
+
+    seeds: list[SeedPair] = []
+    for pool in by_bloom.values():
+        n = min(seeds_per_bloom, len(pool))
+        seeds.extend(rng.sample(pool, n))
+    return seeds
+
+
+def perturb_to_non_answerable(
+    seed: SeedPair,
+    *,
+    kg_node_set: set[str],
+    corpus_index: SourceCorpusIndex,
+    llm: LLMClient,
+    language: str = "pt",
+    base_temperature: float = 0.7,
+    max_retries: int = 3,
+) -> NonAnswerableItem | None:
+    """Perturb one seed into a non-answerable item, or ``None`` on collision.
+
+    Retries up to ``max_retries`` times, nudging temperature up each attempt
+    so a fresh sample is drawn when the replacement collides with the corpus
+    or KG. Returns ``None`` when every attempt collides (or the question has
+    no perturbable entity) - the caller records the miss in ``success_rate``.
+
+    Args:
+        seed: The CEP pair to perturb.
+        kg_node_set: Normalized KG label set; replacement must be absent.
+        corpus_index: Source-corpus membership gate; replacement must be absent.
+        llm: Unified LLM client.
+        language: Prompt language (``"pt"`` default).
+        base_temperature: Temperature for attempt 0; each retry adds 0.1.
+        max_retries: Total attempts before giving up.
+
+    Returns:
+        A populated :class:`NonAnswerableItem`, or ``None`` if no valid swap
+        was produced.
+    """
+    prompt = render_perturbation_prompt(language, question=seed.pair.question)
+    for attempt in range(max_retries):
+        try:
+            output = llm.generate_structured(
+                prompt,
+                PerturbationOutput,
+                temperature=base_temperature + 0.1 * attempt,
+            )
+        except StructuredOutputError as exc:
+            logger.warning(
+                "Perturbation parse failed for %s (attempt %d/%d): %s",
+                seed.parent_qa_pair_id,
+                attempt + 1,
+                max_retries,
+                exc,
+            )
+            continue
+        if _is_valid_swap(output, seed.pair.question, kg_node_set, corpus_index):
+            return _build_item(seed, output)
+    return None
+
+
+def _is_valid_swap(
+    output: PerturbationOutput,
+    question: str,
+    kg_node_set: set[str],
+    corpus_index: SourceCorpusIndex,
+) -> bool:
+    """Verify the swap: replacement absent everywhere, original really present."""
+    replacement_norm = output.replacement_entity.strip().lower()
+    return (
+        replacement_norm not in kg_node_set
+        and output.replacement_entity not in corpus_index
+        and output.original_entity.strip().lower() in question.lower()
+    )
+
+
+def _build_item(seed: SeedPair, output: PerturbationOutput) -> NonAnswerableItem:
+    """Assemble the persisted :class:`NonAnswerableItem` from a valid swap."""
+    return NonAnswerableItem(
+        qa_pair_id=f"{seed.parent_qa_pair_id}:nonans",
+        question=output.new_question,
+        bloom_level=seed.pair.bloom_level,
+        question_type=seed.pair.question_type,
+        source_file_id=seed.source_file_id,
+        parent_qa_pair_id=seed.parent_qa_pair_id,
+        swapped_entity=SwapRecord(
+            original_entity=output.original_entity,
+            replacement_entity=output.replacement_entity,
+            entity_type=output.entity_type,
+        ),
+    )

--- a/src/arandu/qa/non_answerable/prompts.py
+++ b/src/arandu/qa/non_answerable/prompts.py
@@ -1,0 +1,37 @@
+"""Jinja prompt loader for non-answerable perturbation (spec §7.4).
+
+Templates live under the project ``prompts/qa/non_answerable/<lang>.j2``.
+Only ``pt`` ships today (project default); the loader is language-keyed
+so an ``en`` variant can drop in without code changes.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from jinja2 import Environment, FileSystemLoader, StrictUndefined, select_autoescape
+
+from arandu.utils.paths import get_project_root
+
+_PROMPTS_DIR = get_project_root() / "prompts" / "qa" / "non_answerable"
+
+_ENV = Environment(
+    loader=FileSystemLoader(str(_PROMPTS_DIR)),
+    autoescape=select_autoescape(disabled_extensions=("j2",), default_for_string=False),
+    undefined=StrictUndefined,
+    keep_trailing_newline=True,
+)
+
+
+def render_perturbation_prompt(language: Literal["pt", "en"], *, question: str) -> str:
+    """Render the perturbation prompt for ``language`` around ``question``.
+
+    Args:
+        language: ``"pt"`` or ``"en"``. Selects the template file.
+        question: The CEP question to perturb.
+
+    Returns:
+        The rendered prompt ready for :meth:`LLMClient.generate_structured`.
+    """
+    template = _ENV.get_template(f"{language}.j2")
+    return template.render(question=question)

--- a/src/arandu/qa/non_answerable/schemas.py
+++ b/src/arandu/qa/non_answerable/schemas.py
@@ -54,6 +54,7 @@ class NonAnswerableItem(JudgeResultMixin):
     bloom_level: BloomLevel
     question_type: QuestionType
     source_file_id: str = Field(..., min_length=1)
+    chunker_id: str = Field(..., min_length=1)
     parent_qa_pair_id: str = Field(..., min_length=1)
     perturbation_method: Literal["entity_swap_llm"] = "entity_swap_llm"
     swapped_entity: SwapRecord

--- a/src/arandu/qa/non_answerable/schemas.py
+++ b/src/arandu/qa/non_answerable/schemas.py
@@ -1,0 +1,82 @@
+"""Schemas for the non-answerable benchmark (spec §7.2).
+
+- :class:`PerturbationOutput` - structured LLM response from one swap call.
+- :class:`SwapRecord` - the persisted entity-swap provenance.
+- :class:`NonAnswerableItem` - one non-answerable QA item (twin of a CEP pair).
+- :class:`NonAnswerableDataset` - the full dataset + generation provenance.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Literal
+
+from pydantic import BaseModel, Field
+
+from arandu.shared.judge.schemas import JudgeResultMixin
+from arandu.shared.schemas import BloomLevel  # noqa: TC001
+
+if TYPE_CHECKING:
+    from typing import Self
+
+QuestionType = Literal["factual", "conceptual", "temporal", "entity"]
+
+
+class PerturbationOutput(BaseModel):
+    """Structured output from a single LLM perturbation call (spec §7.4)."""
+
+    original_entity: str = Field(..., min_length=1)
+    entity_type: str = Field(..., min_length=1)
+    replacement_entity: str = Field(..., min_length=1)
+    new_question: str = Field(..., min_length=1)
+
+
+class SwapRecord(BaseModel):
+    """Provenance of the entity swap that produced a non-answerable item."""
+
+    original_entity: str = Field(..., min_length=1)
+    replacement_entity: str = Field(..., min_length=1)
+    entity_type: str = Field(..., min_length=1)
+
+
+class NonAnswerableItem(JudgeResultMixin):
+    """A non-answerable QA item derived from a validated CEP pair.
+
+    Shares the ``qa_pair_id`` namespace with :class:`QAPairCEP` (the
+    answerable twin) so retrieval, answering, and judging treat it like
+    any other benchmark item. ``is_answerable`` is pinned ``False`` so
+    the analysis stage classifies it into the TA / FC column.
+    """
+
+    qa_pair_id: str = Field(..., min_length=1)
+    question: str = Field(..., min_length=1)
+    bloom_level: BloomLevel
+    question_type: QuestionType
+    source_file_id: str = Field(..., min_length=1)
+    parent_qa_pair_id: str = Field(..., min_length=1)
+    perturbation_method: Literal["entity_swap_llm"] = "entity_swap_llm"
+    swapped_entity: SwapRecord
+    is_answerable: Literal[False] = False
+
+
+class NonAnswerableDataset(BaseModel):
+    """Full non-answerable benchmark plus generation provenance."""
+
+    items: list[NonAnswerableItem]
+    seed_cep_dataset: str
+    kg_artifact: str
+    seed_count: int = Field(..., ge=0)
+    perturbations_per_seed: int = Field(..., ge=1)
+    success_rate: float = Field(..., ge=0.0, le=1.0)
+    rng_seed: int
+    generated_at: datetime = Field(default_factory=datetime.now)
+
+    def save(self, path: str | Path) -> None:
+        """Serialize this dataset to ``path`` as JSON."""
+        Path(path).write_text(self.model_dump_json(indent=2), encoding="utf-8")
+
+    @classmethod
+    def load(cls, path: str | Path) -> Self:
+        """Load a dataset from ``path``."""
+        return cls.model_validate_json(Path(path).read_text(encoding="utf-8"))

--- a/src/arandu/qa/non_answerable/settings.py
+++ b/src/arandu/qa/non_answerable/settings.py
@@ -18,9 +18,7 @@ class NonAnswerableSettings(BaseSettings):
         api_key_env: Env var holding the API key. Ignored for ollama.
         base_url: Base URL override; ``None`` uses the per-provider default.
         language: Prompt language (``"pt"`` project default).
-        seeds_per_bloom: Target seeds per Bloom level. 100 → ~400 total.
-        perturbations_per_seed: Perturbations per seed. 1 is sufficient at
-            ~400 seeds and avoids near-duplicate variants (spec §7.7).
+        seeds_per_bloom: Target seeds per Bloom level. 100 -> ~400 total.
         rng_seed: Sampler seed for reproducibility.
         retry_max: Collision retries per seed before skipping it.
         base_temperature: Temperature for the first perturbation attempt;
@@ -33,7 +31,6 @@ class NonAnswerableSettings(BaseSettings):
     base_url: str | None = Field(default=None)
     language: Literal["pt", "en"] = Field(default="pt")
     seeds_per_bloom: int = Field(default=100, ge=1)
-    perturbations_per_seed: int = Field(default=1, ge=1)
     rng_seed: int = Field(default=42)
     retry_max: int = Field(default=3, ge=1)
     base_temperature: float = Field(default=0.7, ge=0.0, le=2.0)

--- a/src/arandu/qa/non_answerable/settings.py
+++ b/src/arandu/qa/non_answerable/settings.py
@@ -1,0 +1,49 @@
+"""Pydantic settings for non-answerable generation (env ``ARANDU_NONANSWERABLE_``)."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import Field, field_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class NonAnswerableSettings(BaseSettings):
+    """LLM + sampling settings for the non-answerable builder (spec §7, §12).
+
+    Attributes:
+        provider: LLM provider. Defaults to ``"ollama"`` (local qwen3:14b
+            for thesis runs); flip to ``"openai"`` for cloud.
+        model_id: Model identifier; defaults to ``"qwen3:14b"``.
+        api_key_env: Env var holding the API key. Ignored for ollama.
+        base_url: Base URL override; ``None`` uses the per-provider default.
+        language: Prompt language (``"pt"`` project default).
+        seeds_per_bloom: Target seeds per Bloom level. 100 → ~400 total.
+        perturbations_per_seed: Perturbations per seed. 1 is sufficient at
+            ~400 seeds and avoids near-duplicate variants (spec §7.7).
+        rng_seed: Sampler seed for reproducibility.
+        retry_max: Collision retries per seed before skipping it.
+        base_temperature: Temperature for the first perturbation attempt;
+            each retry adds 0.1 to diversify the sample.
+    """
+
+    provider: str = Field(default="ollama")
+    model_id: str = Field(default="qwen3:14b")
+    api_key_env: str = Field(default="OPENAI_API_KEY")
+    base_url: str | None = Field(default=None)
+    language: Literal["pt", "en"] = Field(default="pt")
+    seeds_per_bloom: int = Field(default=100, ge=1)
+    perturbations_per_seed: int = Field(default=1, ge=1)
+    rng_seed: int = Field(default=42)
+    retry_max: int = Field(default=3, ge=1)
+    base_temperature: float = Field(default=0.7, ge=0.0, le=2.0)
+
+    model_config = SettingsConfigDict(env_prefix="ARANDU_NONANSWERABLE_", extra="ignore")
+
+    @field_validator("provider", mode="before")
+    @classmethod
+    def _normalize_provider(cls, v: str) -> str:
+        """Lowercase the provider so env-var case doesn't break dispatch."""
+        if isinstance(v, str):
+            return v.lower()
+        return v

--- a/src/arandu/shared/rag/retrieve/batch.py
+++ b/src/arandu/shared/rag/retrieve/batch.py
@@ -145,7 +145,7 @@ def run_retrieve_batch(
 
     base = base_dir if base_dir is not None else ResultsConfig().base_dir
     cep_dir = base / pipeline_id / "cep" / "outputs"
-    nonanswerable_dir = base / pipeline_id / "nonanswerable" / "outputs"
+    nonanswerable_dir = base / pipeline_id / PipelineType.NON_ANSWERABLE.value / "outputs"
 
     questions = load_questions(cep_dir, nonanswerable_dir)
     if not questions:

--- a/src/arandu/shared/rag/retrieve/loader.py
+++ b/src/arandu/shared/rag/retrieve/loader.py
@@ -4,9 +4,9 @@ The retrieve stage iterates two source datasets:
 
 - **CEP QA**: per-source ``QARecordCEP`` files at ``results/<id>/cep/outputs/*.json``.
   Each record holds many :class:`QAPairCEP` items; we iterate them.
-- **Non-answerable** (optional, when the ``nonanswerable`` stage has
-  populated): at ``results/<id>/nonanswerable/outputs/`` — silently
-  skipped when absent (that stage is still in development).
+- **Non-answerable** (optional, when the ``non_answerable`` stage has
+  populated): at ``results/<id>/non_answerable/outputs/`` - silently
+  skipped when absent.
 
 Both produce :class:`QuestionRecord` rows, distinguished by ``source``
 (``"cep"`` or ``"nonanswerable"``). The retrieve batch runner emits
@@ -101,11 +101,10 @@ def load_questions(cep_dir: Path, nonanswerable_dir: Path | None = None) -> list
 
     Args:
         cep_dir: ``results/<id>/cep/outputs/``. Each ``*.json`` is a
-            :class:`QARecordCEP`. ``FileNotFoundError`` if missing —
+            :class:`QARecordCEP`. ``FileNotFoundError`` if missing -
             CEP is required for any retrieve run.
-        nonanswerable_dir: ``results/<id>/nonanswerable/outputs/``. When
-            ``None`` or non-existent, silently skipped (the stage that
-            populates this is still in development).
+        nonanswerable_dir: ``results/<id>/non_answerable/outputs/``. When
+            ``None`` or non-existent, silently skipped.
 
     Returns:
         Flat list of :class:`QuestionRecord` rows. CEP rows first, in

--- a/src/arandu/shared/rag/retrieve/loader.py
+++ b/src/arandu/shared/rag/retrieve/loader.py
@@ -33,17 +33,17 @@ QuestionSource = Literal["cep", "nonanswerable"]
 
 
 class _NonAnswerableItem(BaseModel):
-    """Provisional schema for one non-answerable item.
+    """Narrow read-model for one non-answerable item.
 
-    Mirrors the spec §10.3 description of ``NonAnswerableItem`` shape
-    until the producer (``arandu generate-non-answerable``, still in
-    flight) lands and pins the canonical schema. When that producer
-    ships, this stub gets deleted in favour of the real model.
-
-    Accepts the spec field names plus a few likely aliases via
-    :class:`AliasChoices` so we don't have to second-guess the producer's
-    eventual field naming. Each ``AliasChoices`` tries its options in
-    order; first hit wins.
+    The producer (``arandu generate-non-answerable``) writes the full
+    :class:`~arandu.qa.non_answerable.schemas.NonAnswerableItem`, but the
+    retrieve stage only needs four fields to build a query stream. This
+    stub is kept deliberately narrow (ISP) and tolerant: ``extra="ignore"``
+    drops the producer's analysis-only fields (``bloom_level``,
+    ``swapped_entity``, ``parent_qa_pair_id``, …) and the
+    :class:`AliasChoices` decouple retrieve from non-breaking field
+    renames upstream. Each ``AliasChoices`` tries its options in order;
+    first hit wins.
     """
 
     model_config = {"extra": "ignore"}

--- a/src/arandu/shared/schemas.py
+++ b/src/arandu/shared/schemas.py
@@ -199,6 +199,7 @@ class PipelineType(StrEnum):
     ANSWERS = "answers"
     JUDGE_ANSWERS = "judge_answers"
     ANALYSIS = "analysis"
+    NON_ANSWERABLE = "non_answerable"
     EVALUATION = "evaluation"
 
 

--- a/tests/qa/non_answerable/conftest.py
+++ b/tests/qa/non_answerable/conftest.py
@@ -1,0 +1,91 @@
+"""Shared fixtures for non-answerable benchmark tests."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from arandu.qa.schemas import QAPairCEP, QARecordCEP
+from arandu.shared.judge.schemas import (
+    CriterionScore,
+    JudgePipelineResult,
+    JudgeStepResult,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _passed_validation() -> JudgePipelineResult:
+    return JudgePipelineResult(
+        stage_results={
+            "qa_judge": JudgeStepResult(
+                criterion_scores={
+                    "faithfulness": CriterionScore(score=0.9, threshold=0.6, rationale="ok")
+                }
+            )
+        },
+        passed=True,
+    )
+
+
+def make_pair(
+    *,
+    question: str,
+    bloom_level: str = "remember",
+    question_type: str = "factual",
+    chunk_id: str | None = "chk_00",
+    validated: bool = True,
+) -> QAPairCEP:
+    """Build a CEP pair; ``validated=False`` leaves validation unset (ineligible)."""
+    return QAPairCEP(
+        question=question,
+        answer="resposta",
+        context="contexto de origem",
+        question_type=question_type,
+        confidence=0.9,
+        bloom_level=bloom_level,
+        chunk_id=chunk_id,
+        validation=_passed_validation() if validated else None,
+    )
+
+
+def write_cep_record(
+    cep_dir: Path,
+    *,
+    source_file_id: str,
+    pairs: list[QAPairCEP],
+    filename: str | None = None,
+) -> None:
+    """Write one ``QARecordCEP`` JSON file under ``cep_dir``."""
+    cep_dir.mkdir(parents=True, exist_ok=True)
+    record = QARecordCEP(
+        source_gdrive_id=source_file_id,
+        source_filename=f"{source_file_id}.wav",
+        transcription_text="contexto de origem completo",
+        qa_pairs=pairs,
+        model_id="qwen3:14b",
+        provider="ollama",
+        total_pairs=len(pairs),
+    )
+    record.save(cep_dir / (filename or f"{source_file_id}.json"))
+
+
+@pytest.fixture
+def cep_dir(tmp_path: Path) -> Path:
+    """A CEP outputs dir with validated pairs across two Bloom levels."""
+    out = tmp_path / "results" / "run-x" / "cep" / "outputs"
+    write_cep_record(
+        out,
+        source_file_id="src1",
+        pairs=[
+            make_pair(question="Em que ano Maria viu a enchente?", bloom_level="remember"),
+            make_pair(
+                question="Como Maria explica a cheia?",
+                bloom_level="analyze",
+                question_type="conceptual",
+            ),
+        ],
+    )
+    return out

--- a/tests/qa/non_answerable/test_batch.py
+++ b/tests/qa/non_answerable/test_batch.py
@@ -11,6 +11,8 @@ from arandu.qa.non_answerable.batch import run_generate_non_answerable_batch
 from arandu.qa.non_answerable.schemas import NonAnswerableDataset, PerturbationOutput
 from arandu.qa.non_answerable.settings import NonAnswerableSettings
 
+from .conftest import make_pair, write_cep_record
+
 if TYPE_CHECKING:
     from pathlib import Path
 
@@ -128,3 +130,60 @@ def test_regenerate_clears_and_rebuilds(
     )
     assert result.items_built == 2
     assert patched_llm.calls == calls_after_first + 2  # re-perturbed every seed
+
+
+class _RaisingLLM:
+    """generate_structured always raises a non-StructuredOutputError (e.g. RetryError)."""
+
+    def generate_structured(self, *args: object, **kwargs: object) -> object:
+        raise RuntimeError("simulated transient API failure")
+
+
+def test_perturbation_crash_is_isolated_not_fatal(
+    tmp_path: Path, cep_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A non-StructuredOutputError (e.g. tenacity RetryError wrapping an API
+    # error) must not abort the whole batch: each seed is isolated, marked
+    # failed, and a dataset.json is still written.
+    monkeypatch.setattr(batch_mod, "_build_llm_client", lambda _s: _RaisingLLM())
+    base = tmp_path / "results"
+    result = run_generate_non_answerable_batch("run-x", base_dir=base, settings=_settings())
+    assert result.items_built == 0
+    assert result.seeds_failed == 2
+    assert result.success_rate == 0.0
+    assert (base / "run-x" / "non_answerable" / "outputs" / "dataset.json").exists()
+
+
+def test_reduced_seeds_on_resume_does_not_exceed_one(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Run 1 completes 3 same-Bloom seeds; a resume with seeds_per_bloom=1
+    # samples a subset already on disk. success_rate must stay <= 1.0
+    # (len(items)=3 on disk, len(current seeds)=1) rather than crash the
+    # NonAnswerableDataset validator.
+    fake = _FakeLLM()
+    monkeypatch.setattr(batch_mod, "_build_llm_client", lambda _s: fake)
+    base = tmp_path / "results"
+    cep = base / "run-y" / "cep" / "outputs"
+    write_cep_record(
+        cep,
+        source_file_id="src1",
+        pairs=[
+            make_pair(question=f"q{i} Maria?", bloom_level="remember", chunk_id=f"c{i}")
+            for i in range(3)
+        ],
+    )
+
+    first = run_generate_non_answerable_batch(
+        "run-y", base_dir=base, settings=NonAnswerableSettings(provider="ollama", seeds_per_bloom=3)
+    )
+    assert first.items_built == 3
+    assert first.dataset_items == 3
+
+    second = run_generate_non_answerable_batch(
+        "run-y", base_dir=base, settings=NonAnswerableSettings(provider="ollama", seeds_per_bloom=1)
+    )
+    assert second.seed_count == 1
+    assert second.dataset_items == 3  # all prior items still on disk
+    assert 0.0 <= second.success_rate <= 1.0
+    assert second.success_rate == 1.0  # the 1 sampled seed was already completed

--- a/tests/qa/non_answerable/test_batch.py
+++ b/tests/qa/non_answerable/test_batch.py
@@ -1,0 +1,104 @@
+"""End-to-end tests for the non-answerable batch driver (spec §7)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from arandu.qa.non_answerable import batch as batch_mod
+from arandu.qa.non_answerable.batch import run_generate_non_answerable_batch
+from arandu.qa.non_answerable.schemas import NonAnswerableDataset, PerturbationOutput
+from arandu.qa.non_answerable.settings import NonAnswerableSettings
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class _FakeLLM:
+    """Echoes a deterministic same-type swap, deriving names from the question."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def generate_structured(
+        self,
+        prompt: str,
+        response_model: type[PerturbationOutput],
+        *,
+        temperature: float = 0.3,
+        **kwargs: object,
+    ) -> PerturbationOutput:
+        self.calls += 1
+        # The seeded questions all contain "Maria"; swap it for "Joana".
+        return PerturbationOutput(
+            original_entity="Maria",
+            entity_type="person",
+            replacement_entity="Joana",
+            new_question="Em que ano Joana viu a enchente?",
+        )
+
+
+@pytest.fixture
+def patched_llm(monkeypatch: pytest.MonkeyPatch) -> _FakeLLM:
+    """Replace the batch's LLM client builder with a fake."""
+    fake = _FakeLLM()
+    monkeypatch.setattr(batch_mod, "_build_llm_client", lambda _settings: fake)
+    return fake
+
+
+def _settings() -> NonAnswerableSettings:
+    return NonAnswerableSettings(provider="ollama", seeds_per_bloom=10, rng_seed=7, retry_max=2)
+
+
+def test_missing_cep_raises(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError, match="CEP outputs not found"):
+        run_generate_non_answerable_batch("nope", base_dir=tmp_path, settings=_settings())
+
+
+def test_end_to_end_builds_dataset(tmp_path: Path, cep_dir: Path, patched_llm: _FakeLLM) -> None:
+    # cep_dir fixture writes under tmp_path/results/run-x/cep/outputs with
+    # two validated pairs (both contain "Maria"); base_dir is results/.
+    base = tmp_path / "results"
+    result = run_generate_non_answerable_batch("run-x", base_dir=base, settings=_settings())
+
+    assert result.seed_count == 2
+    assert result.items_built == 2
+    assert result.dataset_items == 2
+    assert result.success_rate == 1.0
+    assert patched_llm.calls == 2
+
+    dataset = NonAnswerableDataset.load(
+        base / "run-x" / "non_answerable" / "outputs" / "dataset.json"
+    )
+    assert len(dataset.items) == 2
+    assert all(item.is_answerable is False for item in dataset.items)
+    assert all(item.parent_qa_pair_id.startswith("src1:") for item in dataset.items)
+
+
+def test_resume_skips_completed_seeds(tmp_path: Path, cep_dir: Path, patched_llm: _FakeLLM) -> None:
+    base = tmp_path / "results"
+    first = run_generate_non_answerable_batch("run-x", base_dir=base, settings=_settings())
+    assert first.items_built == 2
+    calls_after_first = patched_llm.calls
+
+    second = run_generate_non_answerable_batch("run-x", base_dir=base, settings=_settings())
+    assert second.items_built == 0  # nothing newly perturbed
+    assert second.dataset_items == 2  # but the dataset is rebuilt from disk
+    assert second.seeds_skipped_resumed == 2
+    assert patched_llm.calls == calls_after_first  # no new LLM calls on resume
+    assert second.success_rate == 1.0
+
+
+def test_regenerate_clears_and_rebuilds(
+    tmp_path: Path, cep_dir: Path, patched_llm: _FakeLLM
+) -> None:
+    base = tmp_path / "results"
+    run_generate_non_answerable_batch("run-x", base_dir=base, settings=_settings())
+    calls_after_first = patched_llm.calls
+
+    result = run_generate_non_answerable_batch(
+        "run-x", base_dir=base, settings=_settings(), regenerate=True
+    )
+    assert result.items_built == 2
+    assert patched_llm.calls == calls_after_first + 2  # re-perturbed every seed

--- a/tests/qa/non_answerable/test_batch.py
+++ b/tests/qa/non_answerable/test_batch.py
@@ -74,6 +74,32 @@ def test_end_to_end_builds_dataset(tmp_path: Path, cep_dir: Path, patched_llm: _
     assert len(dataset.items) == 2
     assert all(item.is_answerable is False for item in dataset.items)
     assert all(item.parent_qa_pair_id.startswith("src1:") for item in dataset.items)
+    # chunker_id is inherited from the parent QARecordCEP (default "cep_4k").
+    assert all(item.chunker_id == "cep_4k" for item in dataset.items)
+    # perturbations_per_seed is pinned to 1 in provenance, not configurable.
+    assert dataset.perturbations_per_seed == 1
+
+
+def test_kg_gate_reads_atlas_output_path(
+    tmp_path: Path, cep_dir: Path, patched_llm: _FakeLLM
+) -> None:
+    # The fake always proposes replacement "Joana". Seed a KG graphml at the
+    # real path (kg/outputs/atlas_output/kg_graphml/) with a "Joana" node:
+    # every swap must now collide on the KG gate, proving _load_kg_nodes
+    # reads the atlas_output segment (the buggy path would yield 0 nodes
+    # and let every swap through).
+    import networkx as nx
+
+    base = tmp_path / "results"
+    kg_dir = base / "run-x" / "kg" / "outputs" / "atlas_output" / "kg_graphml"
+    kg_dir.mkdir(parents=True)
+    graph = nx.DiGraph()
+    graph.add_node("n0", label="Joana")
+    nx.write_graphml(graph, str(kg_dir / "corpus_graph.graphml"))
+
+    result = run_generate_non_answerable_batch("run-x", base_dir=base, settings=_settings())
+    assert result.items_built == 0
+    assert result.seeds_failed == 2
 
 
 def test_resume_skips_completed_seeds(tmp_path: Path, cep_dir: Path, patched_llm: _FakeLLM) -> None:

--- a/tests/qa/non_answerable/test_corpus_index.py
+++ b/tests/qa/non_answerable/test_corpus_index.py
@@ -15,6 +15,8 @@ if TYPE_CHECKING:
 
 
 class TestLoadKgNodeSet:
+    """Tests for loading the normalized KG node label set from GraphML."""
+
     def test_reads_labels_lowercased(self, tmp_path: Path) -> None:
         graph = nx.DiGraph()
         graph.add_node("n0", label="Maria")
@@ -55,6 +57,8 @@ def _write_transcription(transcription_dir: Path, *, file_id: str, text: str) ->
 
 
 class TestSourceCorpusIndex:
+    """Tests for the source-corpus membership gate (NER + token fallback)."""
+
     def test_token_fallback_indexes_alpha_tokens(self, tmp_path: Path, monkeypatch: object) -> None:
         # Force the no-spaCy fallback so the test is deterministic + fast.
         monkeypatch.setattr(ci, "_portuguese_nlp", lambda: None)  # type: ignore[attr-defined]

--- a/tests/qa/non_answerable/test_corpus_index.py
+++ b/tests/qa/non_answerable/test_corpus_index.py
@@ -1,0 +1,81 @@
+"""Tests for the absence-check structures (spec §7.5)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import networkx as nx
+
+from arandu.qa.non_answerable import corpus_index as ci
+from arandu.qa.non_answerable.corpus_index import SourceCorpusIndex, load_kg_node_set
+from arandu.shared.schemas import EnrichedRecord
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class TestLoadKgNodeSet:
+    def test_reads_labels_lowercased(self, tmp_path: Path) -> None:
+        graph = nx.DiGraph()
+        graph.add_node("n0", label="Maria")
+        graph.add_node("n1", label="Itaqui")
+        path = tmp_path / "corpus_graph.graphml"
+        nx.write_graphml(graph, str(path))
+        nodes = load_kg_node_set(path)
+        assert nodes == {"maria", "itaqui"}
+
+    def test_falls_back_to_node_id_without_label(self, tmp_path: Path) -> None:
+        graph = nx.DiGraph()
+        graph.add_node("Cheia2024")
+        path = tmp_path / "g.graphml"
+        nx.write_graphml(graph, str(path))
+        assert "cheia2024" in load_kg_node_set(path)
+
+    def test_absent_file_returns_empty(self, tmp_path: Path) -> None:
+        assert load_kg_node_set(tmp_path / "missing.graphml") == set()
+
+
+def _write_transcription(transcription_dir: Path, *, file_id: str, text: str) -> None:
+    transcription_dir.mkdir(parents=True, exist_ok=True)
+    record = EnrichedRecord(
+        file_id=file_id,
+        name=f"{file_id}.wav",
+        mimeType="audio/wav",
+        parents=["root"],
+        web_content_link=f"https://example.test/{file_id}",
+        transcription_text=text,
+        detected_language="pt",
+        language_probability=0.99,
+        model_id="whisper-large-v3",
+        compute_device="cpu",
+        processing_duration_sec=1.0,
+        transcription_status="completed",
+    )
+    (transcription_dir / f"{file_id}.json").write_text(record.model_dump_json(), encoding="utf-8")
+
+
+class TestSourceCorpusIndex:
+    def test_token_fallback_indexes_alpha_tokens(self, tmp_path: Path, monkeypatch: object) -> None:
+        # Force the no-spaCy fallback so the test is deterministic + fast.
+        monkeypatch.setattr(ci, "_portuguese_nlp", lambda: None)  # type: ignore[attr-defined]
+        tdir = tmp_path / "transcription" / "outputs"
+        _write_transcription(tdir, file_id="src1", text="Maria viu a enchente em Itaqui")
+        index = SourceCorpusIndex(tdir)
+        assert "maria" in index
+        assert "itaqui" in index
+        assert "enchente" in index
+        assert "joana" not in index
+
+    def test_short_tokens_excluded(self, tmp_path: Path, monkeypatch: object) -> None:
+        monkeypatch.setattr(ci, "_portuguese_nlp", lambda: None)  # type: ignore[attr-defined]
+        tdir = tmp_path / "transcription" / "outputs"
+        _write_transcription(tdir, file_id="src1", text="a de em Maria")
+        index = SourceCorpusIndex(tdir)
+        assert "maria" in index
+        assert "de" not in index  # len <= 3 excluded
+
+    def test_absent_dir_is_empty(self, tmp_path: Path, monkeypatch: object) -> None:
+        monkeypatch.setattr(ci, "_portuguese_nlp", lambda: None)  # type: ignore[attr-defined]
+        index = SourceCorpusIndex(tmp_path / "does-not-exist")
+        assert len(index) == 0
+        assert "anything" not in index

--- a/tests/qa/non_answerable/test_perturbation.py
+++ b/tests/qa/non_answerable/test_perturbation.py
@@ -1,0 +1,192 @@
+"""Tests for entity-swap perturbation + stratified seeding (spec §7.3, §7.6)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from arandu.qa.non_answerable.perturbation import (
+    SeedPair,
+    perturb_to_non_answerable,
+    stratified_seed_sample,
+)
+from arandu.qa.non_answerable.schemas import PerturbationOutput
+from arandu.shared.llm_client import StructuredOutputError
+
+from .conftest import make_pair, write_cep_record
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class _FakeLLM:
+    """Returns queued PerturbationOutputs (or raises) per generate_structured call."""
+
+    def __init__(self, outputs: list[PerturbationOutput | Exception]) -> None:
+        self._outputs = list(outputs)
+        self.calls = 0
+
+    def generate_structured(
+        self,
+        prompt: str,
+        response_model: type[PerturbationOutput],
+        *,
+        temperature: float = 0.3,
+        **kwargs: object,
+    ) -> PerturbationOutput:
+        self.calls += 1
+        result = self._outputs.pop(0)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+
+def _seed(question: str = "Em que ano Maria viu a enchente?") -> SeedPair:
+    return SeedPair(
+        parent_qa_pair_id="src:chk_00:0",
+        source_file_id="src",
+        pair=make_pair(question=question),
+    )
+
+
+class _NeverContains:
+    def __contains__(self, _: object) -> bool:
+        return False
+
+
+class _AlwaysContains:
+    def __contains__(self, _: object) -> bool:
+        return True
+
+
+class TestPerturb:
+    def test_valid_swap_builds_item(self) -> None:
+        output = PerturbationOutput(
+            original_entity="Maria",
+            entity_type="person",
+            replacement_entity="Joana",
+            new_question="Em que ano Joana viu a enchente?",
+        )
+        llm = _FakeLLM([output])
+        item = perturb_to_non_answerable(
+            _seed(),
+            kg_node_set=set(),
+            corpus_index=_NeverContains(),
+            llm=llm,
+            max_retries=3,
+        )
+        assert item is not None
+        assert item.qa_pair_id == "src:chk_00:0:nonans"
+        assert item.parent_qa_pair_id == "src:chk_00:0"
+        assert item.is_answerable is False
+        assert item.swapped_entity.replacement_entity == "Joana"
+        assert llm.calls == 1
+
+    def test_collision_then_success_retries(self) -> None:
+        colliding = PerturbationOutput(
+            original_entity="Maria",
+            entity_type="person",
+            replacement_entity="Itaqui",  # rejected by kg_node_set below
+            new_question="...",
+        )
+        good = PerturbationOutput(
+            original_entity="Maria",
+            entity_type="person",
+            replacement_entity="Joana",
+            new_question="Em que ano Joana viu a enchente?",
+        )
+        llm = _FakeLLM([colliding, good])
+        item = perturb_to_non_answerable(
+            _seed(),
+            kg_node_set={"itaqui"},
+            corpus_index=_NeverContains(),
+            llm=llm,
+            max_retries=3,
+        )
+        assert item is not None
+        assert item.swapped_entity.replacement_entity == "Joana"
+        assert llm.calls == 2
+
+    def test_all_collisions_returns_none(self) -> None:
+        output = PerturbationOutput(
+            original_entity="Maria",
+            entity_type="person",
+            replacement_entity="Joana",
+            new_question="...",
+        )
+        llm = _FakeLLM([output, output, output])
+        item = perturb_to_non_answerable(
+            _seed(),
+            kg_node_set=set(),
+            corpus_index=_AlwaysContains(),  # every replacement "in corpus"
+            llm=llm,
+            max_retries=3,
+        )
+        assert item is None
+        assert llm.calls == 3
+
+    def test_original_entity_not_in_question_rejected(self) -> None:
+        output = PerturbationOutput(
+            original_entity="Pedro",  # not in the question
+            entity_type="person",
+            replacement_entity="Joana",
+            new_question="...",
+        )
+        llm = _FakeLLM([output])
+        item = perturb_to_non_answerable(
+            _seed(),
+            kg_node_set=set(),
+            corpus_index=_NeverContains(),
+            llm=llm,
+            max_retries=1,
+        )
+        assert item is None
+
+    def test_parse_error_counts_as_attempt(self) -> None:
+        llm = _FakeLLM([StructuredOutputError("bad json")])
+        item = perturb_to_non_answerable(
+            _seed(),
+            kg_node_set=set(),
+            corpus_index=_NeverContains(),
+            llm=llm,
+            max_retries=1,
+        )
+        assert item is None
+        assert llm.calls == 1
+
+
+class TestStratifiedSeedSample:
+    def test_only_validated_pairs_eligible(self, tmp_path: Path) -> None:
+        cep = tmp_path / "cep"
+        write_cep_record(
+            cep,
+            source_file_id="s1",
+            pairs=[
+                make_pair(question="q1 Maria?", bloom_level="remember", validated=True),
+                make_pair(question="q2 Joao?", bloom_level="remember", validated=False),
+            ],
+        )
+        seeds = stratified_seed_sample(cep, seeds_per_bloom=10, rng_seed=1)
+        assert len(seeds) == 1
+        assert seeds[0].pair.question == "q1 Maria?"
+
+    def test_caps_per_bloom_and_is_reproducible(self, tmp_path: Path) -> None:
+        cep = tmp_path / "cep"
+        pairs = [
+            make_pair(question=f"q{i} Maria?", bloom_level="remember", chunk_id=f"c{i}")
+            for i in range(5)
+        ]
+        write_cep_record(cep, source_file_id="s1", pairs=pairs)
+        first = stratified_seed_sample(cep, seeds_per_bloom=3, rng_seed=42)
+        second = stratified_seed_sample(cep, seeds_per_bloom=3, rng_seed=42)
+        assert len(first) == 3
+        assert [s.parent_qa_pair_id for s in first] == [s.parent_qa_pair_id for s in second]
+
+    def test_parent_id_construction(self, tmp_path: Path) -> None:
+        cep = tmp_path / "cep"
+        write_cep_record(
+            cep,
+            source_file_id="s1",
+            pairs=[make_pair(question="q Maria?", chunk_id="chk_07")],
+        )
+        seeds = stratified_seed_sample(cep, seeds_per_bloom=10, rng_seed=1)
+        assert seeds[0].parent_qa_pair_id == "s1:chk_07:0"

--- a/tests/qa/non_answerable/test_perturbation.py
+++ b/tests/qa/non_answerable/test_perturbation.py
@@ -60,6 +60,8 @@ class _AlwaysContains:
 
 
 class TestPerturb:
+    """Tests for ``perturb_to_non_answerable`` swap + verification."""
+
     def test_valid_swap_builds_item(self) -> None:
         output = PerturbationOutput(
             original_entity="Maria",
@@ -157,6 +159,8 @@ class TestPerturb:
 
 
 class TestStratifiedSeedSample:
+    """Tests for Bloom-stratified seed sampling over validated CEP pairs."""
+
     def test_only_validated_pairs_eligible(self, tmp_path: Path) -> None:
         cep = tmp_path / "cep"
         write_cep_record(

--- a/tests/qa/non_answerable/test_perturbation.py
+++ b/tests/qa/non_answerable/test_perturbation.py
@@ -44,6 +44,7 @@ def _seed(question: str = "Em que ano Maria viu a enchente?") -> SeedPair:
     return SeedPair(
         parent_qa_pair_id="src:chk_00:0",
         source_file_id="src",
+        chunker_id="cep_4k",
         pair=make_pair(question=question),
     )
 
@@ -77,6 +78,7 @@ class TestPerturb:
         assert item is not None
         assert item.qa_pair_id == "src:chk_00:0:nonans"
         assert item.parent_qa_pair_id == "src:chk_00:0"
+        assert item.chunker_id == "cep_4k"
         assert item.is_answerable is False
         assert item.swapped_entity.replacement_entity == "Joana"
         assert llm.calls == 1
@@ -190,3 +192,4 @@ class TestStratifiedSeedSample:
         )
         seeds = stratified_seed_sample(cep, seeds_per_bloom=10, rng_seed=1)
         assert seeds[0].parent_qa_pair_id == "s1:chk_07:0"
+        assert seeds[0].chunker_id == "cep_4k"  # QARecordCEP default

--- a/tests/qa/non_answerable/test_schemas.py
+++ b/tests/qa/non_answerable/test_schemas.py
@@ -1,0 +1,80 @@
+"""Tests for non-answerable schemas (spec §7.2)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from pydantic import ValidationError
+
+from arandu.qa.non_answerable.schemas import (
+    NonAnswerableDataset,
+    NonAnswerableItem,
+    SwapRecord,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _item(qa_pair_id: str = "src:chk:0:nonans") -> NonAnswerableItem:
+    return NonAnswerableItem(
+        qa_pair_id=qa_pair_id,
+        question="Em que ano Joana viu a enchente?",
+        bloom_level="remember",
+        question_type="factual",
+        source_file_id="src",
+        parent_qa_pair_id="src:chk:0",
+        swapped_entity=SwapRecord(
+            original_entity="Maria", replacement_entity="Joana", entity_type="person"
+        ),
+    )
+
+
+class TestNonAnswerableItem:
+    def test_is_answerable_pinned_false(self) -> None:
+        assert _item().is_answerable is False
+
+    def test_cannot_override_is_answerable_true(self) -> None:
+        with pytest.raises(ValidationError):
+            _item().model_copy(update={"is_answerable": True}).model_validate(
+                _item().model_dump() | {"is_answerable": True}
+            )
+
+    def test_perturbation_method_defaults(self) -> None:
+        assert _item().perturbation_method == "entity_swap_llm"
+
+    def test_unjudged_by_default(self) -> None:
+        assert _item().validation is None
+        assert _item().is_valid is None
+
+
+class TestNonAnswerableDataset:
+    def test_round_trip(self, tmp_path: Path) -> None:
+        dataset = NonAnswerableDataset(
+            items=[_item()],
+            seed_cep_dataset="cep/outputs",
+            kg_artifact="kg/outputs/kg_graphml",
+            seed_count=1,
+            perturbations_per_seed=1,
+            success_rate=1.0,
+            rng_seed=42,
+        )
+        path = tmp_path / "dataset.json"
+        dataset.save(path)
+        loaded = NonAnswerableDataset.load(path)
+        assert loaded.seed_count == 1
+        assert loaded.items[0].qa_pair_id == "src:chk:0:nonans"
+        assert loaded.success_rate == 1.0
+
+    def test_success_rate_bounds(self) -> None:
+        with pytest.raises(ValidationError):
+            NonAnswerableDataset(
+                items=[],
+                seed_cep_dataset="x",
+                kg_artifact="y",
+                seed_count=0,
+                perturbations_per_seed=1,
+                success_rate=1.5,
+                rng_seed=42,
+            )

--- a/tests/qa/non_answerable/test_schemas.py
+++ b/tests/qa/non_answerable/test_schemas.py
@@ -24,6 +24,7 @@ def _item(qa_pair_id: str = "src:chk:0:nonans") -> NonAnswerableItem:
         bloom_level="remember",
         question_type="factual",
         source_file_id="src",
+        chunker_id="cep_4k",
         parent_qa_pair_id="src:chk:0",
         swapped_entity=SwapRecord(
             original_entity="Maria", replacement_entity="Joana", entity_type="person"

--- a/tests/qa/non_answerable/test_schemas.py
+++ b/tests/qa/non_answerable/test_schemas.py
@@ -33,6 +33,8 @@ def _item(qa_pair_id: str = "src:chk:0:nonans") -> NonAnswerableItem:
 
 
 class TestNonAnswerableItem:
+    """Tests for the NonAnswerableItem invariants."""
+
     def test_is_answerable_pinned_false(self) -> None:
         assert _item().is_answerable is False
 
@@ -51,6 +53,8 @@ class TestNonAnswerableItem:
 
 
 class TestNonAnswerableDataset:
+    """Tests for NonAnswerableDataset round-trip + field bounds."""
+
     def test_round_trip(self, tmp_path: Path) -> None:
         dataset = NonAnswerableDataset(
             items=[_item()],

--- a/tests/shared/test_results_manager.py
+++ b/tests/shared/test_results_manager.py
@@ -780,6 +780,7 @@ class TestPipelineType:
             "answers",
             "judge_answers",
             "analysis",
+            "non_answerable",
             "evaluation",
         }
         actual = {p.value for p in PipelineType}


### PR DESCRIPTION
## Summary

- Adds `arandu generate-non-answerable --id <pipeline_id>`, the automated entity-perturbation pipeline that derives non-answerable benchmark items from validated CEP pairs.
- **Why it matters:** this is the Tier 1 critical-path input for the RAG analysis confusion matrix. Without non-answerable items, the TA + FC cells (true-abstention + hallucination) are empty and the abstention/hallucination metrics are meaningless.
- One LLM call swaps a single named entity for a plausible same-type alternative; verification is entirely code-side (replacement absent from KG node set AND source corpus; original entity really present in the question). Up to 3 collision retries with a temperature bump.
- Each item carries `parent_qa_pair_id` linking to its answerable twin for paired analysis (spec §7.10); `is_answerable` pinned `False`. Stratified sampling (100 seeds/Bloom, seeded RNG) over judge-validated pairs only.

## Design decisions (deviating from stale spec §10.3)

- `--id` ResultsManager pattern (matches retrieve/answer/judge-answers/rag-analysis), not the spec's positional `cep_dataset` + `--output`.
- Module under `src/arandu/qa/non_answerable/`; Jinja2 prompt at `prompts/qa/non_answerable/pt.j2`.
- Per-seed checkpoint keyed by `parent_qa_pair_id` + incremental item writes → the ~400 LLM calls resume cost-safely after interruption.
- `SourceCorpusIndex` uses spaCy `pt_core_news_sm` NER with a token-only fallback when the model is absent (mirrors the BM25 tokenizer).
- New `PipelineType.NON_ANSWERABLE`.

## Output

`results/<id>/non_answerable/outputs/dataset.json` (`NonAnswerableDataset` with per-item provenance + `success_rate`); intermediate items under `outputs/items/`.

## Test plan

- [x] `uv run ruff check src/ tests/` -> clean
- [x] `uv run ruff format --check src/ tests/` -> clean
- [x] `uv run pytest` -> 1414 passed, 1 skipped (24 new)
- [ ] Real-corpus smoke on test-kg-04 (part of the Tier 2 experiment-dry-run task)