### PR TITLE
feat(rag): deterministic source-recovery retrieval metric (judge-redesign Phase 2)

### DIFF
--- a/src/arandu/shared/rag/analysis/metrics.py
+++ b/src/arandu/shared/rag/analysis/metrics.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
 _CORRECTNESS = "answer_correctness"
 _FAITHFULNESS = "answer_faithfulness"
 _PASSAGE_COVERAGE = "passage_coverage"
+_SOURCE_RECOVERY = "source_recovery"
 
 
 class ProportionMetric(BaseModel):
@@ -63,6 +64,9 @@ class ArmMetrics(BaseModel):
     answer_faithfulness: MeanMetric
     knowledge_coverage: MeanMetric
     passage_coverage: MeanMetric
+    # Deterministic retrieval source-recovery (prose arms only; payload
+    # arms score None and are excluded from the mean by construction).
+    source_recovery: MeanMetric
 
 
 def aggregate_arm(
@@ -93,6 +97,7 @@ def aggregate_arm(
     faithfulness: list[float] = []
     kc_values: list[float] = []
     passage_cov: list[float] = []
+    source_rec: list[float] = []
 
     for record in records:
         label = classify_record(record)
@@ -111,6 +116,11 @@ def aggregate_arm(
         cov = _criterion_score(record, _PASSAGE_COVERAGE)
         if cov is not None:
             passage_cov.append(cov)
+        # Payload arms / empty-passage records score None here, so they
+        # drop out of the mean automatically (prose arms only).
+        recovery = _criterion_score(record, _SOURCE_RECOVERY)
+        if recovery is not None:
+            source_rec.append(recovery)
 
     ta = confusion.get("TA", 0)
     tc = confusion.get("TC", 0)
@@ -136,6 +146,7 @@ def aggregate_arm(
         answer_faithfulness=_mean(faithfulness),
         knowledge_coverage=_mean(kc_values),
         passage_coverage=_mean(passage_cov),
+        source_recovery=_mean(source_rec),
     )
 
 

--- a/src/arandu/shared/rag/analysis/report.py
+++ b/src/arandu/shared/rag/analysis/report.py
@@ -64,9 +64,11 @@ def _table_1_joint(joint: dict[str, ArmMetrics]) -> str:
         "## Table 1 - Per-arm joint-benchmark metrics\n"
         "\n"
         "| Arm | n_answerable | n_nonanswerable | KC ↑ | Hallucination ↓ "
-        "| Over-caution ↓ | Abstention F1 ↑ | Passage cov (judge) ↑ |\n"
+        "| Over-caution ↓ | Abstention F1 ↑ | Passage cov (judge) ↑ "
+        "| Source recovery (prose) ↑ |\n"
         "|-----|--------------|-----------------|------|-----------------"
-        "|----------------|-----------------|-----------------------|"
+        "|----------------|-----------------|-----------------------"
+        "|---------------------------|"
     )
     rows = [header]
     for arm in sorted(joint):
@@ -79,7 +81,8 @@ def _table_1_joint(joint: dict[str, ArmMetrics]) -> str:
             f"| {_fmt_prop_ci(m.hallucination_rate)} "
             f"| {_fmt_prop_ci(m.over_cautiousness_rate)} "
             f"| {_fmt_mean(m.abstention_f1)} "
-            f"| {_fmt_mean(m.passage_coverage.mean)} |"
+            f"| {_fmt_mean(m.passage_coverage.mean)} "
+            f"| {_fmt_mean(m.source_recovery.mean)} |"
         )
     return "\n".join(rows)
 
@@ -144,4 +147,5 @@ def _empty() -> ArmMetrics:
         answer_faithfulness=zero_mean,
         knowledge_coverage=zero_mean,
         passage_coverage=zero_mean,
+        source_recovery=zero_mean,
     )

--- a/src/arandu/shared/rag/judge_answers/batch.py
+++ b/src/arandu/shared/rag/judge_answers/batch.py
@@ -72,7 +72,7 @@ def run_judge_answers_batch(
     base_dir: Path | None = None,
     rejudge: bool = False,
 ) -> JudgeAnswersBatchResult:
-    """Run the 4-criterion LLM judge over every ``AnswerRecord`` for ``pipeline_id``.
+    """Run the gated answer-judge pipeline over every ``AnswerRecord`` for ``pipeline_id``.
 
     Args:
         pipeline_id: Run identifier. The answers stage must be populated.
