### PR TITLE
feat(rag): gated answer-judge pipeline + heuristic commitment gate (spec §6)

### DIFF
--- a/src/arandu/cli/judge_answers.py
+++ b/src/arandu/cli/judge_answers.py
@@ -50,14 +50,17 @@ def judge_answers(
 ) -> None:
     """Run the gated answer judge over every AnswerRecord in a populated run.
 
-    Pipeline: ``abstention`` (always scored) -> a heuristic
-    ``commitment_gate`` -> the gold-requiring criteria
-    (``answer_correctness``, ``answer_faithfulness``, ``passage_coverage``),
-    which run only for True-Commitment items (answerable + committed). The
-    gate skips gold scoring for abstained answers (no answer text) and for
-    non-answerable items (no gold), which are judged on abstention alone.
-    Verdicts persist via :class:`JudgeResultMixin.validation` on each
-    :class:`AnswerRecord` copy under ``judge_answers/outputs/<arm>/<source>/``.
+    Pipeline: ``abstention`` (always scored) -> heuristic
+    ``answerability_gate`` -> ``retrieval_scoring`` (``passage_coverage``,
+    runs for every answerable item) -> heuristic ``commitment_gate`` ->
+    ``answer_scoring`` (``answer_correctness``, ``answer_faithfulness``,
+    run only for True-Commitment items: answerable + committed). The
+    answerability gate skips both LLM-scoring stages for non-answerable
+    items (no gold), which are judged on abstention alone; the commitment
+    gate skips the answer-text scoring stage for abstained answers (no
+    answer text). Verdicts persist via :class:`JudgeResultMixin.validation`
+    on each :class:`AnswerRecord` copy under
+    ``judge_answers/outputs/<arm>/<source>/``.
 
     Judge LLM configuration is read from ``ARANDU_JUDGE_ANSWERS_*`` env
     vars; see :class:`JudgeAnswersSettings` for fields.

--- a/src/arandu/cli/judge_answers.py
+++ b/src/arandu/cli/judge_answers.py
@@ -48,13 +48,16 @@ def judge_answers(
         ),
     ] = False,
 ) -> None:
-    """Run the 4-criterion LLM judge over every AnswerRecord in a populated run.
+    """Run the gated answer judge over every AnswerRecord in a populated run.
 
-    Criteria: ``passage_coverage``, ``abstention``, ``answer_correctness``,
-    ``answer_faithfulness``. All run in ``score`` mode (none reject);
-    verdicts persist via :class:`JudgeResultMixin.validation` on each
-    :class:`AnswerRecord` copy under
-    ``judge_answers/outputs/<arm>/<source>/``.
+    Pipeline: ``abstention`` (always scored) -> a heuristic
+    ``commitment_gate`` -> the gold-requiring criteria
+    (``answer_correctness``, ``answer_faithfulness``, ``passage_coverage``),
+    which run only for True-Commitment items (answerable + committed). The
+    gate skips gold scoring for abstained answers (no answer text) and for
+    non-answerable items (no gold), which are judged on abstention alone.
+    Verdicts persist via :class:`JudgeResultMixin.validation` on each
+    :class:`AnswerRecord` copy under ``judge_answers/outputs/<arm>/<source>/``.
 
     Judge LLM configuration is read from ``ARANDU_JUDGE_ANSWERS_*`` env
     vars; see :class:`JudgeAnswersSettings` for fields.

--- a/src/arandu/shared/rag/judge_answers/batch.py
+++ b/src/arandu/shared/rag/judge_answers/batch.py
@@ -153,10 +153,15 @@ def run_judge_answers_batch(
             failed += 1
             continue
 
+        # Answerable items need their CEP gold for the gold-scoring stage;
+        # an orphan answerable qa_pair_id can't be judged. Non-answerable
+        # items (from `arandu generate-non-answerable`) have no gold and
+        # are judged on abstention alone — the commitment gate skips the
+        # gold criteria for them, so a missing gold is expected.
         gold = gold_lookup.get(answer.qa_pair_id)
-        if gold is None:
+        if answer.is_answerable and gold is None:
             logger.warning(
-                "No gold lookup for qa_pair_id=%s — skipping judge for %s.",
+                "No gold lookup for answerable qa_pair_id=%s — skipping judge for %s.",
                 answer.qa_pair_id,
                 record_path,
             )
@@ -278,24 +283,37 @@ def _judge_one(
     *,
     judge: AnswerJudge,
     answer: AnswerRecord,
-    gold: GoldRecord,
+    gold: GoldRecord | None,
     passage_text: dict[str, str],
 ) -> AnswerRecord:
-    """Run the 4 LLM criteria; attach verdict to the record.
+    """Run the gated judge pipeline; attach the verdict to the record.
 
-    Every kwarg below is consumed by at least one criterion's prompt
-    template (via ``string.Template.safe_substitute``). Criteria that
-    don't reference a given kwarg silently ignore it.
+    Every kwarg below is consumed by at least one stage. The commitment
+    gate reads ``is_answerable`` + ``abstained``; the abstention criterion
+    reads ``abstained`` / ``answer_text`` / ``rationale``; the gold-scoring
+    criteria read ``question`` / ``gold_answer`` / ``context`` / etc.
+    Criteria that don't reference a given kwarg silently ignore it (LLM
+    prompts via ``string.Template.safe_substitute``).
+
+    ``gold`` is ``None`` for non-answerable items (no CEP pair); the
+    commitment gate rejects those before the gold criteria run, so the
+    empty gold fields are never actually consumed.
     """
     passages_text = _format_passages(answer, passage_text)
     pipeline_result = judge.evaluate(
-        question=gold.question,
-        gold_answer=gold.gold_answer,
-        system_answer=answer.answer_text or "",
-        passages_text=passages_text,
+        is_answerable=answer.is_answerable,
         abstained=str(answer.abstained).lower(),
         answer_text=answer.answer_text or "",
+        system_answer=answer.answer_text or "",
         rationale=answer.rationale,
+        passages_text=passages_text,
+        question=gold.question if gold is not None else answer.question,
+        gold_answer=gold.gold_answer if gold is not None else "",
+        context=gold.context if gold is not None else "",
+        bloom_level=gold.bloom_level if gold is not None else "",
+        question_type=gold.question_type if gold is not None else "",
+        reasoning_trace=(gold.reasoning_trace or "") if gold is not None else "",
+        tacit_inference=(gold.tacit_inference or "") if gold is not None else "",
     )
     return answer.model_copy(update={"validation": pipeline_result})
 

