### PR TITLE
feat(data): cross-domain sanity dataset (spec §4.7)

### DIFF
--- a/data/cross_domain_sanity_questions.json
+++ b/data/cross_domain_sanity_questions.json
@@ -1,0 +1,17 @@
+[
+  { "question": "Qual é a capital da França?", "expected_behavior": "abstain" },
+  { "question": "Quem escreveu Dom Casmurro?", "expected_behavior": "abstain" },
+  { "question": "Em que ano caiu o Império Romano do Ocidente?", "expected_behavior": "abstain" },
+  { "question": "Qual é a fórmula química da água?", "expected_behavior": "abstain" },
+  { "question": "Em que continente fica o Quênia?", "expected_behavior": "abstain" },
+  { "question": "Quantos planetas há no Sistema Solar?", "expected_behavior": "abstain" },
+  { "question": "Quem pintou a Mona Lisa?", "expected_behavior": "abstain" },
+  { "question": "Qual é a raiz quadrada de 144?", "expected_behavior": "abstain" },
+  { "question": "Em que ano o homem pisou na Lua pela primeira vez?", "expected_behavior": "abstain" },
+  { "question": "Qual é o maior oceano do planeta?", "expected_behavior": "abstain" },
+  { "question": "Quem foi o primeiro presidente dos Estados Unidos?", "expected_behavior": "abstain" },
+  { "question": "Qual seleção venceu a Copa do Mundo de futebol de 2002?", "expected_behavior": "abstain" },
+  { "question": "Qual é a velocidade da luz no vácuo?", "expected_behavior": "abstain" },
+  { "question": "Quem desenvolveu a teoria da relatividade?", "expected_behavior": "abstain" },
+  { "question": "Qual é o metal mais leve da tabela periódica?", "expected_behavior": "abstain" }
+]


### PR DESCRIPTION
## Summary

Adds `data/cross_domain_sanity_questions.json` — 15 trivially out-of-domain PT-BR questions, each `{question, expected_behavior: "abstain"}`, matching the spec §4.7 minimal schema.

Topics (world capitals, classic literature, chemistry, astronomy, ancient history, sports, physics) have zero overlap with the riverine / climate-event ethnographic corpus, so **every retrieval arm should abstain** on them.

## Role

Calibration floor for the abstention-detection layer (spec §17/§18: target ≥95% TA across all four arms), scored **separately** from the headline benchmark (spec §8.1). Content-only, no consumer wiring — that's the downstream task this unblocks.

## Scope notes

- PT-BR per the task's acceptance criteria. English mirrors (spec parenthetical) deferred until an `en` run actually needs them — no consumer reads them yet (YAGNI).
- Schema kept to the spec's exact `{question, expected_behavior}` example; the consumption task owns any id/key fields it needs.

## Test plan

- [x] Valid JSON; 15 items; schema `{question, expected_behavior}`; all `abstain`; no duplicates.
- [ ] End-to-end abstention check folded into `experiment-dry-run` on test-kg-04.