@@ -288,26 +288,30 @@ def _judge_one(
 ) -> AnswerRecord:
     """Run the gated judge pipeline; attach the verdict to the record.
 
-    Every kwarg below is consumed by at least one stage. The gates read
-    ``is_answerable`` + ``abstained``; the abstention criterion reads
-    ``abstained`` / ``answer_text`` / ``rationale``; the gold-scoring
-    criteria read ``question`` / ``gold_answer`` / ``passages_text``.
-    Criteria that don't reference a given kwarg silently ignore it (LLM
-    prompts via ``string.Template.safe_substitute``).
+    Every kwarg below is consumed by at least one stage. Criteria that
+    don't reference a given kwarg silently ignore it (LLM prompts via
+    ``string.Template.safe_substitute``; heuristics via ``kwargs.get``):
+
+    - gates: ``is_answerable`` (answerability) + ``abstained`` (commitment);
+    - ``abstention``: ``abstained`` / ``answer_text`` / ``rationale``;
+    - ``passage_coverage`` / ``answer_correctness`` / ``answer_faithfulness``:
+      ``question`` / ``gold_answer`` / ``system_answer`` / ``passages_text``;
+    - ``source_recovery`` (heuristic): ``retrieved_text`` (raw joined
+      passage text, no ``[Passage N]`` markers) / ``context`` /
+      ``passages_are_payload``.
 
     ``gold`` is ``None`` for non-answerable items (no CEP pair); the
     answerability gate rejects those before the gold criteria run, so the
     empty gold fields are never actually consumed.
     """
     resolved_passages = _resolve_passage_texts(answer, passage_text)