--- a/src/arandu/shared/rag/judge_answers/gold_lookup.py
+++ b/src/arandu/shared/rag/judge_answers/gold_lookup.py
@@ -1,10 +1,15 @@
-"""Build the ``qa_pair_id`` → (question, gold answer) join the judge needs.
+"""Build the ``qa_pair_id`` → gold-context join the judge needs.
 
-The 4 answer-judging criteria need ground-truth context that lives in
-the CEP stage's output (:class:`QARecordCEP` files): the question and
-the gold answer. This module reads those artifacts once at batch start
-and produces a flat lookup keyed by the same ``qa_pair_id`` format the
-retrieve / answer stages emit (``"<file_id>:<chunk_id>:<idx>"``).
+The answer-judging criteria need ground-truth context that lives in the
+CEP stage's output (:class:`QARecordCEP` files). This module reads those
+artifacts once at batch start and produces a flat lookup keyed by the
+same ``qa_pair_id`` format the retrieve / answer stages emit
+(``"<file_id>:<chunk_id>:<idx>"``).
+
+Beyond the question + gold answer, the record carries the richer CEP
+signals (source context, Bloom level, question type, reasoning trace,
+tacit-knowledge annotation) so heuristic and LLM criteria can use them
+without a second pass over the CEP outputs.
 """
 
 from __future__ import annotations
@@ -12,7 +17,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel, Field, ValidationError
 
 from arandu.qa.schemas import QARecordCEP
 
@@ -23,11 +28,20 @@ logger = logging.getLogger(__name__)
 
 
 class GoldRecord(BaseModel):
-    """Ground-truth context for one ``qa_pair_id``."""
+    """Ground-truth context for one ``qa_pair_id`` (from its CEP pair)."""
 
     qa_pair_id: str
     question: str
     gold_answer: str
+    context: str = Field(default="", description="Source text the QA pair was generated from.")
+    bloom_level: str = Field(default="", description="Bloom's-taxonomy level of the question.")
+    question_type: str = Field(default="", description="factual | conceptual | temporal | entity.")
+    reasoning_trace: str | None = Field(
+        default=None, description="Logical connections leading to the answer, if any."
+    )
+    tacit_inference: str | None = Field(
+        default=None, description="Implicit/tacit knowledge used in the answer, if any."
+    )
 
 
 def build_gold_lookup(cep_dir: Path) -> dict[str, GoldRecord]:
@@ -36,7 +50,7 @@ def build_gold_lookup(cep_dir: Path) -> dict[str, GoldRecord]:
     Args:
         cep_dir: ``results/<id>/cep/outputs/``. Each ``*.json`` is a
             :class:`QARecordCEP` whose ``qa_pairs`` carry questions +
-            gold answers + chunk_id pointers.
+            gold answers + chunk_id pointers + the richer CEP signals.
 
     Returns:
         Flat dict; empty if ``cep_dir`` is absent.
@@ -58,5 +72,10 @@ def build_gold_lookup(cep_dir: Path) -> dict[str, GoldRecord]:
                 qa_pair_id=qa_pair_id,
                 question=pair.question,
                 gold_answer=pair.answer,
+                context=pair.context,
+                bloom_level=str(pair.bloom_level),
+                question_type=str(pair.question_type),
+                reasoning_trace=pair.reasoning_trace,
+                tacit_inference=pair.tacit_inference,
             )
     return out

--- a/src/arandu/shared/rag/judge_answers/heuristic.py
+++ b/src/arandu/shared/rag/judge_answers/heuristic.py
@@ -1,0 +1,62 @@
+"""Heuristic (non-LLM) criteria for the answer judge (spec §6).
+
+The commitment gate decides, deterministically and for free, whether the
+gold-requiring criteria (``answer_correctness`` / ``answer_faithfulness``
+/ ``passage_coverage``) should run at all. They only make sense for a
+**True-Commitment** candidate: an *answerable* question that the system
+actually *committed* to (did not abstain). For every other quadrant of
+the analysis confusion matrix the gate rejects, short-circuiting the
+gold-scoring stage:
+
+- non-answerable + committed (FC, hallucination) — no gold answer exists;
+- non-answerable + abstained (TA, correct refusal) — nothing to score;
+- answerable + abstained (FA, over-cautious) — ``answer_text`` is None.
+
+The ``abstention`` criterion runs in an earlier stage and is always
+recorded, so the TA/TC/FA/FC signal is preserved regardless of the gate.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from arandu.shared.judge.criterion import HeuristicCriterion
+
+
+class CommitmentGateCriterion(HeuristicCriterion):
+    """Pass only for a True-Commitment candidate (answerable + committed).
+
+    Binary gate: ``1.0`` when the question is answerable AND the system
+    committed (``abstained`` is false), else ``0.0``. Used in a
+    ``filter``-mode stage so a ``0.0`` rejects the pipeline and skips the
+    downstream gold-scoring criteria.
+
+    Reads two kwargs forwarded by the batch runner:
+
+    - ``is_answerable``: bool ground-truth answerability of the item.
+    - ``abstained``: the system's structured flag as a lowercased string
+      (``"true"`` / ``"false"``), the same value the abstention LLM prompt
+      consumes.
+    """
+
+    def __init__(self, *, threshold: float = 0.5) -> None:
+        """Initialise the gate; default threshold makes it a binary 0/1 gate."""
+        super().__init__(name="commitment_gate", threshold=threshold)
+
+    def _check(self, **kwargs: Any) -> tuple[float, str]:
+        """Pass iff the item is answerable and the system committed.
+
+        Args:
+            **kwargs: Must contain ``is_answerable`` (bool) and
+                ``abstained`` (``"true"``/``"false"`` string).
+
+        Returns:
+            ``(1.0, rationale)`` for a TC candidate, else ``(0.0, rationale)``.
+        """
+        is_answerable = bool(kwargs.get("is_answerable", False))
+        abstained = str(kwargs.get("abstained", "false")).strip().lower() == "true"
+        if is_answerable and not abstained:
+            return 1.0, "answerable + committed (TC) -> score gold criteria"
+        if not is_answerable:
+            return 0.0, "non-answerable -> no gold; skip gold criteria"
+        return 0.0, "answerable but abstained (FA) -> no answer text; skip gold criteria"

