### PR TITLE
refactor(rag): prune GoldRecord to judge-relevant fields

### DIFF
--- a/src/arandu/shared/rag/judge_answers/batch.py
+++ b/src/arandu/shared/rag/judge_answers/batch.py
@@ -291,9 +291,9 @@ def _judge_one(
     Every kwarg below is consumed by at least one stage. The gates read
     ``is_answerable`` + ``abstained``; the abstention criterion reads
     ``abstained`` / ``answer_text`` / ``rationale``; the gold-scoring
-    criteria read ``question`` / ``gold_answer`` / ``context`` /
-    ``passages_text``. Criteria that don't reference a given kwarg silently
-    ignore it (LLM prompts via ``string.Template.safe_substitute``).
+    criteria read ``question`` / ``gold_answer`` / ``passages_text``.
+    Criteria that don't reference a given kwarg silently ignore it (LLM
+    prompts via ``string.Template.safe_substitute``).
 
     ``gold`` is ``None`` for non-answerable items (no CEP pair); the
     answerability gate rejects those before the gold criteria run, so the
@@ -309,7 +309,6 @@ def _judge_one(
         passages_text=passages_text,
         question=gold.question if gold is not None else answer.question,
         gold_answer=gold.gold_answer if gold is not None else "",
-        context=gold.context if gold is not None else "",
     )
     return answer.model_copy(update={"validation": pipeline_result})
 

--- a/src/arandu/shared/rag/judge_answers/batch.py
+++ b/src/arandu/shared/rag/judge_answers/batch.py
@@ -288,15 +288,15 @@ def _judge_one(
 ) -> AnswerRecord:
     """Run the gated judge pipeline; attach the verdict to the record.
 
-    Every kwarg below is consumed by at least one stage. The commitment
-    gate reads ``is_answerable`` + ``abstained``; the abstention criterion
-    reads ``abstained`` / ``answer_text`` / ``rationale``; the gold-scoring
-    criteria read ``question`` / ``gold_answer`` / ``context`` / etc.
-    Criteria that don't reference a given kwarg silently ignore it (LLM
-    prompts via ``string.Template.safe_substitute``).
+    Every kwarg below is consumed by at least one stage. The gates read
+    ``is_answerable`` + ``abstained``; the abstention criterion reads
+    ``abstained`` / ``answer_text`` / ``rationale``; the gold-scoring
+    criteria read ``question`` / ``gold_answer`` / ``context`` /
+    ``passages_text``. Criteria that don't reference a given kwarg silently
+    ignore it (LLM prompts via ``string.Template.safe_substitute``).
 
     ``gold`` is ``None`` for non-answerable items (no CEP pair); the
-    commitment gate rejects those before the gold criteria run, so the
+    answerability gate rejects those before the gold criteria run, so the
     empty gold fields are never actually consumed.
     """
     passages_text = _format_passages(answer, passage_text)
@@ -310,10 +310,6 @@ def _judge_one(
         question=gold.question if gold is not None else answer.question,
         gold_answer=gold.gold_answer if gold is not None else "",
         context=gold.context if gold is not None else "",
-        bloom_level=gold.bloom_level if gold is not None else "",
-        question_type=gold.question_type if gold is not None else "",
-        reasoning_trace=(gold.reasoning_trace or "") if gold is not None else "",
-        tacit_inference=(gold.tacit_inference or "") if gold is not None else "",
     )
     return answer.model_copy(update={"validation": pipeline_result})
 

--- a/src/arandu/shared/rag/judge_answers/gold_lookup.py
+++ b/src/arandu/shared/rag/judge_answers/gold_lookup.py
@@ -6,17 +6,21 @@ artifacts once at batch start and produces a flat lookup keyed by the
 same ``qa_pair_id`` format the retrieve / answer stages emit
 (``"<file_id>:<chunk_id>:<idx>"``).
 
