### PR TITLE
feat(rag): judge non-answerable items on abstention alone (spec §6, §8.1)

### DIFF
--- a/src/arandu/cli/judge_answers.py
+++ b/src/arandu/cli/judge_answers.py
@@ -50,11 +50,13 @@ def judge_answers(
 ) -> None:
     """Run the 4-criterion LLM judge over every AnswerRecord in a populated run.
 
-    Criteria: ``passage_coverage``, ``abstention``, ``answer_correctness``,
-    ``answer_faithfulness``. All run in ``score`` mode (none reject);
-    verdicts persist via :class:`JudgeResultMixin.validation` on each
-    :class:`AnswerRecord` copy under
-    ``judge_answers/outputs/<arm>/<source>/``.
+    Answerable items run all four criteria (``passage_coverage``,
+    ``abstention``, ``answer_correctness``, ``answer_faithfulness``) in
+    ``score`` mode (none reject). Non-answerable items (from
+    ``arandu generate-non-answerable``) have no gold answer and run the
+    ``abstention`` criterion alone. Verdicts persist via
+    :class:`JudgeResultMixin.validation` on each :class:`AnswerRecord`
+    copy under ``judge_answers/outputs/<arm>/<source>/``.
 
     Judge LLM configuration is read from ``ARANDU_JUDGE_ANSWERS_*`` env
     vars; see :class:`JudgeAnswersSettings` for fields.

--- a/src/arandu/shared/rag/judge_answers/batch.py
+++ b/src/arandu/shared/rag/judge_answers/batch.py
@@ -6,6 +6,13 @@ copies under ``results/<id>/judge_answers/outputs/<arm>/<source>/`` —
 each carrying the answer record's full content plus a populated
 ``validation`` field with per-criterion scores.
 
+Answerable items (``is_answerable=True``) require the CEP gold answer
+and run the full 4-criterion judge. Non-answerable items
+(``is_answerable=False``, from ``arandu generate-non-answerable``) have
+no gold answer, so they run the abstention criterion alone — that's
+what the analysis stage reads to split true-abstention (TA) from
+hallucination (FC).
+
 Emits an ``abstention_audit.jsonl`` file alongside the outputs when
 the answerer's structured ``abstained`` flag disagrees with the
 abstention judge's verdict (spec §6.4).
@@ -153,24 +160,32 @@ def run_judge_answers_batch(
             failed += 1
             continue
 
-        gold = gold_lookup.get(answer.qa_pair_id)
-        if gold is None:
-            logger.warning(
-                "No gold lookup for qa_pair_id=%s — skipping judge for %s.",
-                answer.qa_pair_id,
-                record_path,
-            )
-            checkpoint.mark_failed(ckpt_key, "no gold lookup")
-            failed += 1
-            continue
+        # Non-answerable items (is_answerable=False) have no gold answer;
+        # they are judged on abstention alone (TA vs FC). Answerable items
+        # require the CEP gold for the full 4-criterion judge.
+        gold = None
+        if answer.is_answerable:
+            gold = gold_lookup.get(answer.qa_pair_id)
+            if gold is None:
+                logger.warning(
+                    "No gold lookup for answerable qa_pair_id=%s — skipping judge for %s.",
+                    answer.qa_pair_id,
+                    record_path,
+                )
+                checkpoint.mark_failed(ckpt_key, "no gold lookup")
+                failed += 1
+                continue
 
         try:
-            judged = _judge_one(
-                judge=judge,
-                answer=answer,
-                gold=gold,
-                passage_text=passage_text,
-            )
+            if gold is not None:
+                judged = _judge_one(
+                    judge=judge,
+                    answer=answer,
+                    gold=gold,
+                    passage_text=passage_text,
+                )
+            else:
+                judged = _judge_one_nonanswerable(judge=judge, answer=answer)
         except Exception as exc:
             # Per-record isolation: log + continue per spec §6.6's
             # "all in score mode" contract (a bad record doesn't kill
@@ -293,6 +308,22 @@ def _judge_one(
         gold_answer=gold.gold_answer,
         system_answer=answer.answer_text or "",
         passages_text=passages_text,
+        abstained=str(answer.abstained).lower(),
+        answer_text=answer.answer_text or "",
+        rationale=answer.rationale,
+    )
+    return answer.model_copy(update={"validation": pipeline_result})
+
+
+def _judge_one_nonanswerable(*, judge: AnswerJudge, answer: AnswerRecord) -> AnswerRecord:
+    """Run the abstention-only judge on a non-answerable record.
+
+    Non-answerable items have no gold answer, so only ``abstention`` is
+    scored — that's what the analysis stage reads to split TA (correct
+    refusal) from FC (hallucination). The abstention prompt consumes only
+    the system's structured ``abstained`` flag, answer text, and rationale.
+    """
+    pipeline_result = judge.evaluate_abstention_only(
         abstained=str(answer.abstained).lower(),
         answer_text=answer.answer_text or "",
         rationale=answer.rationale,

--- a/src/arandu/shared/rag/judge_answers/judge.py
+++ b/src/arandu/shared/rag/judge_answers/judge.py
@@ -32,6 +32,7 @@ from arandu.shared.judge import (
 )
 
 if TYPE_CHECKING:
+    from arandu.shared.judge.schemas import JudgePipelineResult
     from arandu.shared.llm_client import LLMClient
     from arandu.shared.rag.judge_answers.settings import JudgeAnswersSettings
 
@@ -44,6 +45,13 @@ _LLM_CRITERIA = (
     "answer_correctness",
     "answer_faithfulness",
 )
+
+# Non-answerable items have no gold answer, so correctness / faithfulness /
+# passage_coverage are undefined for them. Only ``abstention`` is meaningful
+# (it decides TA vs FC in the analysis confusion matrix), so they are judged
+# on that criterion alone. The abstention prompt reads only the system's
+# ``abstained`` flag, answer text, and rationale — no gold needed.
+_ABSTENTION_ONLY = ("abstention",)
 
 
 class AnswerJudge(BaseJudge):
@@ -78,8 +86,34 @@ class AnswerJudge(BaseJudge):
         the judges don't gate each other (no filter mode); a single stage
         avoids redundant ``JudgePipelineResult`` machinery and gives the
         analysis stage one flat ``criterion_scores`` dict to consume.
+
+        Also builds a sibling abstention-only pipeline (same stage name,
+        so the analysis classifier finds the ``abstention`` score the same
+        way) for non-answerable items, which have no gold answer.
         """