--- a/src/arandu/shared/rag/judge_answers/heuristic.py
+++ b/src/arandu/shared/rag/judge_answers/heuristic.py
@@ -1,19 +1,25 @@
-"""Heuristic (non-LLM) criteria for the answer judge (spec §6).
+"""Heuristic (non-LLM) gate criteria for the answer judge (spec §6).
 
-The commitment gate decides, deterministically and for free, whether the
-gold-requiring criteria (``answer_correctness`` / ``answer_faithfulness``
-/ ``passage_coverage``) should run at all. They only make sense for a
-**True-Commitment** candidate: an *answerable* question that the system
-actually *committed* to (did not abstain). For every other quadrant of
-the analysis confusion matrix the gate rejects, short-circuiting the
-gold-scoring stage:
+Two single-responsibility gates compose into a cascade that gates the
+LLM-backed scoring stages on their actual data dependencies:
 
-- non-answerable + committed (FC, hallucination) — no gold answer exists;
-- non-answerable + abstained (TA, correct refusal) — nothing to score;
-- answerable + abstained (FA, over-cautious) — ``answer_text`` is None.
+- :class:`AnswerabilityGateCriterion` passes iff the item is answerable
+  (has a gold answer). Used in front of *retrieval-quality* scoring
+  (``passage_coverage``) and again, transitively, in front of *answer*
+  scoring. A reject leaves only the always-recorded ``abstention``
+  signal in the result.
+- :class:`CommitmentGateCriterion` passes iff the system committed
+  (did not abstain). Used in front of *answer* scoring
+  (``answer_correctness`` / ``answer_faithfulness``), which need the
+  committed answer text. Lives downstream of the answerability gate, so
+  reaching it implies the item is already answerable.
 
-The ``abstention`` criterion runs in an earlier stage and is always
-recorded, so the TA/TC/FA/FC signal is preserved regardless of the gate.
+Together they partition the analysis confusion matrix without any LLM
+call: TA / FC stop at the answerability gate (skip retrieval + answer
+scoring); FA passes the first gate but is stopped at the commitment
+gate (skip answer scoring only; passage_coverage still runs because
+retrieval can be evaluated against the gold answer regardless of
+whether the system used it); TC passes both gates.
 """
 
 from __future__ import annotations
@@ -23,20 +29,43 @@ from typing import Any
 from arandu.shared.judge.criterion import HeuristicCriterion
 
 
+class AnswerabilityGateCriterion(HeuristicCriterion):
+    """Pass iff the item is answerable (a gold answer exists).
+
+    Reads a single kwarg, ``is_answerable`` (bool), forwarded by the
+    batch runner from :attr:`AnswerRecord.is_answerable`. Used in a
+    ``filter``-mode stage so a non-answerable item short-circuits every
+    later gold-using criterion (retrieval-quality + answer-quality).
+    """
+
+    def __init__(self, *, threshold: float = 0.5) -> None:
+        """Initialise the gate; default threshold makes it a binary 0/1 gate."""
+        super().__init__(name="answerability_gate", threshold=threshold)
+
+    def _check(self, **kwargs: Any) -> tuple[float, str]:
+        """Pass iff ``is_answerable`` is true.
+
+        Args:
+            **kwargs: Must contain ``is_answerable`` (bool).
+
+        Returns:
+            ``(1.0, rationale)`` when answerable, else ``(0.0, rationale)``.
+        """
+        if bool(kwargs.get("is_answerable", False)):
+            return 1.0, "answerable -> run retrieval + (if committed) answer scoring"
+        return 0.0, "non-answerable -> no gold; only abstention is meaningful"
+
+
 class CommitmentGateCriterion(HeuristicCriterion):
-    """Pass only for a True-Commitment candidate (answerable + committed).
+    """Pass iff the system committed (did not abstain).
 
-    Binary gate: ``1.0`` when the question is answerable AND the system
-    committed (``abstained`` is false), else ``0.0``. Used in a
-    ``filter``-mode stage so a ``0.0`` rejects the pipeline and skips the
-    downstream gold-scoring criteria.
-
-    Reads two kwargs forwarded by the batch runner:
-
-    - ``is_answerable``: bool ground-truth answerability of the item.
-    - ``abstained``: the system's structured flag as a lowercased string
-      (``"true"`` / ``"false"``), the same value the abstention LLM prompt
-      consumes.
+    Reads the ``abstained`` kwarg as a lowercased string
+    (``"true"`` / ``"false"``), the same value the abstention LLM prompt
+    consumes. Used in a ``filter``-mode stage downstream of
+    :class:`AnswerabilityGateCriterion`, so reaching it implies the
+    item is already answerable; a reject here skips only the answer-text
+    scoring stage (correctness + faithfulness), leaving any prior
+    retrieval-quality score intact.
     """
 
     def __init__(self, *, threshold: float = 0.5) -> None:
@@ -44,19 +73,15 @@ class CommitmentGateCriterion(HeuristicCriterion):
         super().__init__(name="commitment_gate", threshold=threshold)
 
     def _check(self, **kwargs: Any) -> tuple[float, str]:
-        """Pass iff the item is answerable and the system committed.
+        """Pass iff ``abstained`` is the lowercased string ``"false"``.
 
         Args:
-            **kwargs: Must contain ``is_answerable`` (bool) and
-                ``abstained`` (``"true"``/``"false"`` string).
+            **kwargs: Must contain ``abstained`` (``"true"``/``"false"``).
 
         Returns:
-            ``(1.0, rationale)`` for a TC candidate, else ``(0.0, rationale)``.
+            ``(1.0, rationale)`` when committed, else ``(0.0, rationale)``.
         """
-        is_answerable = bool(kwargs.get("is_answerable", False))
         abstained = str(kwargs.get("abstained", "false")).strip().lower() == "true"
-        if is_answerable and not abstained:
-            return 1.0, "answerable + committed (TC) -> score gold criteria"
-        if not is_answerable:
-            return 0.0, "non-answerable -> no gold; skip gold criteria"
-        return 0.0, "answerable but abstained (FA) -> no answer text; skip gold criteria"
+        if not abstained:
+            return 1.0, "committed -> score answer correctness + faithfulness"
+        return 0.0, "abstained -> no answer text; skip answer scoring"

--- a/src/arandu/shared/rag/judge_answers/judge.py
+++ b/src/arandu/shared/rag/judge_answers/judge.py
@@ -1,7 +1,21 @@
-"""``AnswerJudge`` — 4-criterion LLM pipeline composition (spec §6.6).
+"""``AnswerJudge`` — gated answer-judging pipeline (spec §6.6).
 
-All criteria run in ``score`` mode (none reject); the pipeline's role
-is to attach verdicts to each :class:`AnswerRecord` for later analysis.
+Three stages, run in order:
+
+1. ``abstention`` (LLM, ``score`` mode) — always recorded. This is the
+   TA/TC/FA/FC signal the analysis stage reads, so it must survive even
+   when later stages are skipped.
+2. ``commitment_gate`` (heuristic, ``filter`` mode) — passes only for a
+   True-Commitment candidate (answerable + committed). A reject
+   short-circuits the gold-scoring stage. Deterministic, no LLM call.
+3. ``gold_scoring`` (LLM, ``score`` mode) — ``answer_correctness``,
+   ``answer_faithfulness``, ``passage_coverage``. These need a gold
+   answer + a committed answer, so they run only for TC items.
+
+This gating replaces the earlier "run all four criteria unconditionally"
+composition: it stops scoring correctness/faithfulness on abstained
+answers (where ``answer_text`` is None) per spec §6.1/§6.2, and lets
+non-answerable items be judged on abstention alone (no gold needed).
 
 Note on scope: spec §6.3 also describes a deterministic
 ``offset_coverage`` variant alongside the LLM ``passage_coverage``.
@@ -30,24 +44,26 @@ from arandu.shared.judge import (
     JudgeStep,
     LLMCriterionFactory,
 )
+from arandu.shared.rag.judge_answers.heuristic import CommitmentGateCriterion
 
 if TYPE_CHECKING:
     from arandu.shared.llm_client import LLMClient
     from arandu.shared.rag.judge_answers.settings import JudgeAnswersSettings
 
 
-# Spec §6.6 — order matches the pipeline composition described there.
-# All four LLM criteria load from ``prompts/judge/criteria/<name>/``.
-_LLM_CRITERIA = (
-    "passage_coverage",
-    "abstention",
+# Stage 1: the abstention signal, always recorded.
+_ABSTENTION_CRITERIA = ("abstention",)
+# Stage 3: gold-requiring criteria, run only for True-Commitment items.
+# All load from ``prompts/judge/criteria/<name>/``.
+_GOLD_CRITERIA = (
     "answer_correctness",
     "answer_faithfulness",
+    "passage_coverage",
 )
 
 
 class AnswerJudge(BaseJudge):
-    """Drive the 4-criterion LLM judge pipeline over one :class:`AnswerRecord`.
+    """Drive the gated answer-judging pipeline over one :class:`AnswerRecord`.
 
     Attributes:
         factory: The :class:`LLMCriterionFactory` used to load LLM
@@ -72,14 +88,21 @@ class AnswerJudge(BaseJudge):
         super().__init__()  # calls _build_pipeline()
 
     def _build_pipeline(self) -> JudgePipeline:
-        """Assemble the 4 LLM criteria into one score-mode stage.
+        """Assemble the abstention -> commitment-gate -> gold-scoring pipeline.
 
-        All-in-one stage rather than four single-criterion stages because
-        the judges don't gate each other (no filter mode); a single stage
-        avoids redundant ``JudgePipelineResult`` machinery and gives the
-        analysis stage one flat ``criterion_scores`` dict to consume.
+        The commitment gate (heuristic, filter mode) sits between the
+        always-recorded abstention stage and the gold-requiring stage, so
+        correctness/faithfulness/passage_coverage run only for True-
+        Commitment items. Stage names are distinct so the analysis stage
+        still finds the ``abstention`` score by criterion name.
         """
-        step = JudgeStep(criteria=list(_LLM_CRITERIA), factory=self.factory)
+        abstention_step = JudgeStep(criteria=list(_ABSTENTION_CRITERIA), factory=self.factory)
+        gate_step = JudgeStep(criteria=[CommitmentGateCriterion()])
+        gold_step = JudgeStep(criteria=list(_GOLD_CRITERIA), factory=self.factory)
         return JudgePipeline(
-            stages=[JudgeStage(name="answer_judge", step=step, mode="score")],
+            stages=[
+                JudgeStage(name="abstention", step=abstention_step, mode="score"),
+                JudgeStage(name="commitment_gate", step=gate_step, mode="filter"),
+                JudgeStage(name="gold_scoring", step=gold_step, mode="score"),
+            ],
         )