-Beyond the question + gold answer, the record carries the source
-``context`` the pair was generated from, which the faithfulness and
-heuristic-correctness criteria score against. Analysis-only dimensions
-(Bloom level, question type) are deliberately NOT carried here: they are
-stratification keys, not judge inputs, and the analysis stage already
-re-derives them via its own CEP cross-cut map
-(:func:`arandu.shared.rag.analysis.loader.build_cross_cut_map`). The
-CEP's own ``reasoning_trace`` / ``tacit_inference`` annotations are also
-excluded: feeding the generator's self-explanation back as ground truth
-would make the judge score conformance to the CEP annotation rather than
-against an independent reference.
+``GoldRecord`` carries only what an answer-judge criterion actually
+consumes today: the question and the gold answer. Other ``QAPairCEP``
+fields are deliberately NOT carried here:
+
+- Source ``context``, Bloom level, question type: no current criterion
+  reads them. ``answer_faithfulness`` scores against the retrieved
+  ``passages_text``, not the gold context; the analysis stage re-derives
+  Bloom level / question type via its own CEP cross-cut map
+  (:func:`arandu.shared.rag.analysis.loader.build_cross_cut_map`). The
+  planned Phase-2 heuristic-correctness criterion will re-add ``context``
+  here together with the code that consumes it.
+- ``reasoning_trace`` / ``tacit_inference``: feeding the CEP generator's
+  own self-explanation back as ground truth would make the judge score
+  conformance to the annotation rather than against an independent
+  reference.
 """
 
 from __future__ import annotations
@@ -24,7 +28,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-from pydantic import BaseModel, Field, ValidationError
+from pydantic import BaseModel, ValidationError
 
 from arandu.qa.schemas import QARecordCEP
 
@@ -40,7 +44,6 @@ class GoldRecord(BaseModel):
     qa_pair_id: str
     question: str
     gold_answer: str
-    context: str = Field(default="", description="Source text the QA pair was generated from.")
 
 
 def build_gold_lookup(cep_dir: Path) -> dict[str, GoldRecord]:
@@ -49,7 +52,7 @@ def build_gold_lookup(cep_dir: Path) -> dict[str, GoldRecord]:
     Args:
         cep_dir: ``results/<id>/cep/outputs/``. Each ``*.json`` is a
             :class:`QARecordCEP` whose ``qa_pairs`` carry questions +
-            gold answers + source context + chunk_id pointers.
+            gold answers + chunk_id pointers.
 
     Returns:
         Flat dict; empty if ``cep_dir`` is absent.
@@ -71,6 +74,5 @@ def build_gold_lookup(cep_dir: Path) -> dict[str, GoldRecord]:
                 qa_pair_id=qa_pair_id,
                 question=pair.question,
                 gold_answer=pair.answer,
-                context=pair.context,
             )
     return out

--- a/src/arandu/shared/rag/judge_answers/gold_lookup.py
+++ b/src/arandu/shared/rag/judge_answers/gold_lookup.py
@@ -6,10 +6,17 @@ artifacts once at batch start and produces a flat lookup keyed by the
 same ``qa_pair_id`` format the retrieve / answer stages emit
 (``"<file_id>:<chunk_id>:<idx>"``).
 
-Beyond the question + gold answer, the record carries the richer CEP
-signals (source context, Bloom level, question type, reasoning trace,
-tacit-knowledge annotation) so heuristic and LLM criteria can use them
-without a second pass over the CEP outputs.
+Beyond the question + gold answer, the record carries the source
+``context`` the pair was generated from, which the faithfulness and
+heuristic-correctness criteria score against. Analysis-only dimensions
+(Bloom level, question type) are deliberately NOT carried here: they are
+stratification keys, not judge inputs, and the analysis stage already
+re-derives them via its own CEP cross-cut map
+(:func:`arandu.shared.rag.analysis.loader.build_cross_cut_map`). The
+CEP's own ``reasoning_trace`` / ``tacit_inference`` annotations are also
+excluded: feeding the generator's self-explanation back as ground truth
+would make the judge score conformance to the CEP annotation rather than
+against an independent reference.
 """
 
 from __future__ import annotations
@@ -34,14 +41,6 @@ class GoldRecord(BaseModel):
     question: str
     gold_answer: str
     context: str = Field(default="", description="Source text the QA pair was generated from.")