-    passages_text = _format_passages(answer, passage_text)
     pipeline_result = judge.evaluate(
         is_answerable=answer.is_answerable,
         abstained=str(answer.abstained).lower(),
         answer_text=answer.answer_text or "",
         system_answer=answer.answer_text or "",
         rationale=answer.rationale,
-        passages_text=passages_text,
+        passages_text=_format_passages(resolved_passages),
         # Raw joined passage text + payload flag for the deterministic
         # source_recovery criterion (separate from the LLM-facing
         # passages_text, which carries "[Passage N]" markers).
@@ -339,12 +343,13 @@ def _resolve_passage_texts(answer: AnswerRecord, passage_text: dict[str, str]) -
     return texts
 
 
-def _format_passages(answer: AnswerRecord, passage_text: dict[str, str]) -> str:
-    """Format retrieved passages as enumerated text for the LLM prompts."""
-    parts = [
-        f"[Passage {idx}]:\n{text}\n"
-        for idx, text in enumerate(_resolve_passage_texts(answer, passage_text), start=1)
-    ]
+def _format_passages(resolved_passages: list[str]) -> str:
+    """Format already-resolved passage texts as enumerated LLM-prompt text.
+
+    Takes the output of :func:`_resolve_passage_texts` so the caller
+    resolves once and reuses it (the raw join also feeds ``source_recovery``).
+    """
+    parts = [f"[Passage {idx}]:\n{text}\n" for idx, text in enumerate(resolved_passages, start=1)]
     return "\n".join(parts) if parts else "(no passages available)"
 
 

--- a/src/arandu/shared/rag/judge_answers/batch.py
+++ b/src/arandu/shared/rag/judge_answers/batch.py
@@ -299,6 +299,7 @@ def _judge_one(
     answerability gate rejects those before the gold criteria run, so the
     empty gold fields are never actually consumed.
     """
+    resolved_passages = _resolve_passage_texts(answer, passage_text)
     passages_text = _format_passages(answer, passage_text)
     pipeline_result = judge.evaluate(
         is_answerable=answer.is_answerable,
@@ -307,29 +308,43 @@ def _judge_one(
         system_answer=answer.answer_text or "",
         rationale=answer.rationale,
         passages_text=passages_text,
+        # Raw joined passage text + payload flag for the deterministic
+        # source_recovery criterion (separate from the LLM-facing
+        # passages_text, which carries "[Passage N]" markers).
+        retrieved_text="\n".join(resolved_passages),
+        passages_are_payload=any(p.payload is not None for p in answer.passages),
         question=gold.question if gold is not None else answer.question,
         gold_answer=gold.gold_answer if gold is not None else "",
+        context=gold.context if gold is not None else "",
     )
     return answer.model_copy(update={"validation": pipeline_result})
 
 
-def _format_passages(answer: AnswerRecord, passage_text: dict[str, str]) -> str:
-    """Format retrieved passages as enumerated text for the LLM prompts.
+def _resolve_passage_texts(answer: AnswerRecord, passage_text: dict[str, str]) -> list[str]:
+    """Resolve each passage to its raw text (payload or chunk lookup).
 
     Honours :attr:`RetrievedPassage.payload` for triple-arm passages
-    (those skip the chunk_id lookup). Unresolvable passages are
-    silently dropped — the judge sees only the passages that have
-    text grounding.
+    (those skip the chunk_id lookup). Unresolvable / empty passages are
+    dropped, so the caller sees only passages that have text grounding.
     """
-    parts: list[str] = []
-    for idx, passage in enumerate(answer.passages, start=1):
-        if passage.payload is not None:
-            text = passage.payload
-        else:
-            text = passage_text.get(passage.chunk_id, "")
-        if not text:
-            continue
-        parts.append(f"[Passage {idx}]:\n{text}\n")
+    texts: list[str] = []
+    for passage in answer.passages:
+        text = (
+            passage.payload
+            if passage.payload is not None
+            else passage_text.get(passage.chunk_id, "")
+        )
+        if text:
+            texts.append(text)
+    return texts
+
+
+def _format_passages(answer: AnswerRecord, passage_text: dict[str, str]) -> str:
+    """Format retrieved passages as enumerated text for the LLM prompts."""
+    parts = [
+        f"[Passage {idx}]:\n{text}\n"
+        for idx, text in enumerate(_resolve_passage_texts(answer, passage_text), start=1)
+    ]
     return "\n".join(parts) if parts else "(no passages available)"
 
 

--- a/src/arandu/shared/rag/judge_answers/gold_lookup.py
+++ b/src/arandu/shared/rag/judge_answers/gold_lookup.py
@@ -7,16 +7,15 @@ same ``qa_pair_id`` format the retrieve / answer stages emit
 (``"<file_id>:<chunk_id>:<idx>"``).
 
 ``GoldRecord`` carries only what an answer-judge criterion actually
-consumes today: the question and the gold answer. Other ``QAPairCEP``
-fields are deliberately NOT carried here:
+consumes: the question, the gold answer, and the source ``context``.
+``context`` is the source span the QA pair was generated from; the
+deterministic ``source_recovery`` criterion scores retrieved passages
+against it (did retrieval recover the actual source?). Other
+``QAPairCEP`` fields are deliberately NOT carried here:
 
-- Source ``context``, Bloom level, question type: no current criterion
-  reads them. ``answer_faithfulness`` scores against the retrieved
-  ``passages_text``, not the gold context; the analysis stage re-derives
-  Bloom level / question type via its own CEP cross-cut map
-  (:func:`arandu.shared.rag.analysis.loader.build_cross_cut_map`). The
-  planned Phase-2 heuristic-correctness criterion will re-add ``context``
-  here together with the code that consumes it.
+- Bloom level, question type: stratification keys, not judge inputs. The
+  analysis stage re-derives them via its own CEP cross-cut map
+  (:func:`arandu.shared.rag.analysis.loader.build_cross_cut_map`).
 - ``reasoning_trace`` / ``tacit_inference``: feeding the CEP generator's
   own self-explanation back as ground truth would make the judge score
   conformance to the annotation rather than against an independent
@@ -28,7 +27,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel, Field, ValidationError
 
 from arandu.qa.schemas import QARecordCEP
 
@@ -44,6 +43,9 @@ class GoldRecord(BaseModel):
     qa_pair_id: str
     question: str
     gold_answer: str
+    context: str = Field(
+        default="", description="Source span the QA pair was generated from (source_recovery)."
+    )
 
 
 def build_gold_lookup(cep_dir: Path) -> dict[str, GoldRecord]:
@@ -74,5 +76,6 @@ def build_gold_lookup(cep_dir: Path) -> dict[str, GoldRecord]:
                 qa_pair_id=qa_pair_id,
                 question=pair.question,
                 gold_answer=pair.answer,
+                context=pair.context,
             )
     return out

--- a/src/arandu/shared/rag/judge_answers/heuristic.py
+++ b/src/arandu/shared/rag/judge_answers/heuristic.py
@@ -1,4 +1,4 @@
-"""Heuristic (non-LLM) gate criteria for the answer judge (spec §6).
+"""Heuristic (non-LLM) criteria for the answer judge (spec §6).
 
 Two single-responsibility gates compose into a cascade that gates the
 LLM-backed scoring stages on their actual data dependencies:
@@ -20,13 +20,22 @@ scoring); FA passes the first gate but is stopped at the commitment
 gate (skip answer scoring only; passage_coverage still runs because
 retrieval can be evaluated against the gold answer regardless of
 whether the system used it); TC passes both gates.
