### PR TITLE
feat(judge): ordinal-output criterion type (spec §4.1)

### DIFF
--- a/src/arandu/shared/judge/__init__.py
+++ b/src/arandu/shared/judge/__init__.py
@@ -1,6 +1,8 @@
 """Shared judge module for multi-stage evaluation with per-criterion thresholds."""
 
 from arandu.shared.judge.criterion import (
+    BaseCriterionConfig,
+    BaseLLMCriterion,
     CriterionConfig,
     HeuristicCriterion,
     JudgeCriterion,
@@ -9,6 +11,7 @@ from arandu.shared.judge.criterion import (
     OrdinalCriterionConfig,
     OrdinalCriterionResponse,
     OrdinalLLMCriterion,
+    RangeLLMCriterion,
 )
 from arandu.shared.judge.factory import LLMCriterionFactory
 from arandu.shared.judge.judge import BaseJudge
@@ -23,7 +26,9 @@ from arandu.shared.judge.schemas import (
 from arandu.shared.judge.step import JudgeStep
 
 __all__ = [
+    "BaseCriterionConfig",
     "BaseJudge",
+    "BaseLLMCriterion",
     "CriterionConfig",
     "CriterionScale",
     "CriterionScore",
@@ -40,5 +45,6 @@ __all__ = [
     "OrdinalCriterionConfig",
     "OrdinalCriterionResponse",
     "OrdinalLLMCriterion",
+    "RangeLLMCriterion",
     "StageMode",
 ]

--- a/src/arandu/shared/judge/__init__.py
+++ b/src/arandu/shared/judge/__init__.py
@@ -11,6 +11,7 @@ from arandu.shared.judge.criterion import (
     OrdinalCriterionConfig,
     OrdinalCriterionResponse,
     OrdinalLLMCriterion,
+    RangeCriterionResponse,
     RangeLLMCriterion,
 )
 from arandu.shared.judge.factory import LLMCriterionFactory
@@ -45,6 +46,7 @@ __all__ = [
     "OrdinalCriterionConfig",
     "OrdinalCriterionResponse",
     "OrdinalLLMCriterion",
+    "RangeCriterionResponse",
     "RangeLLMCriterion",
     "StageMode",
 ]

--- a/src/arandu/shared/judge/__init__.py
+++ b/src/arandu/shared/judge/__init__.py
@@ -6,11 +6,15 @@ from arandu.shared.judge.criterion import (
     JudgeCriterion,
     LLMCriterion,
     LLMCriterionConfig,
+    OrdinalCriterionConfig,
+    OrdinalCriterionResponse,
+    OrdinalLLMCriterion,
 )
 from arandu.shared.judge.factory import LLMCriterionFactory
 from arandu.shared.judge.judge import BaseJudge
 from arandu.shared.judge.pipeline import JudgePipeline, JudgeStage
 from arandu.shared.judge.schemas import (
+    CriterionScale,
     CriterionScore,
     JudgePipelineResult,
     JudgeStepResult,
@@ -21,6 +25,7 @@ from arandu.shared.judge.step import JudgeStep
 __all__ = [
     "BaseJudge",
     "CriterionConfig",
+    "CriterionScale",
     "CriterionScore",
     "HeuristicCriterion",
     "JudgeCriterion",
@@ -32,5 +37,8 @@ __all__ = [
     "LLMCriterion",
     "LLMCriterionConfig",
     "LLMCriterionFactory",
+    "OrdinalCriterionConfig",
+    "OrdinalCriterionResponse",
+    "OrdinalLLMCriterion",
     "StageMode",
 ]

--- a/src/arandu/shared/judge/criterion.py
+++ b/src/arandu/shared/judge/criterion.py
@@ -86,7 +86,7 @@ class LLMCriterionConfig(CriterionConfig):
     """
 
 
-class CriterionResponse(BaseModel):
+class RangeCriterionResponse(BaseModel):
     """Expected structured response from an LLM criterion evaluation."""
 
     score: float
@@ -219,7 +219,7 @@ class BaseLLMCriterion(JudgeCriterion):
     """
 
     SCALE: ClassVar[CriterionScale] = "continuous"
-    RESPONSE_MODEL: ClassVar[type[BaseModel]] = CriterionResponse
+    RESPONSE_MODEL: ClassVar[type[BaseModel]] = RangeCriterionResponse
     CONFIG_CLS: ClassVar[type[BaseCriterionConfig]] = LLMCriterionConfig
     DEFAULT_TEMPERATURE: ClassVar[float] = 0.3
 
@@ -349,7 +349,7 @@ class RangeLLMCriterion(BaseLLMCriterion):
     """Continuous ``[0, 1]`` LLM criterion (the default engine)."""
 
     SCALE: ClassVar[CriterionScale] = "continuous"
-    RESPONSE_MODEL: ClassVar[type[BaseModel]] = CriterionResponse
+    RESPONSE_MODEL: ClassVar[type[BaseModel]] = RangeCriterionResponse
     CONFIG_CLS: ClassVar[type[BaseCriterionConfig]] = LLMCriterionConfig
     DEFAULT_TEMPERATURE: ClassVar[float] = 0.3
 

--- a/src/arandu/shared/judge/criterion.py
+++ b/src/arandu/shared/judge/criterion.py
@@ -12,14 +12,15 @@ from __future__ import annotations
 import logging
 from abc import ABC, abstractmethod
 from string import Template
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ClassVar
 
 if TYPE_CHECKING:
     from pathlib import Path
+    from typing import Self
 
 from pydantic import BaseModel, Field
 
-from arandu.shared.judge.schemas import CriterionScore
+from arandu.shared.judge.schemas import CriterionScale, CriterionScore
 from arandu.utils.text import validate_ordinal_score, validate_score
 
 ORDINAL_MIN = 1
@@ -28,30 +29,40 @@ ORDINAL_MAX = 5
 logger = logging.getLogger(__name__)
 
 
-class CriterionConfig(BaseModel):
-    """Base configuration for any criterion."""
+def _render_prompt(prompt_template: str, **kwargs: Any) -> str:
+    """Render a ``$variable`` prompt template with the given fields.
 
-    threshold: float = Field(ge=0.0, le=1.0)
+    Shared by the template-based LLM criteria (continuous and ordinal).
+
+    Args:
+        prompt_template: Template string with ``$variable`` placeholders.
+        **kwargs: Values substituted into the template.
+
+    Returns:
+        Formatted prompt string.
+    """
+    return Template(prompt_template).safe_substitute(**kwargs)
 
 
-class LLMCriterionConfig(CriterionConfig):
-    """Configuration for LLM-based criteria.
+class BaseCriterionConfig(BaseModel):
+    """Shared configuration for criteria loaded from ``config.json``.
 
-    Loaded from ``config.json`` at criterion level. Fields override
-    factory defaults when present.
+    Carries the optional sampling temperature and the JSON loader. Concrete
+    configs add their own fields (e.g. a pass ``threshold`` for filtering
+    criteria); ordinal criteria need nothing further.
     """
 
     temperature: float | None = None
 
     @classmethod
-    def load(cls, config_file: Path) -> LLMCriterionConfig:
+    def load(cls, config_file: Path) -> Self:
         """Load config from a JSON file.
 
         Args:
             config_file: Path to config.json.
 
         Returns:
-            Validated config instance.
+            Validated config instance of the calling subclass.
 
         Raises:
             FileNotFoundError: If config file doesn't exist.
@@ -59,6 +70,20 @@ class LLMCriterionConfig(CriterionConfig):
         if not config_file.exists():
             raise FileNotFoundError(f"Criterion config not found: {config_file}")
         return cls.model_validate_json(config_file.read_text(encoding="utf-8"))
+
+
+class CriterionConfig(BaseCriterionConfig):
+    """Base configuration for filtering criteria (carries a pass threshold)."""
+
+    threshold: float = Field(ge=0.0, le=1.0)
+
+
+class LLMCriterionConfig(CriterionConfig):
+    """Configuration for LLM-based filtering criteria.
+
+    Loaded from ``config.json`` at criterion level. Fields override
+    factory defaults when present.
+    """
 
 
 class CriterionResponse(BaseModel):
@@ -152,117 +177,6 @@ class HeuristicCriterion(JudgeCriterion):
         ...
 
 
-class LLMCriterion(JudgeCriterion):
-    """LLM-based criterion using prompt templates and structured output.
-
-    Use ``from_config()`` to load from prompt files and config.json,
-    or instantiate directly for testing.
-
-    Args:
-        name: Criterion identifier.
-        threshold: Minimum score to pass.
-        llm_client: LLM client for evaluation.
-        prompt_template: Prompt template string with ``$variable`` placeholders.
-        temperature: Sampling temperature for LLM generation.
-        max_tokens: Maximum tokens for response.
-    """
-
-    def __init__(
-        self,
-        name: str,
-        threshold: float,
-        llm_client: Any,
-        prompt_template: str,
-        temperature: float = 0.3,
-        max_tokens: int = 2048,
-    ) -> None:
-        super().__init__(name, threshold)
-        self.llm_client = llm_client
-        self.prompt_template = prompt_template
-        self.temperature = temperature
-        self.max_tokens = max_tokens
-
-    @classmethod
-    def from_config(
-        cls,
-        name: str,
-        prompts_dir: Path,
-        language: str,
-        llm_client: Any,
-        temperature: float = 0.3,
-        max_tokens: int = 2048,
-    ) -> LLMCriterion:
-        """Load criterion from prompt files and config.json.
-
-        Args:
-            name: Criterion name (e.g., "faithfulness").
-            prompts_dir: Base directory for criterion prompts.
-            language: Language code (e.g., "pt", "en").
-            llm_client: LLM client for evaluation.
-            temperature: Default temperature (overridden by config if set).
-            max_tokens: Maximum tokens for response.
-
-        Returns:
-            Configured LLMCriterion instance.
-        """
-        config = LLMCriterionConfig.load(prompts_dir / name / "config.json")
-
-        prompt_file = prompts_dir / name / language / "prompt.md"
-        if not prompt_file.exists():
-            raise FileNotFoundError(f"Prompt file not found: {prompt_file}")
-        prompt_template = prompt_file.read_text(encoding="utf-8")
-
-        # Config temperature overrides factory default if set
-        effective_temp = config.temperature if config.temperature is not None else temperature
-
-        logger.debug("Loaded criterion '%s' for language '%s'", name, language)
-
-        return cls(
-            name=name,
-            threshold=config.threshold,
-            llm_client=llm_client,
-            prompt_template=prompt_template,
-            temperature=effective_temp,
-            max_tokens=max_tokens,
-        )
-
-    def _evaluate_impl(self, **kwargs: Any) -> CriterionScore:
-        """Call LLM with structured output and return scored result.
-
-        Args:
-            **kwargs: Domain-specific evaluation parameters.
-
-        Returns:
-            CriterionScore with score and rationale from LLM.
-        """
-        prompt = self._build_prompt(**kwargs)
-
-        response = self.llm_client.generate_structured(
-            prompt=prompt,
-            response_model=CriterionResponse,
-            temperature=self.temperature,
-            max_tokens=self.max_tokens,
-        )
-
-        return CriterionScore(
-            score=validate_score(response.score),
-            threshold=self.threshold,
-            rationale=response.rationale,
-        )
-
-    def _build_prompt(self, **kwargs: Any) -> str:
-        """Build evaluation prompt from template.
-
-        Args:
-            **kwargs: Parameters for template substitution.
-
-        Returns:
-            Formatted prompt string.
-        """
-        template = Template(self.prompt_template)
-        return template.safe_substitute(**kwargs)
-
-
 class OrdinalCriterionResponse(BaseModel):
     """Expected structured response from an ordinal LLM criterion.
 
@@ -275,63 +189,88 @@ class OrdinalCriterionResponse(BaseModel):
     rationale: str
 
 
-class OrdinalCriterionConfig(BaseModel):
+class OrdinalCriterionConfig(BaseCriterionConfig):
     """Configuration for ordinal LLM criteria.
 
     Ordinal criteria run in score mode, so no continuous ``threshold`` is
-    required; only the optional sampling temperature is configurable.
+    required; only the optional sampling temperature (from the shared base)
+    is configurable.
     """
 
-    temperature: float | None = None
 
-    @classmethod
-    def load(cls, config_file: Path) -> OrdinalCriterionConfig:
-        """Load config from a JSON file.
+class BaseLLMCriterion(JudgeCriterion):
+    """Shared machinery for prompt-template LLM criteria.
 
-        Args:
-            config_file: Path to config.json.
-
-        Returns:
-            Validated config instance.
-
-        Raises:
-            FileNotFoundError: If config file doesn't exist.
-        """
-        if not config_file.exists():
-            raise FileNotFoundError(f"Criterion config not found: {config_file}")
-        return cls.model_validate_json(config_file.read_text(encoding="utf-8"))
-
-
-class OrdinalLLMCriterion(JudgeCriterion):
-    """LLM-based criterion that emits an ordinal label instead of a float.
-
-    Mirrors ``LLMCriterion`` but produces a ``CriterionScore`` with
-    ``scale="ordinal"`` and an integer ``ordinal_score`` in
-    ``[ORDINAL_MIN, ORDINAL_MAX]``. The continuous ``threshold`` is unused
-    (fixed at ``0.0``); the criterion is meant to run in ``score`` mode.
+    Renders a ``$variable`` prompt, calls the structured LLM endpoint with
+    ``RESPONSE_MODEL``, and maps the response to a ``CriterionScore`` via
+    ``_score_from_response``. Concrete engines set the class attributes and
+    the score mapping: ``RangeLLMCriterion`` (continuous ``[0, 1]``) and
+    ``OrdinalLLMCriterion`` (ordinal ``{1..5}``). ``LLMCriterion`` is the
+    public router that picks an engine and delegates to it.
 
     Args:
         name: Criterion identifier.
         llm_client: LLM client for evaluation.
         prompt_template: Prompt template string with ``$variable`` placeholders.
-        temperature: Sampling temperature (low by default; the judgment is
-            structural, not creative).
+        threshold: Minimum score to pass (continuous criteria); ordinal
+            criteria run in score mode and leave this at ``0.0``.
+        temperature: Sampling temperature; falls back to ``DEFAULT_TEMPERATURE``.
         max_tokens: Maximum tokens for response.
     """
+
+    SCALE: ClassVar[CriterionScale] = "continuous"
+    RESPONSE_MODEL: ClassVar[type[BaseModel]] = CriterionResponse
+    CONFIG_CLS: ClassVar[type[BaseCriterionConfig]] = LLMCriterionConfig
+    DEFAULT_TEMPERATURE: ClassVar[float] = 0.3
 
     def __init__(
         self,
         name: str,
         llm_client: Any,
         prompt_template: str,
-        temperature: float = 0.1,
+        *,
+        threshold: float = 0.0,
+        temperature: float | None = None,
         max_tokens: int = 2048,
     ) -> None:
-        super().__init__(name, threshold=0.0)
+        super().__init__(name, threshold)
         self.llm_client = llm_client
         self.prompt_template = prompt_template
-        self.temperature = temperature
+        self.temperature = self.DEFAULT_TEMPERATURE if temperature is None else temperature
         self.max_tokens = max_tokens
+
+    @staticmethod
+    def _load_prompt_and_config(
+        engine_cls: type[BaseLLMCriterion],
+        name: str,
+        prompts_dir: Path,
+        language: str,
+        temperature: float | None,
+    ) -> tuple[str, float, float]:
+        """Load the prompt template and config for a criterion.
+
+        Shared by both the concrete engines and the router so the file/config
+        loading lives in one place.
+
+        Returns:
+            Tuple of ``(prompt_template, threshold, effective_temperature)``.
+            ``threshold`` is ``0.0`` for configs without one (ordinal).
+
+        Raises:
+            FileNotFoundError: If config.json or the prompt file is missing.
+        """
+        config = engine_cls.CONFIG_CLS.load(prompts_dir / name / "config.json")
+
+        prompt_file = prompts_dir / name / language / "prompt.md"
+        if not prompt_file.exists():
+            raise FileNotFoundError(f"Prompt file not found: {prompt_file}")
+        prompt_template = prompt_file.read_text(encoding="utf-8")
+
+        base_temp = engine_cls.DEFAULT_TEMPERATURE if temperature is None else temperature
+        effective_temp = config.temperature if config.temperature is not None else base_temp
+
+        logger.debug("Loaded criterion '%s' for language '%s'", name, language)
+        return prompt_template, getattr(config, "threshold", 0.0), effective_temp
 
     @classmethod
     def from_config(
@@ -340,13 +279,14 @@ class OrdinalLLMCriterion(JudgeCriterion):
         prompts_dir: Path,
         language: str,
         llm_client: Any,
-        temperature: float = 0.1,
+        *,
+        temperature: float | None = None,
         max_tokens: int = 2048,
-    ) -> OrdinalLLMCriterion:
-        """Load criterion from prompt files and config.json.
+    ) -> Self:
+        """Load a concrete engine from prompt files and config.json.
 
         Args:
-            name: Criterion name (e.g., "emic_validity").
+            name: Criterion name (e.g., "faithfulness", "emic_validity").
             prompts_dir: Base directory for criterion prompts.
             language: Language code (e.g., "pt", "en").
             llm_client: LLM client for evaluation.
@@ -354,49 +294,87 @@ class OrdinalLLMCriterion(JudgeCriterion):
             max_tokens: Maximum tokens for response.
 
         Returns:
-            Configured OrdinalLLMCriterion instance.
-
-        Raises:
-            FileNotFoundError: If config.json or the prompt file is missing.
+            Configured engine instance of the calling subclass.
         """
-        config = OrdinalCriterionConfig.load(prompts_dir / name / "config.json")
-
-        prompt_file = prompts_dir / name / language / "prompt.md"
-        if not prompt_file.exists():
-            raise FileNotFoundError(f"Prompt file not found: {prompt_file}")
-        prompt_template = prompt_file.read_text(encoding="utf-8")
-
-        effective_temp = config.temperature if config.temperature is not None else temperature
-
-        logger.debug("Loaded ordinal criterion '%s' for language '%s'", name, language)
-
+        prompt_template, threshold, effective_temp = cls._load_prompt_and_config(
+            cls, name, prompts_dir, language, temperature
+        )
         return cls(
             name=name,
             llm_client=llm_client,
             prompt_template=prompt_template,
+            threshold=threshold,
             temperature=effective_temp,
             max_tokens=max_tokens,
         )
 
     def _evaluate_impl(self, **kwargs: Any) -> CriterionScore:
-        """Call the LLM and return an ordinal-scored result.
-
-        Args:
-            **kwargs: Domain-specific evaluation parameters.
-
-        Returns:
-            CriterionScore with ``scale="ordinal"`` and an integer
-            ``ordinal_score``.
-        """
-        prompt = self._build_prompt(**kwargs)
-
+        """Render the prompt, call the LLM, and map the response to a score."""
+        prompt = _render_prompt(self.prompt_template, **kwargs)
         response = self.llm_client.generate_structured(
             prompt=prompt,
-            response_model=OrdinalCriterionResponse,
+            response_model=self.RESPONSE_MODEL,
             temperature=self.temperature,
             max_tokens=self.max_tokens,
         )
+        return self._score_from_response(response)
 
+    def evaluate(self, **kwargs: Any) -> CriterionScore:
+        """Evaluate content, wrapping errors via ``_error_score``."""
+        try:
+            return self._evaluate_impl(**kwargs)
+        except Exception as e:
+            logger.warning("Criterion '%s' evaluation failed: %s", self.name, e)
+            return self._error_score(str(e))
+
+    @abstractmethod
+    def _score_from_response(self, response: Any) -> CriterionScore:
+        """Map a structured LLM response to a CriterionScore."""
+        ...
+
+    def _error_score(self, error: str) -> CriterionScore:
+        """Build the CriterionScore used when evaluation raises.
+
+        Continuous default; ordinal engines override to keep ``scale``.
+        """
+        return CriterionScore(
+            score=None,
+            threshold=self.threshold,
+            rationale="",
+            error=error,
+        )
+
+
+class RangeLLMCriterion(BaseLLMCriterion):
+    """Continuous ``[0, 1]`` LLM criterion (the default engine)."""
+
+    SCALE: ClassVar[CriterionScale] = "continuous"
+    RESPONSE_MODEL: ClassVar[type[BaseModel]] = CriterionResponse
+    CONFIG_CLS: ClassVar[type[BaseCriterionConfig]] = LLMCriterionConfig
+    DEFAULT_TEMPERATURE: ClassVar[float] = 0.3
+
+    def _score_from_response(self, response: Any) -> CriterionScore:
+        return CriterionScore(
+            score=validate_score(response.score),
+            threshold=self.threshold,
+            rationale=response.rationale,
+        )
+
+
+class OrdinalLLMCriterion(BaseLLMCriterion):
+    """Ordinal ``{1..5}`` LLM criterion engine.
+
+    Produces a ``CriterionScore`` with ``scale="ordinal"`` and an integer
+    ``ordinal_score``. The continuous ``threshold`` is unused (fixed at
+    ``0.0``); the criterion runs in ``score`` mode.
+    """
+
+    SCALE: ClassVar[CriterionScale] = "ordinal"
+    RESPONSE_MODEL: ClassVar[type[BaseModel]] = OrdinalCriterionResponse
+    CONFIG_CLS: ClassVar[type[BaseCriterionConfig]] = OrdinalCriterionConfig
+    DEFAULT_TEMPERATURE: ClassVar[float] = 0.1
+
+    def _score_from_response(self, response: Any) -> CriterionScore:
         return CriterionScore(
             ordinal_score=validate_ordinal_score(response.score, ORDINAL_MIN, ORDINAL_MAX),
             scale="ordinal",
@@ -404,39 +382,117 @@ class OrdinalLLMCriterion(JudgeCriterion):
             rationale=response.rationale,
         )
 
+    def _error_score(self, error: str) -> CriterionScore:
+        return CriterionScore(
+            ordinal_score=None,
+            scale="ordinal",
+            threshold=self.threshold,
+            rationale="",
+            error=error,
+        )
+
+
+_ENGINES_BY_SCALE: dict[CriterionScale, type[BaseLLMCriterion]] = {
+    "continuous": RangeLLMCriterion,
+    "ordinal": OrdinalLLMCriterion,
+}
+
+
+def _engine_for_scale(scale: CriterionScale) -> type[BaseLLMCriterion]:
+    """Resolve the engine class for a scale, defaulting to continuous."""
+    try:
+        return _ENGINES_BY_SCALE[scale]
+    except KeyError:
+        raise ValueError(f"Unknown criterion scale: {scale!r}") from None
+
+
+class LLMCriterion(BaseLLMCriterion):
+    """Public router that delegates to a Range (default) or Ordinal engine.
+
+    Extends ``BaseLLMCriterion`` so it is a drop-in ``JudgeCriterion``, but
+    construction selects a concrete engine by ``scale`` and all evaluation is
+    delegated to it. Existing callers keep using ``LLMCriterion`` /
+    ``LLMCriterion.from_config`` and transparently get the continuous engine;
+    pass ``scale="ordinal"`` for the ordinal one.
+
+    Args:
+        name: Criterion identifier.
+        llm_client: LLM client for evaluation.
+        prompt_template: Prompt template string with ``$variable`` placeholders.
+        threshold: Minimum score to pass (continuous only).
+        temperature: Sampling temperature; falls back to the engine default.
+        max_tokens: Maximum tokens for response.
+        scale: ``"continuous"`` (default) or ``"ordinal"``.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        llm_client: Any,
+        prompt_template: str,
+        *,
+        threshold: float = 0.0,
+        temperature: float | None = None,
+        max_tokens: int = 2048,
+        scale: CriterionScale = "continuous",
+    ) -> None:
+        self._engine: BaseLLMCriterion = _engine_for_scale(scale)(
+            name,
+            llm_client,
+            prompt_template,
+            threshold=threshold,
+            temperature=temperature,
+            max_tokens=max_tokens,
+        )
+        self.scale = scale
+        super().__init__(
+            name,
+            llm_client,
+            prompt_template,
+            threshold=self._engine.threshold,
+            temperature=self._engine.temperature,
+            max_tokens=max_tokens,
+        )
+
+    @classmethod
+    def from_config(
+        cls,
+        name: str,
+        prompts_dir: Path,
+        language: str,
+        llm_client: Any,
+        *,
+        temperature: float | None = None,
+        max_tokens: int = 2048,
+        scale: CriterionScale = "continuous",
+    ) -> LLMCriterion:
+        """Load the router with the engine indicated by ``scale``.
+
+        Reads ``config.json`` + ``prompt.md`` once (via the shared loader for
+        the chosen engine) and constructs the router around the result.
+
+        Returns:
+            Configured ``LLMCriterion`` delegating to the selected engine.
+        """
+        engine_cls = _engine_for_scale(scale)
+        prompt_template, threshold, effective_temp = cls._load_prompt_and_config(
+            engine_cls, name, prompts_dir, language, temperature
+        )
+        return cls(
+            name=name,
+            llm_client=llm_client,
+            prompt_template=prompt_template,
+            threshold=threshold,
+            temperature=effective_temp,
+            max_tokens=max_tokens,
+            scale=scale,
+        )
+
+    def _evaluate_impl(self, **kwargs: Any) -> CriterionScore:
+        return self._engine._evaluate_impl(**kwargs)
+
     def evaluate(self, **kwargs: Any) -> CriterionScore:
-        """Evaluate content, wrapping errors into an ordinal CriterionScore.
+        return self._engine.evaluate(**kwargs)
 
-        Overrides the base wrapper so a failed evaluation still reports
-        ``scale="ordinal"`` (with ``ordinal_score=None``) rather than the
-        continuous default, keeping error rows self-describing.
-
-        Args:
-            **kwargs: Domain-specific evaluation parameters.
-
-        Returns:
-            CriterionScore with the ordinal scale set even on error.
-        """
-        try:
-            return self._evaluate_impl(**kwargs)
-        except Exception as e:
-            logger.warning("Ordinal criterion '%s' evaluation failed: %s", self.name, e)
-            return CriterionScore(
-                ordinal_score=None,
-                scale="ordinal",
-                threshold=self.threshold,
-                rationale="",
-                error=str(e),
-            )
-
-    def _build_prompt(self, **kwargs: Any) -> str:
-        """Build evaluation prompt from template.
-
-        Args:
-            **kwargs: Parameters for template substitution.
-
-        Returns:
-            Formatted prompt string.
-        """
-        template = Template(self.prompt_template)
-        return template.safe_substitute(**kwargs)
+    def _score_from_response(self, response: Any) -> CriterionScore:
+        return self._engine._score_from_response(response)

--- a/src/arandu/shared/judge/criterion.py
+++ b/src/arandu/shared/judge/criterion.py
@@ -20,7 +20,10 @@ if TYPE_CHECKING:
 from pydantic import BaseModel, Field
 
 from arandu.shared.judge.schemas import CriterionScore
-from arandu.utils.text import validate_score
+from arandu.utils.text import validate_ordinal_score, validate_score
+
+ORDINAL_MIN = 1
+ORDINAL_MAX = 5
 
 logger = logging.getLogger(__name__)
 
@@ -246,6 +249,185 @@ class LLMCriterion(JudgeCriterion):
             threshold=self.threshold,
             rationale=response.rationale,
         )
+
+    def _build_prompt(self, **kwargs: Any) -> str:
+        """Build evaluation prompt from template.
+
+        Args:
+            **kwargs: Parameters for template substitution.
+
+        Returns:
+            Formatted prompt string.
+        """
+        template = Template(self.prompt_template)
+        return template.safe_substitute(**kwargs)
+
+
+class OrdinalCriterionResponse(BaseModel):
+    """Expected structured response from an ordinal LLM criterion.
+
+    ``score`` is an integer label on the ordinal scale ``[ORDINAL_MIN,
+    ORDINAL_MAX]``. The range constraint makes ``generate_structured`` retry
+    when the model returns an out-of-range or fractional value.
+    """
+
+    score: int = Field(ge=ORDINAL_MIN, le=ORDINAL_MAX)
+    rationale: str
+
+
+class OrdinalCriterionConfig(BaseModel):
+    """Configuration for ordinal LLM criteria.
+
+    Ordinal criteria run in score mode, so no continuous ``threshold`` is
+    required; only the optional sampling temperature is configurable.
+    """
+
+    temperature: float | None = None
+
+    @classmethod
+    def load(cls, config_file: Path) -> OrdinalCriterionConfig:
+        """Load config from a JSON file.
+
+        Args:
+            config_file: Path to config.json.
+
+        Returns:
+            Validated config instance.
+
+        Raises:
+            FileNotFoundError: If config file doesn't exist.
+        """
+        if not config_file.exists():
+            raise FileNotFoundError(f"Criterion config not found: {config_file}")
+        return cls.model_validate_json(config_file.read_text(encoding="utf-8"))
+
+
+class OrdinalLLMCriterion(JudgeCriterion):
+    """LLM-based criterion that emits an ordinal label instead of a float.
+
+    Mirrors ``LLMCriterion`` but produces a ``CriterionScore`` with
+    ``scale="ordinal"`` and an integer ``ordinal_score`` in
+    ``[ORDINAL_MIN, ORDINAL_MAX]``. The continuous ``threshold`` is unused
+    (fixed at ``0.0``); the criterion is meant to run in ``score`` mode.
+
+    Args:
+        name: Criterion identifier.
+        llm_client: LLM client for evaluation.
+        prompt_template: Prompt template string with ``$variable`` placeholders.
+        temperature: Sampling temperature (low by default; the judgment is
+            structural, not creative).
+        max_tokens: Maximum tokens for response.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        llm_client: Any,
+        prompt_template: str,
+        temperature: float = 0.1,
+        max_tokens: int = 2048,
+    ) -> None:
+        super().__init__(name, threshold=0.0)
+        self.llm_client = llm_client
+        self.prompt_template = prompt_template
+        self.temperature = temperature
+        self.max_tokens = max_tokens
+
+    @classmethod
+    def from_config(
+        cls,
+        name: str,
+        prompts_dir: Path,
+        language: str,
+        llm_client: Any,
+        temperature: float = 0.1,
+        max_tokens: int = 2048,
+    ) -> OrdinalLLMCriterion:
+        """Load criterion from prompt files and config.json.
+
+        Args:
+            name: Criterion name (e.g., "emic_validity").
+            prompts_dir: Base directory for criterion prompts.
+            language: Language code (e.g., "pt", "en").
+            llm_client: LLM client for evaluation.
+            temperature: Default temperature (overridden by config if set).
+            max_tokens: Maximum tokens for response.
+
+        Returns:
+            Configured OrdinalLLMCriterion instance.
+
+        Raises:
+            FileNotFoundError: If config.json or the prompt file is missing.
+        """
+        config = OrdinalCriterionConfig.load(prompts_dir / name / "config.json")
+
+        prompt_file = prompts_dir / name / language / "prompt.md"
+        if not prompt_file.exists():
+            raise FileNotFoundError(f"Prompt file not found: {prompt_file}")
+        prompt_template = prompt_file.read_text(encoding="utf-8")
+
+        effective_temp = config.temperature if config.temperature is not None else temperature
+
+        logger.debug("Loaded ordinal criterion '%s' for language '%s'", name, language)
+
+        return cls(
+            name=name,
+            llm_client=llm_client,
+            prompt_template=prompt_template,
+            temperature=effective_temp,
+            max_tokens=max_tokens,
+        )
+
+    def _evaluate_impl(self, **kwargs: Any) -> CriterionScore:
+        """Call the LLM and return an ordinal-scored result.
+
+        Args:
+            **kwargs: Domain-specific evaluation parameters.
+
+        Returns:
+            CriterionScore with ``scale="ordinal"`` and an integer
+            ``ordinal_score``.
+        """
+        prompt = self._build_prompt(**kwargs)
+
+        response = self.llm_client.generate_structured(
+            prompt=prompt,
+            response_model=OrdinalCriterionResponse,
+            temperature=self.temperature,
+            max_tokens=self.max_tokens,
+        )
+
+        return CriterionScore(
+            ordinal_score=validate_ordinal_score(response.score, ORDINAL_MIN, ORDINAL_MAX),
+            scale="ordinal",
+            threshold=self.threshold,
+            rationale=response.rationale,
+        )
+
+    def evaluate(self, **kwargs: Any) -> CriterionScore:
+        """Evaluate content, wrapping errors into an ordinal CriterionScore.
+
+        Overrides the base wrapper so a failed evaluation still reports
+        ``scale="ordinal"`` (with ``ordinal_score=None``) rather than the
+        continuous default, keeping error rows self-describing.
+
+        Args:
+            **kwargs: Domain-specific evaluation parameters.
+
+        Returns:
+            CriterionScore with the ordinal scale set even on error.
+        """
+        try:
+            return self._evaluate_impl(**kwargs)
+        except Exception as e:
+            logger.warning("Ordinal criterion '%s' evaluation failed: %s", self.name, e)
+            return CriterionScore(
+                ordinal_score=None,
+                scale="ordinal",
+                threshold=self.threshold,
+                rationale="",
+                error=str(e),
+            )
 
     def _build_prompt(self, **kwargs: Any) -> str:
         """Build evaluation prompt from template.

--- a/src/arandu/shared/judge/criterion.py
+++ b/src/arandu/shared/judge/criterion.py
@@ -109,6 +109,15 @@ class JudgeCriterion(ABC):
         self.name = name
         self.threshold = threshold
 
+    @property
+    def scale(self) -> CriterionScale:
+        """Scale of this criterion's score. Continuous unless overridden.
+
+        Used by the pipeline to reject score-mode-only (ordinal) criteria from
+        filter stages.
+        """
+        return "continuous"
+
     def evaluate(self, **kwargs: Any) -> CriterionScore:
         """Evaluate content against this criterion.
 
@@ -218,9 +227,12 @@ class BaseLLMCriterion(JudgeCriterion):
         max_tokens: Maximum tokens for response.
     """
 
-    SCALE: ClassVar[CriterionScale] = "continuous"
-    RESPONSE_MODEL: ClassVar[type[BaseModel]] = RangeCriterionResponse
-    CONFIG_CLS: ClassVar[type[BaseCriterionConfig]] = LLMCriterionConfig
+    # Set by concrete engines (RangeLLMCriterion / OrdinalLLMCriterion). Left
+    # unset on the base so a new engine that forgets to declare them fails
+    # loudly (AttributeError) rather than silently inheriting continuous values.
+    SCALE: ClassVar[CriterionScale]
+    RESPONSE_MODEL: ClassVar[type[BaseModel]]
+    CONFIG_CLS: ClassVar[type[BaseCriterionConfig]]
     DEFAULT_TEMPERATURE: ClassVar[float] = 0.3
 
     def __init__(
@@ -238,6 +250,10 @@ class BaseLLMCriterion(JudgeCriterion):
         self.prompt_template = prompt_template
         self.temperature = self.DEFAULT_TEMPERATURE if temperature is None else temperature
         self.max_tokens = max_tokens
+
+    @property
+    def scale(self) -> CriterionScale:
+        return self.SCALE
 
     @staticmethod
     def _load_prompt_and_config(
@@ -346,12 +362,14 @@ class BaseLLMCriterion(JudgeCriterion):
 
 
 class RangeLLMCriterion(BaseLLMCriterion):
-    """Continuous ``[0, 1]`` LLM criterion (the default engine)."""
+    """Continuous ``[0, 1]`` LLM criterion (the default engine).
+
+    Inherits ``DEFAULT_TEMPERATURE = 0.3`` from the base.
+    """
 
     SCALE: ClassVar[CriterionScale] = "continuous"
     RESPONSE_MODEL: ClassVar[type[BaseModel]] = RangeCriterionResponse
     CONFIG_CLS: ClassVar[type[BaseCriterionConfig]] = LLMCriterionConfig
-    DEFAULT_TEMPERATURE: ClassVar[float] = 0.3
 
     def _score_from_response(self, response: Any) -> CriterionScore:
         return CriterionScore(
@@ -444,7 +462,6 @@ class LLMCriterion(BaseLLMCriterion):
             temperature=temperature,
             max_tokens=max_tokens,
         )
-        self.scale = scale
         super().__init__(
             name,
             llm_client,
@@ -453,6 +470,11 @@ class LLMCriterion(BaseLLMCriterion):
             temperature=self._engine.temperature,
             max_tokens=max_tokens,
         )
+
+    @property
+    def scale(self) -> CriterionScale:
+        """Derived from the delegate engine (single source of truth)."""
+        return self._engine.scale
 
     @classmethod
     def from_config(

--- a/src/arandu/shared/judge/pipeline.py
+++ b/src/arandu/shared/judge/pipeline.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, model_validator
 
 from arandu.shared.judge.schemas import JudgePipelineResult, JudgeStepResult, StageMode
 from arandu.shared.judge.step import JudgeStep  # noqa: TC001 (Pydantic needs runtime access)
@@ -37,6 +37,26 @@ class JudgeStage(BaseModel):
     mode: StageMode = "score"
 
     model_config = {"arbitrary_types_allowed": True}
+
+    @model_validator(mode="after")
+    def _reject_ordinal_in_filter(self) -> JudgeStage:
+        """Forbid ordinal (score-mode-only) criteria in a filter stage.
+
+        An ordinal criterion's ``passed`` is always True on success (no
+        continuous gate), so in a filter stage it would silently never reject.
+        Threshold-based ordinal filtering is a separate, deferred step; until
+        then this misconfiguration fails loudly at construction.
+        """
+        if self.mode == "filter":
+            ordinal = [
+                c.name for c in self.step.criteria if getattr(c, "scale", "continuous") == "ordinal"
+            ]
+            if ordinal:
+                raise ValueError(
+                    f"Filter-mode stage '{self.name}' contains ordinal criteria "
+                    f"{ordinal}; ordinal criteria run in score mode only."
+                )
+        return self
 
 
 class JudgePipeline:

--- a/src/arandu/shared/judge/schemas.py
+++ b/src/arandu/shared/judge/schemas.py
@@ -19,10 +19,28 @@ StageMode = Literal["filter", "score", "always"]
 """
 
 
-class CriterionScore(BaseModel):
-    """Result of a single criterion evaluation."""
+CriterionScale = Literal["continuous", "ordinal"]
+"""Which scale a criterion's result lives on.
 
-    score: float | None
+- ``"continuous"`` -- ``score`` holds a float in ``[0, 1]`` (default; the
+  classic LLM/heuristic criterion).
+- ``"ordinal"``    -- ``ordinal_score`` holds an integer label (e.g. ``{1..5}``);
+  ``score`` is unused. The continuous ``threshold`` does not gate ordinal
+  criteria, which run in ``score`` mode (any downstream filter threshold is
+  applied separately).
+"""
+
+
+class CriterionScore(BaseModel):
+    """Result of a single criterion evaluation.
+
+    Carries either a continuous ``score`` or an ``ordinal_score``, selected by
+    ``scale``. Continuous is the default so existing criteria are unaffected.
+    """
+
+    score: float | None = None
+    ordinal_score: int | None = None
+    scale: CriterionScale = "continuous"
     threshold: float
     rationale: str
     thinking: str | None = None
@@ -30,8 +48,18 @@ class CriterionScore(BaseModel):
 
     @property
     def passed(self) -> bool:
-        """Whether the score meets the threshold. Always False on error."""
-        if self.error is not None or self.score is None:
+        """Whether the criterion is satisfied. Always False on error.
+
+        For continuous criteria this is ``score >= threshold``. Ordinal
+        criteria run in score mode (no continuous gate), so a successful
+        evaluation counts as passed; any emic filter threshold is applied
+        downstream, not here.
+        """
+        if self.error is not None:
+            return False
+        if self.scale == "ordinal":
+            return self.ordinal_score is not None
+        if self.score is None:
             return False
         return self.score >= self.threshold
 

--- a/src/arandu/shared/judge/step.py
+++ b/src/arandu/shared/judge/step.py
@@ -42,6 +42,11 @@ class JudgeStep:
         """
         self._criteria = self._resolve_criteria(criteria, factory)
 
+    @property
+    def criteria(self) -> list[JudgeCriterion]:
+        """The resolved criteria this step evaluates."""
+        return self._criteria
+
     @staticmethod
     def _resolve_criteria(
         criteria: list[JudgeCriterion | str],

--- a/src/arandu/utils/text.py
+++ b/src/arandu/utils/text.py
@@ -113,9 +113,9 @@ def validate_ordinal_score(value: Any, low: int = 1, high: int = 5, default: int
     try:
         as_float = float(value)
     except (ValueError, TypeError):
-        return default
+        return max(low, min(high, default))
     if not as_float.is_integer():
-        return default
+        return max(low, min(high, default))
     return max(low, min(high, int(as_float)))
 
 

--- a/src/arandu/utils/text.py
+++ b/src/arandu/utils/text.py
@@ -84,6 +84,41 @@ def validate_score(value: Any, default: float = 0.5) -> float:
         return default
 
 
+def validate_ordinal_score(value: Any, low: int = 1, high: int = 5, default: int = 3) -> int:
+    """Validate and clamp an ordinal score to the integer range ``[low, high]``.
+
+    Coerces whole-number floats (``5.0``) to ``int`` and clamps out-of-range
+    values to the nearest bound. Non-numeric or fractional values fall back to
+    ``default``. Used as a safety net after an LLM returns an ordinal label.
+
+    Args:
+        value: Raw score value from an LLM response.
+        low: Inclusive lower bound of the ordinal scale.
+        high: Inclusive upper bound of the ordinal scale.
+        default: Fallback score when value is not a whole number.
+
+    Returns:
+        Integer score clamped to ``[low, high]``.
+
+    Examples:
+        >>> validate_ordinal_score(4)
+        4
+        >>> validate_ordinal_score(5.0)
+        5
+        >>> validate_ordinal_score(9)
+        5
+        >>> validate_ordinal_score("not_a_number")
+        3
+    """
+    try:
+        as_float = float(value)
+    except (ValueError, TypeError):
+        return default
+    if not as_float.is_integer():
+        return default
+    return max(low, min(high, int(as_float)))
+
+
 def strip_markdown_codeblock(text: str) -> str:
     """Remove markdown code block wrappers from text.
 

--- a/tests/shared/judge/test_criterion.py
+++ b/tests/shared/judge/test_criterion.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any
 import pytest
 from pydantic import ValidationError
 
-from arandu.shared.judge.criterion import CriterionResponse, HeuristicCriterion, LLMCriterion
+from arandu.shared.judge.criterion import HeuristicCriterion, LLMCriterion, RangeCriterionResponse
 from arandu.shared.judge.schemas import CriterionScore
 from arandu.shared.llm_client import StructuredOutputError
 
@@ -146,7 +146,7 @@ class TestLLMCriterion:
         mock_llm_client: Any,
     ) -> None:
         """Test successful evaluation."""
-        mock_llm_client.generate_structured.return_value = CriterionResponse(
+        mock_llm_client.generate_structured.return_value = RangeCriterionResponse(
             score=0.8, rationale="Good quality"
         )
 
@@ -174,14 +174,14 @@ class TestLLMCriterion:
         mock_llm_client.generate_structured.assert_called_once()
         call_kwargs = mock_llm_client.generate_structured.call_args.kwargs
         assert call_kwargs["temperature"] == 0.3
-        assert call_kwargs["response_model"] is CriterionResponse
+        assert call_kwargs["response_model"] is RangeCriterionResponse
 
     def test_evaluate_builds_prompt_with_kwargs(
         self,
         mock_llm_client: Any,
     ) -> None:
         """Test that evaluate passes kwargs to prompt building."""
-        mock_llm_client.generate_structured.return_value = CriterionResponse(
+        mock_llm_client.generate_structured.return_value = RangeCriterionResponse(
             score=0.7, rationale="Decent"
         )
 
@@ -267,7 +267,7 @@ class TestLLMCriterion:
         mock_llm_client: Any,
     ) -> None:
         """Test that scores outside [0, 1] are clamped."""
-        mock_llm_client.generate_structured.return_value = CriterionResponse(
+        mock_llm_client.generate_structured.return_value = RangeCriterionResponse(
             score=1.5, rationale="Too high"
         )
 
@@ -291,7 +291,7 @@ class TestLLMCriterion:
         mock_llm_client: Any,
     ) -> None:
         """Test that negative scores are clamped to 0."""
-        mock_llm_client.generate_structured.return_value = CriterionResponse(
+        mock_llm_client.generate_structured.return_value = RangeCriterionResponse(
             score=-0.5, rationale="Too low"
         )
 
@@ -315,7 +315,7 @@ class TestLLMCriterion:
         mock_llm_client: Any,
     ) -> None:
         """Test evaluation with criterion-specific extra parameters."""
-        mock_llm_client.generate_structured.return_value = CriterionResponse(
+        mock_llm_client.generate_structured.return_value = RangeCriterionResponse(
             score=0.6, rationale="OK"
         )
 

--- a/tests/shared/judge/test_ordinal_criterion.py
+++ b/tests/shared/judge/test_ordinal_criterion.py
@@ -81,6 +81,11 @@ class TestValidateOrdinalScore:
     def test_custom_default(self) -> None:
         assert validate_ordinal_score(None, default=2) == 2
 
+    def test_default_is_clamped_to_range(self) -> None:
+        # An out-of-range default must still honor the [low, high] contract.
+        assert validate_ordinal_score("garbage", low=1, high=4, default=9) == 4
+        assert validate_ordinal_score("garbage", low=2, high=5, default=0) == 2
+
 
 class TestCriterionScoreOrdinal:
     """CriterionScore carries ordinal results alongside continuous ones."""
@@ -344,3 +349,32 @@ class TestMixedPipeline:
         restored_emic = restored.stage_results["emic"].criterion_scores["emic_validity"]
         assert restored_emic.ordinal_score == 2
         assert restored_emic.scale == "ordinal"
+
+
+class TestScaleAccessor:
+    """Every criterion exposes a uniform `scale`; ordinal-in-filter is rejected."""
+
+    def test_continuous_criterion_scale(self, mock_llm_client: Any) -> None:
+        cont = LLMCriterion(name="f", llm_client=mock_llm_client, prompt_template="$x")
+        assert cont.scale == "continuous"
+
+    def test_ordinal_engine_scale(self, mock_llm_client: Any) -> None:
+        emic = OrdinalLLMCriterion(name="e", llm_client=mock_llm_client, prompt_template="$x")
+        assert emic.scale == "ordinal"
+
+    def test_router_scale_tracks_engine(self, mock_llm_client: Any) -> None:
+        # scale is derived from the engine, not stored separately.
+        router = LLMCriterion(
+            name="e", llm_client=mock_llm_client, prompt_template="$x", scale="ordinal"
+        )
+        assert router.scale == router._engine.scale == "ordinal"
+
+    def test_ordinal_criterion_in_filter_stage_rejected(self, mock_llm_client: Any) -> None:
+        emic = OrdinalLLMCriterion(name="e", llm_client=mock_llm_client, prompt_template="$x")
+        with pytest.raises(ValueError, match="ordinal"):
+            JudgeStage(name="bad", step=JudgeStep([emic]), mode="filter")
+
+    def test_ordinal_criterion_in_score_stage_allowed(self, mock_llm_client: Any) -> None:
+        emic = OrdinalLLMCriterion(name="e", llm_client=mock_llm_client, prompt_template="$x")
+        stage = JudgeStage(name="ok", step=JudgeStep([emic]), mode="score")
+        assert stage.mode == "score"

--- a/tests/shared/judge/test_ordinal_criterion.py
+++ b/tests/shared/judge/test_ordinal_criterion.py
@@ -15,8 +15,11 @@ import pytest
 from pydantic import ValidationError
 
 from arandu.shared.judge.criterion import (
+    CriterionResponse,
+    LLMCriterion,
     OrdinalCriterionResponse,
     OrdinalLLMCriterion,
+    RangeLLMCriterion,
 )
 from arandu.shared.judge.pipeline import JudgePipeline, JudgeStage
 from arandu.shared.judge.schemas import CriterionScore, JudgePipelineResult
@@ -210,29 +213,110 @@ class TestOrdinalLLMCriterion:
         assert "Modo antropólogo" in criterion.prompt_template
 
 
+class TestLLMCriterionRouter:
+    """LLMCriterion routes to a Range (default) or Ordinal engine."""
+
+    def test_default_routes_to_range_engine(self, mock_llm_client: Any) -> None:
+        criterion = LLMCriterion(
+            name="faithfulness",
+            llm_client=mock_llm_client,
+            prompt_template="$context",
+            threshold=0.7,
+        )
+        assert criterion.scale == "continuous"
+        assert isinstance(criterion._engine, RangeLLMCriterion)
+        assert criterion.threshold == 0.7
+
+    def test_scale_ordinal_routes_to_ordinal_engine(self, mock_llm_client: Any) -> None:
+        criterion = LLMCriterion(
+            name="emic_validity",
+            llm_client=mock_llm_client,
+            prompt_template="$context",
+            scale="ordinal",
+        )
+        assert criterion.scale == "ordinal"
+        assert isinstance(criterion._engine, OrdinalLLMCriterion)
+
+    def test_unknown_scale_rejected(self, mock_llm_client: Any) -> None:
+        with pytest.raises(ValueError, match="scale"):
+            LLMCriterion(
+                name="x",
+                llm_client=mock_llm_client,
+                prompt_template="$context",
+                scale="nonsense",  # type: ignore[arg-type]
+            )
+
+    def test_continuous_evaluation_delegated(self, mock_llm_client: Any) -> None:
+        mock_llm_client.generate_structured.return_value = CriterionResponse(
+            score=0.8, rationale="grounded"
+        )
+        criterion = LLMCriterion(
+            name="faithfulness",
+            llm_client=mock_llm_client,
+            prompt_template="$context",
+            threshold=0.7,
+        )
+        result = criterion.evaluate(context="c")
+        assert result.scale == "continuous"
+        assert result.score == 0.8
+        assert (
+            mock_llm_client.generate_structured.call_args.kwargs["response_model"]
+            is CriterionResponse
+        )
+
+    def test_ordinal_evaluation_delegated(self, mock_llm_client: Any) -> None:
+        mock_llm_client.generate_structured.return_value = OrdinalCriterionResponse(
+            score=2, rationale="reenquadramento"
+        )
+        criterion = LLMCriterion(
+            name="emic_validity",
+            llm_client=mock_llm_client,
+            prompt_template="$context",
+            scale="ordinal",
+        )
+        result = criterion.evaluate(context="c")
+        assert result.scale == "ordinal"
+        assert result.ordinal_score == 2
+        assert (
+            mock_llm_client.generate_structured.call_args.kwargs["response_model"]
+            is OrdinalCriterionResponse
+        )
+
+    def test_from_config_routes_ordinal(self, mock_llm_client: Any, tmp_path: Path) -> None:
+        base = tmp_path / "criteria"
+        crit_dir = base / "emic_validity" / "pt"
+        crit_dir.mkdir(parents=True)
+        (crit_dir / "prompt.md").write_text("$context")
+        (base / "emic_validity" / "config.json").write_text(json.dumps({"temperature": 0.1}))
+
+        criterion = LLMCriterion.from_config(
+            name="emic_validity",
+            prompts_dir=base,
+            language="pt",
+            llm_client=mock_llm_client,
+            scale="ordinal",
+        )
+        assert criterion.scale == "ordinal"
+        assert isinstance(criterion._engine, OrdinalLLMCriterion)
+        assert criterion.temperature == 0.1
+
+
 class TestMixedPipeline:
     """Ordinal and continuous criteria coexist in one pipeline."""
 
     def test_ordinal_score_stage_after_continuous_filter(self, mock_llm_client: Any) -> None:
-        from arandu.shared.judge.criterion import LLMCriterion
-
-        # Continuous filter criterion that passes.
-        mock_continuous = mock_llm_client
+        # Continuous filter criterion (router → Range engine) that passes.
         cont = LLMCriterion(
             name="faithfulness",
-            threshold=0.6,
-            llm_client=mock_continuous,
+            llm_client=mock_llm_client,
             prompt_template="$context $question $answer",
+            threshold=0.6,
         )
-        # Separate mock for the ordinal criterion so call routing is clear.
-        ordinal_client = mock_llm_client
         emic = OrdinalLLMCriterion(
             name="emic_validity",
-            llm_client=ordinal_client,
+            llm_client=mock_llm_client,
             prompt_template="$context $question $answer",
         )
-
-        from arandu.shared.judge.criterion import CriterionResponse
 
         def _route(**kwargs: Any) -> Any:
             if kwargs["response_model"] is OrdinalCriterionResponse:

--- a/tests/shared/judge/test_ordinal_criterion.py
+++ b/tests/shared/judge/test_ordinal_criterion.py
@@ -15,10 +15,10 @@ import pytest
 from pydantic import ValidationError
 
 from arandu.shared.judge.criterion import (
-    CriterionResponse,
     LLMCriterion,
     OrdinalCriterionResponse,
     OrdinalLLMCriterion,
+    RangeCriterionResponse,
     RangeLLMCriterion,
 )
 from arandu.shared.judge.pipeline import JudgePipeline, JudgeStage
@@ -247,7 +247,7 @@ class TestLLMCriterionRouter:
             )
 
     def test_continuous_evaluation_delegated(self, mock_llm_client: Any) -> None:
-        mock_llm_client.generate_structured.return_value = CriterionResponse(
+        mock_llm_client.generate_structured.return_value = RangeCriterionResponse(
             score=0.8, rationale="grounded"
         )
         criterion = LLMCriterion(
@@ -261,7 +261,7 @@ class TestLLMCriterionRouter:
         assert result.score == 0.8
         assert (
             mock_llm_client.generate_structured.call_args.kwargs["response_model"]
-            is CriterionResponse
+            is RangeCriterionResponse
         )
 
     def test_ordinal_evaluation_delegated(self, mock_llm_client: Any) -> None:
@@ -321,7 +321,7 @@ class TestMixedPipeline:
         def _route(**kwargs: Any) -> Any:
             if kwargs["response_model"] is OrdinalCriterionResponse:
                 return OrdinalCriterionResponse(score=2, rationale="reenquadramento")
-            return CriterionResponse(score=0.9, rationale="grounded")
+            return RangeCriterionResponse(score=0.9, rationale="grounded")
 
         mock_llm_client.generate_structured.side_effect = _route
 

--- a/tests/shared/judge/test_ordinal_criterion.py
+++ b/tests/shared/judge/test_ordinal_criterion.py
@@ -1,0 +1,262 @@
+"""Tests for ordinal-output judge criteria.
+
+Covers the ordinal extension of the composable judge module: a criterion
+type that emits an integer score in ``{1..5}`` plus a rationale, instead of
+the continuous ``[0, 1]`` score produced by ``LLMCriterion``. The ordinal
+score is the first consumer of this extension (emic validity, Phase D).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from pydantic import ValidationError
+
+from arandu.shared.judge.criterion import (
+    OrdinalCriterionResponse,
+    OrdinalLLMCriterion,
+)
+from arandu.shared.judge.pipeline import JudgePipeline, JudgeStage
+from arandu.shared.judge.schemas import CriterionScore, JudgePipelineResult
+from arandu.shared.judge.step import JudgeStep
+from arandu.utils.text import validate_ordinal_score
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from pytest_mock import MockerFixture
+
+
+@pytest.fixture
+def mock_llm_client(mocker: MockerFixture) -> Any:
+    """Create a mock LLM client mirroring tests/shared/judge/test_criterion.py."""
+    client = mocker.MagicMock()
+    client.provider.value = "ollama"
+    client.model_id = "test-model"
+    return client
+
+
+class TestOrdinalCriterionResponse:
+    """The structured response model enforces the {1..5} range."""
+
+    @pytest.mark.parametrize("value", [1, 2, 3, 4, 5])
+    def test_accepts_in_range(self, value: int) -> None:
+        resp = OrdinalCriterionResponse(score=value, rationale="ok")
+        assert resp.score == value
+
+    @pytest.mark.parametrize("value", [0, 6, -1, 10])
+    def test_rejects_out_of_range(self, value: int) -> None:
+        with pytest.raises(ValidationError):
+            OrdinalCriterionResponse(score=value, rationale="bad")
+
+    def test_rejects_non_integer(self) -> None:
+        # A float that is not a whole number must not silently truncate.
+        with pytest.raises(ValidationError):
+            OrdinalCriterionResponse(score=3.5, rationale="bad")
+
+
+class TestValidateOrdinalScore:
+    """The validate_ordinal_score helper coerces and clamps to {1..5}."""
+
+    def test_passes_through_valid_int(self) -> None:
+        assert validate_ordinal_score(4) == 4
+
+    def test_coerces_whole_float(self) -> None:
+        assert validate_ordinal_score(5.0) == 5
+
+    def test_clamps_above_range(self) -> None:
+        assert validate_ordinal_score(9) == 5
+
+    def test_clamps_below_range(self) -> None:
+        assert validate_ordinal_score(0) == 1
+
+    def test_default_on_garbage(self) -> None:
+        assert validate_ordinal_score("not_a_number") == 3
+
+    def test_custom_default(self) -> None:
+        assert validate_ordinal_score(None, default=2) == 2
+
+
+class TestCriterionScoreOrdinal:
+    """CriterionScore carries ordinal results alongside continuous ones."""
+
+    def test_continuous_score_unchanged(self) -> None:
+        cs = CriterionScore(score=0.8, threshold=0.7, rationale="good")
+        assert cs.scale == "continuous"
+        assert cs.passed is True
+        assert cs.ordinal_score is None
+
+    def test_ordinal_score_field(self) -> None:
+        cs = CriterionScore(
+            ordinal_score=4,
+            scale="ordinal",
+            threshold=0.0,
+            rationale="mostly emic",
+        )
+        assert cs.scale == "ordinal"
+        assert cs.ordinal_score == 4
+        assert cs.score is None
+
+    def test_ordinal_passed_when_evaluated(self) -> None:
+        # An ordinal criterion runs in score mode; a successful evaluation
+        # is "passed" regardless of the continuous threshold (the emic filter
+        # threshold is applied downstream, not here).
+        cs = CriterionScore(
+            ordinal_score=1,
+            scale="ordinal",
+            threshold=0.0,
+            rationale="distortion",
+        )
+        assert cs.passed is True
+
+    def test_ordinal_not_passed_on_error(self) -> None:
+        cs = CriterionScore(
+            ordinal_score=None,
+            scale="ordinal",
+            threshold=0.0,
+            rationale="",
+            error="LLM call failed",
+        )
+        assert cs.passed is False
+
+    def test_ordinal_json_round_trip(self) -> None:
+        cs = CriterionScore(
+            ordinal_score=3,
+            scale="ordinal",
+            threshold=0.0,
+            rationale="mixed framing",
+        )
+        restored = CriterionScore.model_validate_json(cs.model_dump_json())
+        assert restored.scale == "ordinal"
+        assert restored.ordinal_score == 3
+        assert restored.score is None
+
+
+class TestOrdinalLLMCriterion:
+    """OrdinalLLMCriterion produces ordinal CriterionScores via the LLM."""
+
+    def test_evaluate_success(self, mock_llm_client: Any) -> None:
+        mock_llm_client.generate_structured.return_value = OrdinalCriterionResponse(
+            score=4, rationale="leve deslize de enquadramento"
+        )
+        criterion = OrdinalLLMCriterion(
+            name="emic_validity",
+            llm_client=mock_llm_client,
+            prompt_template="Context: $context\nQuestion: $question\nAnswer: $answer\n",
+            temperature=0.1,
+            max_tokens=1024,
+        )
+
+        result = criterion.evaluate(
+            context="o pescador tira o barco quando a água sobe",
+            question="Como o pescador sabe que é hora de tirar o barco?",
+            answer="Quando percebe a água subindo rápido.",
+        )
+
+        assert isinstance(result, CriterionScore)
+        assert result.scale == "ordinal"
+        assert result.ordinal_score == 4
+        assert result.score is None
+        assert result.rationale == "leve deslize de enquadramento"
+
+        call_kwargs = mock_llm_client.generate_structured.call_args.kwargs
+        assert call_kwargs["temperature"] == 0.1
+        assert call_kwargs["response_model"] is OrdinalCriterionResponse
+
+    def test_evaluate_clamps_out_of_range_response(self, mock_llm_client: Any) -> None:
+        # If structured output somehow yields an out-of-range int, the
+        # criterion clamps rather than emitting an invalid ordinal.
+        mock_llm_client.generate_structured.return_value = OrdinalCriterionResponse.model_construct(
+            score=9, rationale="overflow"
+        )
+        criterion = OrdinalLLMCriterion(
+            name="emic_validity",
+            llm_client=mock_llm_client,
+            prompt_template="$context $question $answer",
+        )
+        result = criterion.evaluate(context="c", question="q", answer="a")
+        assert result.ordinal_score == 5
+
+    def test_evaluate_error_returns_blank_ordinal(self, mock_llm_client: Any) -> None:
+        mock_llm_client.generate_structured.side_effect = RuntimeError("boom")
+        criterion = OrdinalLLMCriterion(
+            name="emic_validity",
+            llm_client=mock_llm_client,
+            prompt_template="$context $question $answer",
+        )
+        result = criterion.evaluate(context="c", question="q", answer="a")
+        assert result.ordinal_score is None
+        assert result.scale == "ordinal"
+        assert result.error is not None
+        assert result.passed is False
+
+    def test_from_config(self, mock_llm_client: Any, tmp_path: Path) -> None:
+        base = tmp_path / "criteria"
+        crit_dir = base / "emic_validity" / "pt"
+        crit_dir.mkdir(parents=True)
+        (crit_dir / "prompt.md").write_text("Modo antropólogo: $context $question $answer")
+        (base / "emic_validity" / "config.json").write_text(json.dumps({"temperature": 0.1}))
+
+        criterion = OrdinalLLMCriterion.from_config(
+            name="emic_validity",
+            prompts_dir=base,
+            language="pt",
+            llm_client=mock_llm_client,
+        )
+        assert criterion.name == "emic_validity"
+        assert criterion.temperature == 0.1
+        assert "Modo antropólogo" in criterion.prompt_template
+
+
+class TestMixedPipeline:
+    """Ordinal and continuous criteria coexist in one pipeline."""
+
+    def test_ordinal_score_stage_after_continuous_filter(self, mock_llm_client: Any) -> None:
+        from arandu.shared.judge.criterion import LLMCriterion
+
+        # Continuous filter criterion that passes.
+        mock_continuous = mock_llm_client
+        cont = LLMCriterion(
+            name="faithfulness",
+            threshold=0.6,
+            llm_client=mock_continuous,
+            prompt_template="$context $question $answer",
+        )
+        # Separate mock for the ordinal criterion so call routing is clear.
+        ordinal_client = mock_llm_client
+        emic = OrdinalLLMCriterion(
+            name="emic_validity",
+            llm_client=ordinal_client,
+            prompt_template="$context $question $answer",
+        )
+
+        from arandu.shared.judge.criterion import CriterionResponse
+
+        def _route(**kwargs: Any) -> Any:
+            if kwargs["response_model"] is OrdinalCriterionResponse:
+                return OrdinalCriterionResponse(score=2, rationale="reenquadramento")
+            return CriterionResponse(score=0.9, rationale="grounded")
+
+        mock_llm_client.generate_structured.side_effect = _route
+
+        pipeline = JudgePipeline(
+            stages=[
+                JudgeStage(name="canonical", step=JudgeStep([cont]), mode="filter"),
+                JudgeStage(name="emic", step=JudgeStep([emic]), mode="score"),
+            ]
+        )
+
+        result = pipeline.evaluate(context="c", question="q", answer="a")
+
+        assert result.passed is True  # continuous filter passed
+        emic_score = result.stage_results["emic"].criterion_scores["emic_validity"]
+        assert emic_score.scale == "ordinal"
+        assert emic_score.ordinal_score == 2
+
+        # Pipeline result persists with the ordinal score intact.
+        restored = JudgePipelineResult.model_validate_json(result.model_dump_json())
+        restored_emic = restored.stage_results["emic"].criterion_scores["emic_validity"]
+        assert restored_emic.ordinal_score == 2
+        assert restored_emic.scale == "ordinal"

--- a/tests/shared/rag/judge_answers/test_judge.py
+++ b/tests/shared/rag/judge_answers/test_judge.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
-from arandu.shared.judge.criterion import CriterionResponse
+from arandu.shared.judge.criterion import RangeCriterionResponse
 from arandu.shared.rag.judge_answers.judge import AnswerJudge
 from arandu.shared.rag.judge_answers.settings import JudgeAnswersSettings
 
@@ -18,7 +18,7 @@ from arandu.shared.rag.judge_answers.settings import JudgeAnswersSettings
 def _judge() -> tuple[AnswerJudge, MagicMock]:
     """Build an AnswerJudge whose LLM criteria all return a fixed score."""
     llm = MagicMock()
-    llm.generate_structured.return_value = CriterionResponse(score=0.8, rationale="ok")
+    llm.generate_structured.return_value = RangeCriterionResponse(score=0.8, rationale="ok")
     judge = AnswerJudge(llm_client=llm, settings=JudgeAnswersSettings(provider="ollama"))
     return judge, llm
 

--- a/tests/transcription/test_judge.py
+++ b/tests/transcription/test_judge.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any
 import pytest
 
 from arandu.shared.judge import BaseJudge
-from arandu.shared.judge.criterion import CriterionResponse
+from arandu.shared.judge.criterion import RangeCriterionResponse
 from arandu.shared.llm_client import LLMProvider
 from arandu.transcription.judge import TranscriptionJudge, build_validator_client
 
@@ -100,7 +100,7 @@ def mock_llm_client(mocker: MockerFixture) -> Any:
     client = mocker.MagicMock()
     client.provider.value = "ollama"
     client.model_id = "test-model"
-    client.generate_structured.return_value = CriterionResponse(score=1.0, rationale="clean")
+    client.generate_structured.return_value = RangeCriterionResponse(score=1.0, rationale="clean")
     return client
 
 
@@ -127,11 +127,11 @@ class TestTranscriptionJudgeLLMStage:
         assert mock_llm_client.generate_structured.call_count == 2
 
     def test_llm_stage_rejects_on_drift(self, mock_llm_client: Any) -> None:
-        def _structured_response(**kwargs: Any) -> CriterionResponse:
+        def _structured_response(**kwargs: Any) -> RangeCriterionResponse:
             prompt = kwargs.get("prompt", "")
             if "Language Drift" in prompt or "Linguística" in prompt:
-                return CriterionResponse(score=0.0, rationale="fully English")
-            return CriterionResponse(score=1.0, rationale="no hallucination")
+                return RangeCriterionResponse(score=0.0, rationale="fully English")
+            return RangeCriterionResponse(score=1.0, rationale="no hallucination")
 
         mock_llm_client.generate_structured.side_effect = _structured_response
 


### PR DESCRIPTION
## What

Extends the composable judge module to support criteria that emit an **integer ordinal label in `{1..5}` + rationale**, alongside the existing continuous `[0,1]` score. This is the foundation for the emic-validity criterion (Phase D human-comparison protocol, spec §4.1); the concrete `emic_validity` criterion and its "modo antropólogo" prompt land in a follow-up.

## Design

The whole pipeline (`JudgeStep`, `JudgePipeline`, `JudgeResultMixin`) flows on `dict[str, CriterionScore]`. A parallel `OrdinalScore` carrier would ripple through every layer and break that typing. So this **extends `CriterionScore`** (additive, OCP) rather than introducing a new carrier type.

- **`schemas.py`** — `CriterionScore` gains `ordinal_score: int | None` + a `scale: Literal["continuous","ordinal"]` discriminator. `passed` is now scale-aware: continuous is unchanged (`score >= threshold`); ordinal runs in score mode (no continuous gate — the emic filter threshold is applied downstream, in a later task). New `CriterionScale` alias.
- **`criterion.py`** — `OrdinalCriterionResponse` (`score: int` with `Field(ge=1, le=5)`, so an out-of-range model output triggers the retry `generate_structured` already does), `OrdinalCriterionConfig` (no threshold; temperature only), `OrdinalLLMCriterion` (mirrors `LLMCriterion` + `from_config`; `evaluate` override so error rows stay `scale="ordinal"`).
- **`utils/text.py`** — `validate_ordinal_score` safety net: converts whole-floats (`5.0` → `5`), rejects fractionals (`3.5`), clamps out-of-range, defaults on garbage.

**No binning of continuous scores** — the criterion is natively ordinal.

## Tests

26 new cases in `tests/shared/judge/test_ordinal_criterion.py`: response range enforcement, `validate_ordinal_score`, `CriterionScore` ordinal semantics + JSON round-trip, `OrdinalLLMCriterion` success/clamp/error/`from_config`, and a mixed continuous-filter + ordinal-score pipeline with persistence round-trip.

## Verification

- New tests: 26 passed
- Judge + utils + qa/cep/rag/transcription consumers: 204 passed
- Full suite: **1457 passed, 1 skipped** (2 pre-existing SWIG deprecation warnings, unrelated)
- `ruff check` + `ruff format --check`: clean