--- a/src/arandu/shared/rag/judge_answers/judge.py
+++ b/src/arandu/shared/rag/judge_answers/judge.py
@@ -1,21 +1,33 @@
 """``AnswerJudge`` — gated answer-judging pipeline (spec §6.6).
 
-Three stages, run in order:
+Five stages composed as a cascade of single-responsibility gates, so
+each LLM-backed scoring stage runs only when its data dependencies are
+satisfied:
 
-1. ``abstention`` (LLM, ``score`` mode) — always recorded. This is the
-   TA/TC/FA/FC signal the analysis stage reads, so it must survive even
-   when later stages are skipped.
-2. ``commitment_gate`` (heuristic, ``filter`` mode) — passes only for a
-   True-Commitment candidate (answerable + committed). A reject
-   short-circuits the gold-scoring stage. Deterministic, no LLM call.
-3. ``gold_scoring`` (LLM, ``score`` mode) — ``answer_correctness``,
-   ``answer_faithfulness``, ``passage_coverage``. These need a gold
-   answer + a committed answer, so they run only for TC items.
+1. ``abstention`` (LLM, ``score``) — always recorded. The TA/TC/FA/FC
+   signal the analysis stage reads, so it must survive every stage-skip.
+2. ``answerability_gate`` (heuristic, ``filter``) — passes iff the item
+   has a gold answer (``is_answerable=True``). A reject leaves only the
+   abstention score in the result.
+3. ``retrieval_scoring`` (LLM, ``score``) — ``passage_coverage``. A
+   retrieval-quality lens: did the retrieved passages cover the gold
+   answer? Runs for every answerable item (TC + FA); the system's
+   answer text is not consulted, so abstention does not gate it.
+4. ``commitment_gate`` (heuristic, ``filter``) — passes iff the system
+   committed (``abstained=False``). Lives downstream of the
+   answerability gate; reaching it implies the item is answerable.
+5. ``answer_scoring`` (LLM, ``score``) — ``answer_correctness``,
+   ``answer_faithfulness``. Need a committed answer + gold, so they run
+   only for TC.
 
-This gating replaces the earlier "run all four criteria unconditionally"
-composition: it stops scoring correctness/faithfulness on abstained
-answers (where ``answer_text`` is None) per spec §6.1/§6.2, and lets
-non-answerable items be judged on abstention alone (no gold needed).
+This split fixes a TC-only narrowing of ``passage_coverage`` that an
+earlier draft introduced by lumping it with the answer-scoring criteria:
+passage coverage depends only on retrieval + gold, not on commitment.
+
+The whole pipeline still stops scoring ``answer_correctness`` /
+``answer_faithfulness`` on abstained answers (where ``answer_text`` is
+``None``) per spec §6.1/§6.2, and still lets non-answerable items be
+judged on abstention alone (no gold needed).
 
 Note on scope: spec §6.3 also describes a deterministic
 ``offset_coverage`` variant alongside the LLM ``passage_coverage``.
@@ -44,7 +56,10 @@ from arandu.shared.judge import (
     JudgeStep,
     LLMCriterionFactory,
 )
-from arandu.shared.rag.judge_answers.heuristic import CommitmentGateCriterion
+from arandu.shared.rag.judge_answers.heuristic import (
+    AnswerabilityGateCriterion,
+    CommitmentGateCriterion,
+)
 
 if TYPE_CHECKING:
     from arandu.shared.llm_client import LLMClient
@@ -53,12 +68,13 @@ if TYPE_CHECKING:
 
 # Stage 1: the abstention signal, always recorded.
 _ABSTENTION_CRITERIA = ("abstention",)
-# Stage 3: gold-requiring criteria, run only for True-Commitment items.
-# All load from ``prompts/judge/criteria/<name>/``.
-_GOLD_CRITERIA = (
+# Stage 3: retrieval-quality lens, run for every answerable item (TC + FA).
+_RETRIEVAL_CRITERIA = ("passage_coverage",)
+# Stage 5: answer-text quality, run only for True-Commitment items (TC).
+# All LLM criteria load from ``prompts/judge/criteria/<name>/``.
+_ANSWER_CRITERIA = (
     "answer_correctness",
     "answer_faithfulness",
-    "passage_coverage",
 )
 
 
@@ -88,21 +104,31 @@ class AnswerJudge(BaseJudge):
         super().__init__()  # calls _build_pipeline()
 
     def _build_pipeline(self) -> JudgePipeline:
-        """Assemble the abstention -> commitment-gate -> gold-scoring pipeline.
+        """Assemble the cascaded answer-judging pipeline.
 
-        The commitment gate (heuristic, filter mode) sits between the
-        always-recorded abstention stage and the gold-requiring stage, so
-        correctness/faithfulness/passage_coverage run only for True-
-        Commitment items. Stage names are distinct so the analysis stage
-        still finds the ``abstention`` score by criterion name.
+        Two heuristic gates partition the LLM-backed scoring stages on
+        their actual data dependencies:
+
+        - the answerability gate (filter) fronts both retrieval and
+          answer scoring (both need a gold answer);
+        - the commitment gate (filter) fronts answer scoring alone
+          (only the answer-text criteria need a committed answer).
+
+        Stage names are distinct so the analysis stage finds the
+        ``abstention`` score by criterion name regardless of which
+        stages were skipped.
         """
         abstention_step = JudgeStep(criteria=list(_ABSTENTION_CRITERIA), factory=self.factory)
-        gate_step = JudgeStep(criteria=[CommitmentGateCriterion()])
-        gold_step = JudgeStep(criteria=list(_GOLD_CRITERIA), factory=self.factory)
+        answerability_step = JudgeStep(criteria=[AnswerabilityGateCriterion()])
+        retrieval_step = JudgeStep(criteria=list(_RETRIEVAL_CRITERIA), factory=self.factory)
+        commitment_step = JudgeStep(criteria=[CommitmentGateCriterion()])
+        answer_step = JudgeStep(criteria=list(_ANSWER_CRITERIA), factory=self.factory)
         return JudgePipeline(
             stages=[
                 JudgeStage(name="abstention", step=abstention_step, mode="score"),
-                JudgeStage(name="commitment_gate", step=gate_step, mode="filter"),
-                JudgeStage(name="gold_scoring", step=gold_step, mode="score"),
+                JudgeStage(name="answerability_gate", step=answerability_step, mode="filter"),
+                JudgeStage(name="retrieval_scoring", step=retrieval_step, mode="score"),
+                JudgeStage(name="commitment_gate", step=commitment_step, mode="filter"),
+                JudgeStage(name="answer_scoring", step=answer_step, mode="score"),
             ],
         )

--- a/tests/shared/rag/judge_answers/test_batch.py
+++ b/tests/shared/rag/judge_answers/test_batch.py
@@ -149,9 +149,10 @@ class TestRunJudgeAnswersBatch:
         assert rec.answer_text is None
 
     def test_missing_gold_lookup_records_as_failed(self, tmp_path: Path) -> None:
-        # AnswerRecord exists but no matching CEP pair (orphan qa_pair_id).
-        # Without the gold answer the judge can't run; surface it cleanly.
-        _seed_answers(tmp_path)  # no _seed_cep call
+        # ANSWERABLE AnswerRecord with no matching CEP pair (orphan
+        # qa_pair_id). Without the gold answer the gold criteria can't run;
+        # surface it cleanly. (Non-answerable orphans are fine — see below.)
+        _seed_answers(tmp_path)  # is_answerable=True, no _seed_cep call
         settings = JudgeAnswersSettings(provider="ollama")
 
         with (
@@ -164,6 +165,60 @@ class TestRunJudgeAnswersBatch:
 
         assert result.judgments_written == 0
         assert result.judgments_failed >= 1
+
+    def test_nonanswerable_judged_without_gold(self, tmp_path: Path) -> None:
+        # A non-answerable item (is_answerable=False) has no CEP gold, but
+        # must still be judged (abstention only, via the commitment gate) —
+        # not skipped as "no gold lookup".
+        out_dir = tmp_path / "run_x" / "answers" / "outputs" / "bm25" / "nonanswerable"
+        out_dir.mkdir(parents=True)
+        record = AnswerRecord(
+            qa_pair_id="src_a:chk_aa:0:nonans",
+            question="Onde Joana mora?",
+            retriever_id="bm25",
+            chunker_id="cep_4k",
+            top_k=5,
+            passages=[],
+            elapsed_ms=1.0,
+            is_answerable=False,
+            answer_text="Em Itaqui.",
+            abstained=False,
+            rationale="Committed despite no support.",
+            answerer_model="qwen3:14b",
+            answerer_temperature=0.2,
+        )
+        record.save(out_dir / "src_a__chk_aa__0__nonans.json")
+        # Deliberately no _seed_cep: non-answerable items need no gold.
+        settings = JudgeAnswersSettings(provider="ollama")
+
+        with (
+            patch("arandu.shared.rag.judge_answers.batch.LLMClient"),
+            patch("arandu.shared.rag.judge_answers.batch.AnswerJudge") as mock_judge_cls,
+        ):
+            judge = MagicMock()
+            judge.evaluate.return_value = JudgePipelineResult(
+                stage_results={
+                    "abstention": JudgeStepResult(
+                        criterion_scores={
+                            "abstention": CriterionScore(
+                                score=0.1, threshold=0.7, rationale="substantive claim"
+                            ),
+                        }
+                    )
+                },
+                passed=False,
+                rejected_at="commitment_gate",
+            )
+            mock_judge_cls.return_value = judge
+
+            result = run_judge_answers_batch(
+                pipeline_id="run_x", settings=settings, base_dir=tmp_path
+            )
+
+        assert result.judgments_written == 1
+        assert result.judgments_failed == 0
+        # judge.evaluate received is_answerable=False (gate input).
+        assert judge.evaluate.call_args.kwargs["is_answerable"] is False
 
     def test_resume_skips_completed_records(self, tmp_path: Path) -> None:
         _seed_answers(tmp_path)

--- a/tests/shared/rag/judge_answers/test_heuristic.py
+++ b/tests/shared/rag/judge_answers/test_heuristic.py
@@ -1,0 +1,39 @@
+"""Tests for the heuristic commitment gate (spec §6)."""
+
+from __future__ import annotations
+
+from arandu.shared.rag.judge_answers.heuristic import CommitmentGateCriterion
+
+
+class TestCommitmentGateCriterion:
+    """The gate passes only for a True-Commitment candidate."""
+
+    def test_answerable_committed_passes(self) -> None:
+        score = CommitmentGateCriterion().evaluate(is_answerable=True, abstained="false")
+        assert score.score == 1.0
+        assert score.passed is True
+
+    def test_answerable_abstained_rejects(self) -> None:
+        score = CommitmentGateCriterion().evaluate(is_answerable=True, abstained="true")
+        assert score.score == 0.0
+        assert score.passed is False
+
+    def test_nonanswerable_committed_rejects(self) -> None:
+        score = CommitmentGateCriterion().evaluate(is_answerable=False, abstained="false")
+        assert score.score == 0.0
+        assert score.passed is False
+
+    def test_nonanswerable_abstained_rejects(self) -> None:
+        score = CommitmentGateCriterion().evaluate(is_answerable=False, abstained="true")
+        assert score.score == 0.0
+        assert score.passed is False
+
+    def test_abstained_string_case_insensitive(self) -> None:
+        score = CommitmentGateCriterion().evaluate(is_answerable=True, abstained="True")
+        assert score.passed is False
+
+    def test_missing_kwargs_default_to_reject(self) -> None:
+        # No kwargs -> is_answerable defaults False -> reject (never errors).
+        score = CommitmentGateCriterion().evaluate()
+        assert score.score == 0.0
+        assert score.error is None

--- a/tests/shared/rag/judge_answers/test_heuristic.py
+++ b/tests/shared/rag/judge_answers/test_heuristic.py
@@ -1,39 +1,55 @@
-"""Tests for the heuristic commitment gate (spec §6)."""
+"""Tests for the heuristic gate criteria (spec §6)."""
 
 from __future__ import annotations
 
-from arandu.shared.rag.judge_answers.heuristic import CommitmentGateCriterion
+from arandu.shared.rag.judge_answers.heuristic import (
+    AnswerabilityGateCriterion,
+    CommitmentGateCriterion,
+)
 
 
-class TestCommitmentGateCriterion:
-    """The gate passes only for a True-Commitment candidate."""
+class TestAnswerabilityGateCriterion:
+    """Gate passes iff the item has a gold answer (``is_answerable``)."""
 
-    def test_answerable_committed_passes(self) -> None:
-        score = CommitmentGateCriterion().evaluate(is_answerable=True, abstained="false")
+    def test_answerable_passes(self) -> None:
+        score = AnswerabilityGateCriterion().evaluate(is_answerable=True)
         assert score.score == 1.0
         assert score.passed is True
 
-    def test_answerable_abstained_rejects(self) -> None:
-        score = CommitmentGateCriterion().evaluate(is_answerable=True, abstained="true")
+    def test_nonanswerable_rejects(self) -> None:
+        score = AnswerabilityGateCriterion().evaluate(is_answerable=False)
         assert score.score == 0.0
         assert score.passed is False
 
-    def test_nonanswerable_committed_rejects(self) -> None:
-        score = CommitmentGateCriterion().evaluate(is_answerable=False, abstained="false")
+    def test_missing_kwarg_defaults_to_reject(self) -> None:
+        score = AnswerabilityGateCriterion().evaluate()
         assert score.score == 0.0
-        assert score.passed is False
+        assert score.error is None
 
-    def test_nonanswerable_abstained_rejects(self) -> None:
-        score = CommitmentGateCriterion().evaluate(is_answerable=False, abstained="true")
+    def test_ignores_unrelated_kwargs(self) -> None:
+        score = AnswerabilityGateCriterion().evaluate(is_answerable=True, abstained="true")
+        assert score.passed is True
+
+
+class TestCommitmentGateCriterion:
+    """Gate passes iff the system committed (did not abstain)."""
+
+    def test_committed_passes(self) -> None:
+        score = CommitmentGateCriterion().evaluate(abstained="false")
+        assert score.score == 1.0
+        assert score.passed is True
+
+    def test_abstained_rejects(self) -> None:
+        score = CommitmentGateCriterion().evaluate(abstained="true")
         assert score.score == 0.0
         assert score.passed is False
 
     def test_abstained_string_case_insensitive(self) -> None:
-        score = CommitmentGateCriterion().evaluate(is_answerable=True, abstained="True")
+        score = CommitmentGateCriterion().evaluate(abstained="True")
         assert score.passed is False
 
-    def test_missing_kwargs_default_to_reject(self) -> None:
-        # No kwargs -> is_answerable defaults False -> reject (never errors).
+    def test_missing_kwarg_defaults_to_committed(self) -> None:
+        # Default "false" -> committed; the producer always sets the
+        # value explicitly, so this is just the safe default.
         score = CommitmentGateCriterion().evaluate()
-        assert score.score == 0.0
-        assert score.error is None
+        assert score.passed is True

--- a/tests/shared/rag/judge_answers/test_judge.py
+++ b/tests/shared/rag/judge_answers/test_judge.py
@@ -1,9 +1,9 @@
 """Tests for the gated AnswerJudge pipeline (spec §6.6).
 
 Mocks the LLMClient so the real pipeline structure runs (abstention ->
-commitment gate -> gold scoring) without LLM calls. Verifies the
-commitment gate short-circuits the gold-scoring stage for everything
-except a True-Commitment candidate.
+answerability gate -> retrieval scoring -> commitment gate -> answer
+scoring) without LLM calls. Verifies the cascaded gates produce the
+expected per-quadrant criterion coverage.
 """
 
 from __future__ import annotations
@@ -42,44 +42,61 @@ def _kwargs(*, is_answerable: bool, abstained: str) -> dict[str, object]:
 
 
 class TestAnswerJudgePipeline:
-    """The commitment gate gates the gold-scoring stage."""
+    """The cascaded gates partition criteria by their data dependencies."""
 
-    def test_true_commitment_runs_gold_scoring(self) -> None:
+    def test_true_commitment_runs_all_stages(self) -> None:
         judge, _ = _judge()
         result = judge.evaluate(**_kwargs(is_answerable=True, abstained="false"))
         assert result.passed is True
-        assert "abstention" in result.stage_results
-        assert "gold_scoring" in result.stage_results
-        gold = result.stage_results["gold_scoring"].criterion_scores
-        assert set(gold) == {"answer_correctness", "answer_faithfulness", "passage_coverage"}
-        # abstention is always recorded, in its own stage.
-        assert "abstention" in result.stage_results["abstention"].criterion_scores
+        # All five stages recorded; both LLM-scoring stages populated.
+        assert set(result.stage_results) == {
+            "abstention",
+            "answerability_gate",
+            "retrieval_scoring",
+            "commitment_gate",
+            "answer_scoring",
+        }
+        assert "passage_coverage" in result.stage_results["retrieval_scoring"].criterion_scores
+        assert set(result.stage_results["answer_scoring"].criterion_scores) == {
+            "answer_correctness",
+            "answer_faithfulness",
+        }
 
-    def test_answerable_abstained_skips_gold(self) -> None:
+    def test_false_abstention_keeps_passage_coverage(self) -> None:
+        # Answerable + abstained (FA): retrieval can still be evaluated
+        # against the gold answer; only the answer-text scoring stage skips.
         judge, _ = _judge()
         result = judge.evaluate(**_kwargs(is_answerable=True, abstained="true"))
         assert result.passed is False
         assert result.rejected_at == "commitment_gate"
-        assert "abstention" in result.stage_results
-        assert "gold_scoring" not in result.stage_results
+        assert "retrieval_scoring" in result.stage_results
+        assert "passage_coverage" in result.stage_results["retrieval_scoring"].criterion_scores
+        assert "answer_scoring" not in result.stage_results
 
-    def test_nonanswerable_committed_skips_gold(self) -> None:
+    def test_nonanswerable_committed_only_abstention(self) -> None:
         judge, _ = _judge()
         result = judge.evaluate(**_kwargs(is_answerable=False, abstained="false"))
         assert result.passed is False
-        assert "gold_scoring" not in result.stage_results
-        assert "abstention" in result.stage_results["abstention"].criterion_scores
+        assert result.rejected_at == "answerability_gate"
+        assert "abstention" in result.stage_results
+        # Both downstream LLM stages skipped (no gold).
+        assert "retrieval_scoring" not in result.stage_results
+        assert "answer_scoring" not in result.stage_results
 
-    def test_nonanswerable_abstained_skips_gold(self) -> None:
+    def test_nonanswerable_abstained_only_abstention(self) -> None:
         judge, _ = _judge()
         result = judge.evaluate(**_kwargs(is_answerable=False, abstained="true"))
         assert result.passed is False
-        assert "gold_scoring" not in result.stage_results
+        assert result.rejected_at == "answerability_gate"
+        assert "retrieval_scoring" not in result.stage_results
+        assert "answer_scoring" not in result.stage_results
 
-    def test_gate_does_not_call_llm(self) -> None:
-        # On a rejected (non-TC) item only the abstention criterion hits the
-        # LLM; the gate is heuristic and gold scoring is skipped -> exactly
-        # one generate_structured call.
+    def test_non_tc_items_skip_answer_scoring_llm_calls(self) -> None:
+        # FA: 1 LLM call for abstention + 1 for passage_coverage = 2.
+        # Non-answerable (TA/FC): 1 LLM call for abstention only.
         judge, llm = _judge()
+        judge.evaluate(**_kwargs(is_answerable=True, abstained="true"))
+        assert llm.generate_structured.call_count == 2
+        llm.reset_mock()
         judge.evaluate(**_kwargs(is_answerable=False, abstained="true"))
         assert llm.generate_structured.call_count == 1

--- a/tests/shared/rag/judge_answers/test_judge.py
+++ b/tests/shared/rag/judge_answers/test_judge.py
@@ -1,0 +1,85 @@
+"""Tests for the gated AnswerJudge pipeline (spec §6.6).
+
+Mocks the LLMClient so the real pipeline structure runs (abstention ->
+commitment gate -> gold scoring) without LLM calls. Verifies the
+commitment gate short-circuits the gold-scoring stage for everything
+except a True-Commitment candidate.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from arandu.shared.judge.criterion import CriterionResponse
+from arandu.shared.rag.judge_answers.judge import AnswerJudge
+from arandu.shared.rag.judge_answers.settings import JudgeAnswersSettings
+
+
+def _judge() -> tuple[AnswerJudge, MagicMock]:
+    """Build an AnswerJudge whose LLM criteria all return a fixed score."""
+    llm = MagicMock()
+    llm.generate_structured.return_value = CriterionResponse(score=0.8, rationale="ok")
+    judge = AnswerJudge(llm_client=llm, settings=JudgeAnswersSettings(provider="ollama"))
+    return judge, llm
+
+
+def _kwargs(*, is_answerable: bool, abstained: str) -> dict[str, object]:
+    return {
+        "is_answerable": is_answerable,
+        "abstained": abstained,
+        "answer_text": "Em Itaqui." if abstained == "false" else "",
+        "system_answer": "Em Itaqui." if abstained == "false" else "",
+        "rationale": "r",
+        "passages_text": "p",
+        "question": "Onde Maria mora?",
+        "gold_answer": "Em Itaqui.",
+        "context": "Maria mora em Itaqui.",
+        "bloom_level": "remember",
+        "question_type": "factual",
+        "reasoning_trace": "",
+        "tacit_inference": "",
+    }
+
+
+class TestAnswerJudgePipeline:
+    """The commitment gate gates the gold-scoring stage."""
+
+    def test_true_commitment_runs_gold_scoring(self) -> None:
+        judge, _ = _judge()
+        result = judge.evaluate(**_kwargs(is_answerable=True, abstained="false"))
+        assert result.passed is True
+        assert "abstention" in result.stage_results
+        assert "gold_scoring" in result.stage_results
+        gold = result.stage_results["gold_scoring"].criterion_scores
+        assert set(gold) == {"answer_correctness", "answer_faithfulness", "passage_coverage"}
+        # abstention is always recorded, in its own stage.
+        assert "abstention" in result.stage_results["abstention"].criterion_scores
+
+    def test_answerable_abstained_skips_gold(self) -> None:
+        judge, _ = _judge()
+        result = judge.evaluate(**_kwargs(is_answerable=True, abstained="true"))
+        assert result.passed is False
+        assert result.rejected_at == "commitment_gate"
+        assert "abstention" in result.stage_results
+        assert "gold_scoring" not in result.stage_results
+
+    def test_nonanswerable_committed_skips_gold(self) -> None:
+        judge, _ = _judge()
+        result = judge.evaluate(**_kwargs(is_answerable=False, abstained="false"))
+        assert result.passed is False
+        assert "gold_scoring" not in result.stage_results
+        assert "abstention" in result.stage_results["abstention"].criterion_scores
+
+    def test_nonanswerable_abstained_skips_gold(self) -> None:
+        judge, _ = _judge()
+        result = judge.evaluate(**_kwargs(is_answerable=False, abstained="true"))
+        assert result.passed is False
+        assert "gold_scoring" not in result.stage_results
+
+    def test_gate_does_not_call_llm(self) -> None:
+        # On a rejected (non-TC) item only the abstention criterion hits the
+        # LLM; the gate is heuristic and gold scoring is skipped -> exactly
+        # one generate_structured call.
+        judge, llm = _judge()
+        judge.evaluate(**_kwargs(is_answerable=False, abstained="true"))
+        assert llm.generate_structured.call_count == 1


### PR DESCRIPTION
## Summary

Phase 1 of the judge redesign. Restructures `AnswerJudge` from "run 4 LLM criteria in one score stage" into a 3-stage pipeline that uses the judge framework's filter/score machinery and its `HeuristicCriterion` ABC:

1. **`abstention`** (LLM, `score`) — always recorded; the TA/TC/FA/FC signal the analysis stage reads, so it survives even when later stages skip.
2. **`commitment_gate`** (heuristic, `filter`) — deterministic, no LLM call; passes only for a True-Commitment candidate (`is_answerable and not abstained`). A reject short-circuits the gold-scoring stage.
3. **`gold_scoring`** (LLM, `score`) — `answer_correctness`, `answer_faithfulness`, `passage_coverage`; run only for TC items.

### Why

- The old composition scored correctness/faithfulness on abstained answers (`answer_text=None`), wasting LLM calls and producing meaningless numbers — contrary to spec §6.1/§6.2 ("run only when `abstained=False`").
- The gate lets non-answerable items be judged on **abstention alone** with no gold, so this **supersedes #113** (its two-pipeline, branch-on-`is_answerable` approach) with one unified pipeline. #113 can be closed.
- Widens `GoldRecord` beyond question+gold_answer to carry the richer CEP signals (`context`, `bloom_level`, `question_type`, `reasoning_trace`, `tacit_inference`) so Phase 2 heuristic correctness criteria need no second schema change.

### Notes

- The batch forwards `is_answerable` + the gold fields, and only fails an *answerable* orphan `qa_pair_id`; a non-answerable item with no gold is expected and judged on abstention.
- Analysis + audit are stage-name-agnostic (they iterate `stage_results` by criterion name), so the new stage names are compatible — no analysis change needed.
- One behavior note: non-TC items now have `validation.passed=False` (rejected at the gate), where the old all-score pipeline always reported `passed=True`. The analysis classifier reads the abstention score, not `passed`, so this doesn't affect TA/TC/FA/FC; it's arguably more meaningful (a hallucination is "not valid").

### Phase 2 (separate PR)

Heuristic correctness criterion using the widened gold context (token-F1 / embedding cosine), recorded alongside the LLM `answer_correctness` as a cheap cross-check.

## Test plan

- [x] `uv run ruff check src/ tests/` -> clean
- [x] `uv run ruff format --check src/ tests/` -> clean
- [x] `uv run pytest` -> 1429 passed, 1 skipped
- New: heuristic gate (4 quadrants), real pipeline gating with mocked LLM (gold scoring present only for TC), batch judges non-answerable without gold.