+
+This module also hosts :class:`SourceRecoveryCriterion`, a deterministic
+*scoring* criterion (not a gate) that lives in the retrieval-scoring
+stage alongside the LLM ``passage_coverage``.
 """
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from arandu.shared.judge.criterion import HeuristicCriterion
+from arandu.shared.judge.schemas import CriterionScore
+from arandu.shared.rag.retrievers._bm25_tokenize import portuguese_tokenizer
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 class AnswerabilityGateCriterion(HeuristicCriterion):
@@ -85,3 +94,93 @@ class CommitmentGateCriterion(HeuristicCriterion):
         if not abstained:
             return 1.0, "committed -> score answer correctness + faithfulness"
         return 0.0, "abstained -> no answer text; skip answer scoring"
+
+
+class SourceRecoveryCriterion(HeuristicCriterion):
+    """Deterministic retrieval source-recovery (spec §6.3 lineage).
+
+    Set-precision (containment) of the retrieved passages' content tokens
+    within the CEP source ``context`` the QA pair was generated from:
+
+        score = |tokens(retrieved) ∩ tokens(context)| / |tokens(retrieved)|
+
+    This is a retrieval-*targeting* lens distinct from the LLM
+    ``passage_coverage`` (which asks semantically whether the passages
+    support the gold answer): did the retriever recover the actual source
+    span? It runs in the retrieval-scoring stage, for every answerable
+    item (TC + FA), and never gates.
+
+    Containment, not symmetric F1, on purpose: the source ``context`` is a
+    large generation-time chunk while a retrieved passage is a shorter
+    span, so a perfect retriever returns a *subset* and symmetric overlap
+    would be capped low by the length mismatch. Precision answers "is what
+    I retrieved drawn from the right source?".
+
+    Returns ``score=None`` (not ``0.0``) for the cases where the metric is
+    undefined or would bias the cross-arm comparison, so the analysis mean
+    excludes them:
+
+    - **payload arms** (e.g. ``KHopTripleRetriever``): linearized triples
+      are not source prose, so token overlap is structurally near-zero
+      regardless of relevance — the same bias that kept the deterministic
+      ``offset_coverage`` variant out of the pipeline.
+    - **no retrieved passages** (e.g. ``NullRetriever``): empty denominator.
+    - **no source context**: empty denominator on the gold side.
+
+    Tokenization reuses the BM25 Portuguese tokenizer (lemma + stopword
+    removal), so containment is over content words, not surface forms or
+    stopwords.
+    """
+
+    def __init__(self, *, threshold: float = 0.5) -> None:
+        """Initialise the criterion and build the tokenizer once."""
+        super().__init__(name="source_recovery", threshold=threshold)
+        self._tokenize: Callable[[str], list[str]] = portuguese_tokenizer()
+
+    def _check(self, **kwargs: Any) -> tuple[float, str]:
+        """Unused: :meth:`_evaluate_impl` is overridden to express the
+        not-applicable (``score=None``) cases a ``(float, str)`` cannot."""
+        raise NotImplementedError  # pragma: no cover
+
+    def _evaluate_impl(self, **kwargs: Any) -> CriterionScore:
+        """Compute containment, or ``score=None`` for the undefined cases.
+
+        Args:
+            **kwargs: Reads ``passages_are_payload`` (bool),
+                ``retrieved_text`` (raw joined passage text), and
+                ``context`` (gold source span).
+
+        Returns:
+            CriterionScore with the containment fraction, or ``score=None``
+            for payload arms / empty passages / empty context.
+        """
+        if bool(kwargs.get("passages_are_payload", False)):
+            return CriterionScore(
+                score=None,
+                threshold=self.threshold,
+                rationale="payload arm (non-prose passages); source-recovery N/A",
+            )
+        retrieved_tokens = set(self._tokenize(str(kwargs.get("retrieved_text", ""))))
+        context_tokens = set(self._tokenize(str(kwargs.get("context", ""))))
+        if not retrieved_tokens:
+            return CriterionScore(
+                score=None,
+                threshold=self.threshold,
+                rationale="no retrieved passages; source-recovery undefined",
+            )
+        if not context_tokens:
+            return CriterionScore(
+                score=None,
+                threshold=self.threshold,
+                rationale="no source context; source-recovery undefined",
+            )
+        overlap = len(retrieved_tokens & context_tokens)
+        containment = overlap / len(retrieved_tokens)
+        return CriterionScore(
+            score=containment,
+            threshold=self.threshold,
+            rationale=(
+                f"{overlap}/{len(retrieved_tokens)} retrieved content tokens "
+                f"found in source context"
+            ),
+        )

--- a/src/arandu/shared/rag/judge_answers/heuristic.py
+++ b/src/arandu/shared/rag/judge_answers/heuristic.py
@@ -32,7 +32,7 @@ from typing import TYPE_CHECKING, Any
 
 from arandu.shared.judge.criterion import HeuristicCriterion
 from arandu.shared.judge.schemas import CriterionScore
-from arandu.shared.rag.retrievers._bm25_tokenize import portuguese_tokenizer
+from arandu.shared.rag.retrievers._bm25_tokenize import english_tokenizer, portuguese_tokenizer
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -127,15 +127,25 @@ class SourceRecoveryCriterion(HeuristicCriterion):
     - **no retrieved passages** (e.g. ``NullRetriever``): empty denominator.
     - **no source context**: empty denominator on the gold side.
 
-    Tokenization reuses the BM25 Portuguese tokenizer (lemma + stopword
-    removal), so containment is over content words, not surface forms or
-    stopwords.
+    Tokenization reuses the BM25 tokenizer for the run ``language`` (lemma
+    + stopword removal), so containment is over content words, not surface
+    forms or stopwords. The language must match the corpus, hence it is
+    threaded through from the judge settings rather than hard-coded.
     """
 