-    bloom_level: str = Field(default="", description="Bloom's-taxonomy level of the question.")
-    question_type: str = Field(default="", description="factual | conceptual | temporal | entity.")
-    reasoning_trace: str | None = Field(
-        default=None, description="Logical connections leading to the answer, if any."
-    )
-    tacit_inference: str | None = Field(
-        default=None, description="Implicit/tacit knowledge used in the answer, if any."
-    )
 
 
 def build_gold_lookup(cep_dir: Path) -> dict[str, GoldRecord]:
@@ -50,7 +49,7 @@ def build_gold_lookup(cep_dir: Path) -> dict[str, GoldRecord]:
     Args:
         cep_dir: ``results/<id>/cep/outputs/``. Each ``*.json`` is a
             :class:`QARecordCEP` whose ``qa_pairs`` carry questions +
-            gold answers + chunk_id pointers + the richer CEP signals.
+            gold answers + source context + chunk_id pointers.
 
     Returns:
         Flat dict; empty if ``cep_dir`` is absent.
@@ -73,9 +72,5 @@ def build_gold_lookup(cep_dir: Path) -> dict[str, GoldRecord]:
                 question=pair.question,
                 gold_answer=pair.answer,
                 context=pair.context,
-                bloom_level=str(pair.bloom_level),
-                question_type=str(pair.question_type),
-                reasoning_trace=pair.reasoning_trace,
-                tacit_inference=pair.tacit_inference,
             )
     return out

--- a/tests/shared/rag/judge_answers/test_judge.py
+++ b/tests/shared/rag/judge_answers/test_judge.py
@@ -33,7 +33,6 @@ def _kwargs(*, is_answerable: bool, abstained: str) -> dict[str, object]:
         "passages_text": "p",
         "question": "Onde Maria mora?",
         "gold_answer": "Em Itaqui.",
-        "context": "Maria mora em Itaqui.",
     }
 
 

--- a/tests/shared/rag/judge_answers/test_judge.py
+++ b/tests/shared/rag/judge_answers/test_judge.py
@@ -34,10 +34,6 @@ def _kwargs(*, is_answerable: bool, abstained: str) -> dict[str, object]:
         "question": "Onde Maria mora?",
         "gold_answer": "Em Itaqui.",
         "context": "Maria mora em Itaqui.",
-        "bloom_level": "remember",
-        "question_type": "factual",
-        "reasoning_trace": "",
-        "tacit_inference": "",
     }
 
 


### PR DESCRIPTION
## Summary

Follow-up to the judge redesign (#114). That PR widened `GoldRecord` with the full CEP field set on a "carry everything so Phase 2 needs no schema change" rationale. Reviewing what the judge actually consumes, four of those fields don't belong:

- **`bloom_level` / `question_type`** are analysis-side **stratification keys**, not judge inputs. The analysis stage already re-derives them from CEP via its own cross-cut map (`analysis/loader.build_cross_cut_map`), so carrying them on `GoldRecord` is duplicative.
- **`reasoning_trace` / `tacit_inference`** are the CEP generator's own self-explanations. Feeding the generator's annotation back into the judge as ground truth would make the judge score *conformance to that annotation* rather than against an independent reference — circular.

`GoldRecord` is now `qa_pair_id` / `question` / `gold_answer` / `context`. The `context` field stays: faithfulness and the planned Phase-2 heuristic-correctness criterion score against the source text the pair was generated from.

## Notes

- Verified against the criterion prompts that none of the answer-judge criteria (`abstention`, `passage_coverage`, `answer_correctness`, `answer_faithfulness`) read any of the four removed fields, so dropping them from `build_gold_lookup` + `_judge_one` is behavior-preserving.
- `test_judge._kwargs` cleaned to match the real `evaluate()` call (it was passing the four now-unused fields).

## Test plan

- [x] `uv run ruff check` -> clean
- [x] `uv run pytest tests/shared/rag/judge_answers/` -> 36 passed
- [x] `uv run pytest` -> 1431 passed, 1 skipped