+        self._abstention_pipeline = JudgePipeline(
+            stages=[
+                JudgeStage(
+                    name="answer_judge",
+                    step=JudgeStep(criteria=list(_ABSTENTION_ONLY), factory=self.factory),
+                    mode="score",
+                )
+            ],
+        )
         step = JudgeStep(criteria=list(_LLM_CRITERIA), factory=self.factory)
         return JudgePipeline(
             stages=[JudgeStage(name="answer_judge", step=step, mode="score")],
         )
+
+    def evaluate_abstention_only(self, **kwargs: object) -> JudgePipelineResult:
+        """Run only the ``abstention`` criterion (for non-answerable items).
+
+        Args:
+            **kwargs: Template parameters for the abstention prompt
+                (``abstained``, ``answer_text``, ``rationale``).
+
+        Returns:
+            A :class:`JudgePipelineResult` whose single stage carries the
+            ``abstention`` :class:`CriterionScore`.
+        """
+        return self._abstention_pipeline.evaluate(**kwargs)

--- a/tests/shared/rag/judge_answers/test_batch.py
+++ b/tests/shared/rag/judge_answers/test_batch.py
@@ -165,6 +165,77 @@ class TestRunJudgeAnswersBatch:
         assert result.judgments_written == 0
         assert result.judgments_failed >= 1
 