-    def __init__(self, *, threshold: float = 0.5) -> None:
-        """Initialise the criterion and build the tokenizer once."""
+    def __init__(self, *, language: str = "pt", threshold: float = 0.5) -> None:
+        """Initialise the criterion and build the language tokenizer once.
+
+        Args:
+            language: ``"pt"`` (default) or ``"en"``; selects the BM25
+                tokenizer. Any other value falls back to Portuguese (the
+                project default corpus language).
+            threshold: Pass threshold (advisory; this criterion runs in
+                score mode and never gates).
+        """
         super().__init__(name="source_recovery", threshold=threshold)
-        self._tokenize: Callable[[str], list[str]] = portuguese_tokenizer()
+        tokenizer = english_tokenizer if language == "en" else portuguese_tokenizer
+        self._tokenize: Callable[[str], list[str]] = tokenizer()
 
     def _check(self, **kwargs: Any) -> tuple[float, str]:
         """Unused: :meth:`_evaluate_impl` is overridden to express the

--- a/src/arandu/shared/rag/judge_answers/judge.py
+++ b/src/arandu/shared/rag/judge_answers/judge.py
@@ -29,9 +29,9 @@ The whole pipeline still stops scoring ``answer_correctness`` /
 ``None``) per spec §6.1/§6.2, and still lets non-answerable items be
 judged on abstention alone (no gold needed).
 
-Note on scope: spec §6.3 also describes a deterministic
-``offset_coverage`` variant alongside the LLM ``passage_coverage``.
-The deterministic variant is intentionally **not** wired here:
+Note on scope: spec §6.3 also describes a deterministic *byte-offset*
+``offset_coverage`` variant alongside the LLM ``passage_coverage``. That
+specific variant is intentionally **not** wired here:
 
 - The thesis's research question is semantic ("did retrieval support a
   faithful tacit-knowledge answer?"), not extractive (literal-byte
@@ -43,6 +43,12 @@ The deterministic variant is intentionally **not** wired here:
   it, so its only role would be downstream analysis — and a standalone
   script can recompute char-overlap from the persisted records if a
   robustness sanity check ever needs it.
+
+A *different* deterministic criterion, :class:`SourceRecoveryCriterion`,
+**is** wired into the retrieval-scoring stage: it is token-containment
+against the gold ``context`` (not byte offsets), returns ``None`` for the
+payload arms that the offset variant would have biased, and is reported
+as a prose-arms-only diagnostic that does not feed ``KC``.
 """
 
 from __future__ import annotations

