### PR TITLE
docs(rag): reframe NullRetriever docstring as abstention baseline

### DIFF
--- a/src/arandu/shared/rag/retrievers/null.py
+++ b/src/arandu/shared/rag/retrievers/null.py
@@ -1,7 +1,11 @@
-"""NullRetriever — parametric arm of the Phase C four-arm decomposition (spec §4.6).
+"""NullRetriever: abstention/hallucination baseline for Phase C (spec §4.6).
 
-Returns no passages; forces the Answerer to fall back to parametric (LLM-internal)
-knowledge. The arm-vs-null delta is the *graph lift* metric in Joel's framing.
+Returns no passages. With the Answerer prompt held constant across all retrieval
+arms, the Null arm is expected to abstain on most items; cases where it commits
+despite zero passages surface as parametric-memory leaks. Used as the
+abstention/hallucination baseline for cross-arm comparison via abstention-F1 and
+hallucination-rate (not via a KC subtraction; the corpus is private ethnographic
+material outside LLM parametric coverage by construction).
 """
 
 from __future__ import annotations

--- a/tests/shared/rag/retrievers/test_null.py
+++ b/tests/shared/rag/retrievers/test_null.py
@@ -1,4 +1,4 @@
-"""Tests for shared/rag/retrievers/null.py — NullRetriever parametric arm."""
+"""Tests for shared/rag/retrievers/null.py (NullRetriever abstention baseline)."""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary

- Rewrite the `NullRetriever` module docstring (`src/arandu/shared/rag/retrievers/null.py`) so it no longer frames Null as a "parametric arm" backing a `KC_arm - KC_null` subtraction.
- Restate Null's role as the abstention/hallucination baseline under a held-constant Answerer prompt, with a one-sentence justification (this corpus is private ethnographic interviews about specific individuals' tacit knowledge of specific events, so it lies outside LLM parametric coverage by construction and the subtraction is not informative).

## Why

Spotted during dry-run review of the gated answer-judge pipeline (#110): the Answerer prompt instructs the model to abstain when no passages support an answer, and `NullRetriever` supplies none, so `n_TC_null` collapses toward zero and Joel's `KC_arm - KC_null` decomposition becomes non-computable. Decision recorded 2026-05-28 in the `phase-c-rag-evaluation` tracking session. A second relaxed-prompt Null variant was considered and rejected (would add a defendable second IV with no informational gain on this corpus).

Confirmed by grep that `src/arandu/shared/rag/analysis/` never implemented the subtraction, so the codebase change is documentary only.

## Out of scope

- The spec at `docs/superpowers/specs/2026-05-08-phase-c-rag-evaluation-design.md` (§1 / §4.6 / §5.1 / §8.7 / §15) was updated in the same pass but lives untracked in the working tree by existing convention; it is not part of this PR.
- Dissertation tex Ch.3 Fase 4 KC subsection is tracked separately in the `dissertacao-tex` workspace (sister session `methodology-null-baseline-reframe`).
- `docs/methodology.md` §6 carries no `KC_arm - KC_null` framing today (existing "parametric knowledge" mentions are about the §6 answer-generation prompt, not a null arm), so no edit was needed. The deeper §6 rewrite remains owned by the `methodology-rewrite` task, gated on first full-run results.
- `docs/planning/ROADMAP.md` references to "parametric knowledge detection" describe Luciana's non-answerable experiment accurately and survive the reframe untouched.

## Test plan

- [x] `uvx ruff check src/arandu/shared/rag/retrievers/null.py`
- [x] `uvx ruff format --check src/arandu/shared/rag/retrievers/null.py`
- [x] grep `src/arandu/` for residual `KC_arm` / `KC_null` / "graph lift" / "parametric arm" framing: only the rewritten docstring matches.
- [ ] Visual review of the docstring rendering in source.