+    def test_nonanswerable_judged_via_abstention_only(self, tmp_path: Path) -> None:
+        # A non-answerable item (is_answerable=False) has no CEP gold, but
+        # must still be judged on abstention alone — not skipped. Here the
+        # system committed (abstained=False) on a non-answerable question,
+        # so the abstention score is low (an FC / hallucination).
+        out_dir = tmp_path / "run_x" / "answers" / "outputs" / "bm25" / "nonanswerable"
+        out_dir.mkdir(parents=True)
+        record = AnswerRecord(
+            qa_pair_id="src_a:chk_aa:0:nonans",
+            question="Onde Joana mora?",
+            retriever_id="bm25",
+            chunker_id="cep_4k",
+            top_k=5,
+            passages=[],
+            elapsed_ms=1.0,
+            is_answerable=False,
+            answer_text="Em Itaqui.",
+            abstained=False,
+            rationale="Committed despite no support.",
+            answerer_model="qwen3:14b",
+            answerer_temperature=0.2,
+        )
+        record.save(out_dir / "src_a__chk_aa__0__nonans.json")
+        # Deliberately no _seed_cep: non-answerable items need no gold.
+        settings = JudgeAnswersSettings(provider="ollama")
+
+        with (
+            patch("arandu.shared.rag.judge_answers.batch.LLMClient"),
+            patch("arandu.shared.rag.judge_answers.batch.AnswerJudge") as mock_judge_cls,
+        ):
+            judge = MagicMock()
+            judge.evaluate_abstention_only.return_value = JudgePipelineResult(
+                stage_results={
+                    "answer_judge": JudgeStepResult(
+                        criterion_scores={
+                            "abstention": CriterionScore(
+                                score=0.1, threshold=0.7, rationale="substantive claim"
+                            ),
+                        }
+                    )
+                },
+                passed=False,
+            )
+            mock_judge_cls.return_value = judge
+
+            result = run_judge_answers_batch(
+                pipeline_id="run_x", settings=settings, base_dir=tmp_path
+            )
+
+        assert result.judgments_written == 1
+        assert result.judgments_failed == 0
+        # The abstention-only path ran; the 4-criterion path did not.
+        judge.evaluate_abstention_only.assert_called_once()
+        judge.evaluate.assert_not_called()
+
+        judged_path = (
+            tmp_path
+            / "run_x"
+            / "judge_answers"
+            / "outputs"
+            / "bm25"
+            / "nonanswerable"
+            / "src_a__chk_aa__0__nonans.json"
+        )
+        rec = AnswerRecord.load(judged_path)
+        assert rec.validation is not None
+        scores = rec.validation.stage_results["answer_judge"].criterion_scores
+        assert "abstention" in scores
+        assert "answer_correctness" not in scores  # no gold → not scored
+        assert rec.is_answerable is False
+
     def test_resume_skips_completed_records(self, tmp_path: Path) -> None:
         _seed_answers(tmp_path)
         _seed_cep(tmp_path)


### PR DESCRIPTION
## Summary

Closes the integration gap found during the PR #112 review. The judge stage built its gold lookup from CEP pairs only, so non-answerable items (`qa_pair_id` `<parent>:nonans`, produced by `arandu generate-non-answerable`) missed `gold_lookup`, were marked "no gold lookup", and were skipped — leaving the analysis confusion matrix's **TA** (true-abstention) and **FC** (hallucination) cells permanently empty.

The batch now branches on `AnswerRecord.is_answerable`:

- **Answerable** items: unchanged — require the CEP gold and run the full 4-criterion judge.
- **Non-answerable** items: no gold answer exists, so they run the `abstention` criterion alone. The abstention prompt reads only the system's `abstained` flag, answer text, and rationale — and that score is exactly what the analysis stage's `classify_record` consumes to split TA from FC. `answer_correctness` / `answer_faithfulness` / `passage_coverage` are undefined without a gold answer and are skipped.

`AnswerJudge` gains a sibling abstention-only pipeline (same `answer_judge` stage name, so the analysis classifier finds the score identically), exposed via `evaluate_abstention_only`.

## Notes

- Answerable behavior is preserved, including the "no gold lookup" failure for a genuinely orphaned answerable `qa_pair_id`.
- This is the follow-up tracked after #112; it makes the non-answerable benchmark actually count end-to-end (`retrieve` → `answer` → `judge-answers` → `rag-analysis`).

## Test plan

- [x] `uv run ruff check src/ tests/` -> clean
- [x] `uv run ruff format --check src/ tests/` -> clean
- [x] `uv run pytest` -> 1418 passed, 1 skipped (new test: non-answerable item judged via abstention-only, not skipped)
- [ ] Real-corpus verification folded into the `experiment-dry-run` task