--- a/src/arandu/shared/rag/judge_answers/judge.py
+++ b/src/arandu/shared/rag/judge_answers/judge.py
@@ -131,7 +131,11 @@ class AnswerJudge(BaseJudge):
         abstention_step = JudgeStep(criteria=list(_ABSTENTION_CRITERIA), factory=self.factory)
         answerability_step = JudgeStep(criteria=[AnswerabilityGateCriterion()])
         retrieval_step = JudgeStep(
-            criteria=[*_RETRIEVAL_CRITERIA, SourceRecoveryCriterion()], factory=self.factory
+            criteria=[
+                *_RETRIEVAL_CRITERIA,
+                SourceRecoveryCriterion(language=self._settings.language),
+            ],
+            factory=self.factory,
         )
         commitment_step = JudgeStep(criteria=[CommitmentGateCriterion()])
         answer_step = JudgeStep(criteria=list(_ANSWER_CRITERIA), factory=self.factory)

--- a/src/arandu/shared/rag/judge_answers/judge.py
+++ b/src/arandu/shared/rag/judge_answers/judge.py
@@ -59,6 +59,7 @@ from arandu.shared.judge import (
 from arandu.shared.rag.judge_answers.heuristic import (
     AnswerabilityGateCriterion,
     CommitmentGateCriterion,
+    SourceRecoveryCriterion,
 )
 
 if TYPE_CHECKING:
@@ -114,13 +115,18 @@ class AnswerJudge(BaseJudge):
         - the commitment gate (filter) fronts answer scoring alone
           (only the answer-text criteria need a committed answer).
 
-        Stage names are distinct so the analysis stage finds the
-        ``abstention`` score by criterion name regardless of which
-        stages were skipped.
+        The retrieval-scoring stage mixes the LLM ``passage_coverage``
+        with the deterministic :class:`SourceRecoveryCriterion`
+        (``JudgeStep`` accepts factory-resolved strings + criterion
+        objects in one list). Stage names are distinct so the analysis
+        stage finds scores by criterion name regardless of which stages
+        were skipped.
         """
         abstention_step = JudgeStep(criteria=list(_ABSTENTION_CRITERIA), factory=self.factory)
         answerability_step = JudgeStep(criteria=[AnswerabilityGateCriterion()])
-        retrieval_step = JudgeStep(criteria=list(_RETRIEVAL_CRITERIA), factory=self.factory)
+        retrieval_step = JudgeStep(
+            criteria=[*_RETRIEVAL_CRITERIA, SourceRecoveryCriterion()], factory=self.factory
+        )
         commitment_step = JudgeStep(criteria=[CommitmentGateCriterion()])
         answer_step = JudgeStep(criteria=list(_ANSWER_CRITERIA), factory=self.factory)
         return JudgePipeline(

--- a/tests/shared/rag/analysis/conftest.py
+++ b/tests/shared/rag/analysis/conftest.py
@@ -28,6 +28,7 @@ def make_answer(
     correctness_score: float | None = 0.9,
     faithfulness_score: float | None = 0.8,
     passage_coverage_score: float | None = 0.7,
+    source_recovery_score: float | None = None,
 ) -> AnswerRecord:
     """Build a fully judged :class:`AnswerRecord` for analysis tests."""
     criterion_scores: dict[str, CriterionScore] = {
@@ -38,6 +39,9 @@ def make_answer(
         ),
         "passage_coverage": CriterionScore(
             score=passage_coverage_score, threshold=0.5, rationale="r"
+        ),
+        "source_recovery": CriterionScore(
+            score=source_recovery_score, threshold=0.5, rationale="r"
         ),
     }
     validation = JudgePipelineResult(

--- a/tests/shared/rag/analysis/test_metrics.py
+++ b/tests/shared/rag/analysis/test_metrics.py
@@ -119,3 +119,22 @@ class TestAggregateArm:
         metrics = aggregate_arm("bm25", records)
         assert metrics.knowledge_coverage.mean is not None
         assert abs(metrics.knowledge_coverage.mean - 0.4) < 1e-9
+
+    def test_source_recovery_mean_excludes_none(self) -> None:
+        # Two prose records carry source_recovery; one payload/null-style
+        # record carries None and must be excluded from the mean.
+        records = [
+            make_answer(qa_pair_id="r:c:0", source_recovery_score=0.6),
+            make_answer(qa_pair_id="r:c:1", source_recovery_score=0.8),
+            make_answer(qa_pair_id="r:c:2", source_recovery_score=None),
+        ]
+        metrics = aggregate_arm("bm25", records)
+        assert metrics.source_recovery.n == 2
+        assert metrics.source_recovery.mean is not None
+        assert abs(metrics.source_recovery.mean - 0.7) < 1e-9
+
+    def test_source_recovery_all_none_yields_none(self) -> None:
+        records = [make_answer(qa_pair_id="r:c:0", source_recovery_score=None)]
+        metrics = aggregate_arm("bm25", records)
+        assert metrics.source_recovery.mean is None
+        assert metrics.source_recovery.n == 0

--- a/tests/shared/rag/judge_answers/test_heuristic.py
+++ b/tests/shared/rag/judge_answers/test_heuristic.py
@@ -1,10 +1,11 @@
-"""Tests for the heuristic gate criteria (spec §6)."""
+"""Tests for the heuristic criteria (spec §6)."""
 
 from __future__ import annotations
 
 from arandu.shared.rag.judge_answers.heuristic import (
     AnswerabilityGateCriterion,
     CommitmentGateCriterion,
+    SourceRecoveryCriterion,
 )
 
 
@@ -53,3 +54,47 @@ class TestCommitmentGateCriterion:
         # value explicitly, so this is just the safe default.
         score = CommitmentGateCriterion().evaluate()
         assert score.passed is True
+
+
+class TestSourceRecoveryCriterion:
+    """Containment of retrieved tokens in the CEP source context."""
+
+    def test_full_containment_scores_one(self) -> None:
+        score = SourceRecoveryCriterion().evaluate(
+            retrieved_text="Maria mora em Itaqui",
+            context="Maria mora em Itaqui na beira do rio",
+            passages_are_payload=False,
+        )
+        assert score.score == 1.0
+
+    def test_partial_containment(self) -> None:
+        # Retrieved content tokens: {maria, morar, brasilia}; context has
+        # maria + morar but not brasilia -> 2/3.
+        score = SourceRecoveryCriterion().evaluate(
+            retrieved_text="Maria mora em Brasilia",
+            context="Maria mora em Itaqui",
+            passages_are_payload=False,
+        )
+        assert score.score is not None
+        assert 0.0 < score.score < 1.0
+
+    def test_payload_arm_scores_none(self) -> None:
+        score = SourceRecoveryCriterion().evaluate(
+            retrieved_text="(Maria, mora_em, Itaqui)",
+            context="Maria mora em Itaqui",
+            passages_are_payload=True,
+        )
+        assert score.score is None
+        assert score.error is None
+
+    def test_empty_passages_scores_none(self) -> None:
+        score = SourceRecoveryCriterion().evaluate(
+            retrieved_text="", context="Maria mora em Itaqui", passages_are_payload=False
+        )
+        assert score.score is None
+
+    def test_empty_context_scores_none(self) -> None:
+        score = SourceRecoveryCriterion().evaluate(
+            retrieved_text="Maria mora em Itaqui", context="", passages_are_payload=False
+        )
+        assert score.score is None

--- a/tests/shared/rag/judge_answers/test_heuristic.py
+++ b/tests/shared/rag/judge_answers/test_heuristic.py
@@ -67,6 +67,16 @@ class TestSourceRecoveryCriterion:
         )
         assert score.score == 1.0
 
+    def test_english_language_uses_english_tokenizer(self) -> None:
+        # language="en" must build an English tokenizer; containment still
+        # computes over English content words (smoke: no PT-tokenizer reuse).
+        score = SourceRecoveryCriterion(language="en").evaluate(
+            retrieved_text="Maria lives in Itaqui",
+            context="Maria lives in Itaqui by the river",
+            passages_are_payload=False,
+        )
+        assert score.score == 1.0
+
     def test_partial_containment(self) -> None:
         # Retrieved content tokens: {maria, morar, brasilia}; context has
         # maria + morar but not brasilia -> 2/3.

--- a/tests/shared/rag/judge_answers/test_judge.py
+++ b/tests/shared/rag/judge_answers/test_judge.py
@@ -73,7 +73,11 @@ class TestAnswerJudgePipeline:
         assert result.passed is False
         assert result.rejected_at == "commitment_gate"
         assert "retrieval_scoring" in result.stage_results
-        assert "passage_coverage" in result.stage_results["retrieval_scoring"].criterion_scores
+        retrieval = result.stage_results["retrieval_scoring"].criterion_scores
+        # Both retrieval-stage criteria run for FA, not just passage_coverage.
+        assert "passage_coverage" in retrieval
+        assert "source_recovery" in retrieval
+        assert retrieval["source_recovery"].score == 1.0
         assert "answer_scoring" not in result.stage_results
 
     def test_nonanswerable_committed_only_abstention(self) -> None:

--- a/tests/shared/rag/judge_answers/test_judge.py
+++ b/tests/shared/rag/judge_answers/test_judge.py
@@ -31,8 +31,11 @@ def _kwargs(*, is_answerable: bool, abstained: str) -> dict[str, object]:
         "system_answer": "Em Itaqui." if abstained == "false" else "",
         "rationale": "r",
         "passages_text": "p",
+        "retrieved_text": "Maria mora em Itaqui",
+        "passages_are_payload": False,
         "question": "Onde Maria mora?",
         "gold_answer": "Em Itaqui.",
+        "context": "Maria mora em Itaqui na beira do rio",
     }
 
 
@@ -51,7 +54,12 @@ class TestAnswerJudgePipeline:
             "commitment_gate",
             "answer_scoring",
         }
-        assert "passage_coverage" in result.stage_results["retrieval_scoring"].criterion_scores
+        retrieval = result.stage_results["retrieval_scoring"].criterion_scores
+        assert "passage_coverage" in retrieval
+        # Deterministic source_recovery rides alongside the LLM criterion
+        # in the same stage; here the retrieved text is fully contained.
+        assert "source_recovery" in retrieval
+        assert retrieval["source_recovery"].score == 1.0
         assert set(result.stage_results["answer_scoring"].criterion_scores) == {
             "answer_correctness",
             "answer_faithfulness",


### PR DESCRIPTION
## Summary

Phase 2 of the judge redesign. Adds `SourceRecoveryCriterion`, a **heuristic (non-LLM) scoring criterion** in the retrieval-scoring stage alongside the LLM `passage_coverage`. It measures retrieval *targeting*: set-precision (containment) of the retrieved passages' content tokens within the CEP source `context` the QA pair was generated from.

> Did the retriever recover the actual source span? — distinct from `passage_coverage`'s semantic "do the passages support the gold answer".

This is the version that survived the design discussion: heuristic *correctness* (token-F1 vs gold answer) was rejected as a lexical proxy for a semantic question the LLM already judges, and a naive retrieval-overlap was rejected as the biased `offset_coverage` we'd already dropped. Source-recovery against the **known source context** is a legitimate, interpretable retrieval diagnostic with a real ground truth.

## Design choices

- **Containment, not symmetric F1.** The source context is a large generation-time chunk; a retrieved passage is a shorter span. A perfect retriever returns a subset, so symmetric overlap would be capped low by length mismatch. Precision answers "is what I retrieved drawn from the right source?".
- **`score=None` (not `0.0`) where undefined or biasing**, so the analysis mean excludes them by construction → **prose-arms-only diagnostic**:
  - payload arms (`KHopTriple` linearized triples aren't source prose — the exact bias that kept `offset_coverage` out);
  - empty passages (`NullRetriever`);
  - empty context.
- Tokenization reuses the BM25 Portuguese tokenizer (lemma + stopword removal) → containment over content words.
- **Diagnostic only** — does NOT feed KC or the headline cross-arm comparison. New "Source recovery (prose)" column in Table 1.

## Wiring

- `GoldRecord` re-gains `context` — now with an actual consumer (this criterion), per the "add fields with the code that uses them" principle we set on #116.
- `_judge_one` forwards `context`, raw `retrieved_text` (markers stripped via a shared `_resolve_passage_texts` helper), and `passages_are_payload`.
- `analysis/metrics.py` aggregates a `source_recovery` MeanMetric (None auto-excluded); `report.py` adds the column.

## Test plan

- [x] `uv run ruff check` / `ruff format --check` -> clean
- [x] `uv run pytest` -> 1438 passed, 1 skipped (12 new: criterion 4-path behaviour, pipeline placement, metrics None-exclusion)