### PR TITLE
feat(judge): emic_validity ordinal criterion prompt + config (spec §4.2)

### DIFF
--- a/prompts/judge/criteria/emic_validity/config.json
+++ b/prompts/judge/criteria/emic_validity/config.json
@@ -1,0 +1,1 @@
+{"temperature": 0.1}

--- a/prompts/judge/criteria/emic_validity/pt/prompt.md
+++ b/prompts/judge/criteria/emic_validity/pt/prompt.md
@@ -41,18 +41,23 @@ Modelos de linguagem como você tendem a **elevar queixas e descrições situada
 
 **Exemplos** (provisórios; pendentes de validação por especialista):
 
+Cada exemplo traz os mesmos três campos que você vê na avaliação (segmento, pergunta, resposta).
+
 *Nota 5 (generalização que preserva o sentido).*
+- Segmento: "ganhei o açucareiro de presente; o fogão eu comprei com um dinheiro que o Maikinho emprestou, que veio pelo Jô, porque tava caro e eu não tinha."
 - Pergunta: "Como Dona Gilda adquiriu seus objetos domésticos?"
 - Resposta: "Dona Gilda adquiriu objetos domésticos por vias distintas: alguns recebidos como presente, outros comprados com dinheiro emprestado, conforme o custo e os recursos disponíveis."
 - Por quê: abstrai os objetos específicos (açucareiro, fogão) numa generalização que **preserva o sentido** e a lógica da interlocutora (doação vs crédito). Generalizar aqui é bom. Nenhum marcador.
 
 *Nota 4 (troca leve de registro).*
 - Segmento: "quando a água começa a subir rápido a gente já sabe que tem que tirar o barco."
+- Pergunta: "Como o pescador sabe que é hora de retirar o barco?"
 - Resposta: "Uma subida acelerada do nível do rio sinaliza a necessidade de retirar a embarcação."
 - Por quê: o sentido se mantém, mas "embarcação"/"subida acelerada do nível do rio" troca o registro situado ("barco", "a água subiu rápido") por um mais formal. Marcador 5 brando.
 
 *Nota 2 (claim externo adicionado).*
 - Segmento: "o pescador vive oprimido pelo IBAMA, pela PATRAM (...) em vez de te proteger e te ajudar, eles te prejudicam."
+- Pergunta: "Como o pescador descreve a atuação dos órgãos ambientais?"
 - Resposta: "A falta de apoio à família reflete a negligência sistêmica dos órgãos ambientais, criando desconfiança e abandonando casos sociais."
 - Por quê: não é apenas vocabulário diferente; **eleva uma queixa pessoal ("te prejudicam") a um diagnóstico estrutural ("negligência sistêmica", "casos sociais")** que o interlocutor não afirmou. Marcador 2 (claim externo adicionado).
 

--- a/prompts/judge/criteria/emic_validity/pt/prompt.md
+++ b/prompts/judge/criteria/emic_validity/pt/prompt.md
@@ -4,43 +4,57 @@ Sua tarefa é atribuir a **VALIDADE ÊMICA** de um par pergunta-resposta gerado 
 
 **O construto: validade êmica**
 
-Um par tem validade êmica quando representa o conhecimento nas **categorias, termos e visão de mundo do próprio interlocutor** (perspectiva *êmica*), sem impor enquadramento externo do analista (*ético*), estereótipo, romantização ou senso comum.
+Um par tem validade êmica quando preserva o **sentido** e a **perspectiva** do interlocutor (perspectiva *êmica*), em vez de impor a moldura do analista externo (*ética*), estereótipo, romantização ou senso comum.
 
-A pergunta que você responde: *dado o segmento de origem, o próprio interlocutor (ou um membro da comunidade) reconheceria este par como fiel ao que quis dizer e a como ele entende o mundo? Ou o sentido foi deslocado para uma moldura de fora?*
+**Generalizar e abstrair é desejável, não um defeito.** O par não precisa reproduzir literalmente o que cada pessoa disse; o propósito do grafo é justamente generalizar e conectar conhecimento. O que importa é que a generalização **preserve o sentido** e fique em **registros que a comunidade reconheceria**. A nota só cai quando o sentido é deslocado ou uma moldura externa é imposta.
 
-Isto **não** é fidelidade textual. Um par pode citar fielmente o que foi dito e ainda assim ser eticamente distorcido ao reenquadrar o sentido. Fidelidade pergunta "está no texto?"; validade êmica pergunta "respeita a perspectiva do interlocutor?".
+A pergunta que você responde: *o interlocutor (ou um membro da comunidade) reconheceria este par como fiel ao que quis dizer e a como entende o mundo? Ou o sentido foi alterado / uma interpretação de fora foi atribuída a ele?*
+
+Isto **não** é fidelidade textual. Um par pode citar fielmente o que foi dito e ainda assim distorcer o sentido ao reenquadrá-lo. Fidelidade pergunta "está no texto?"; validade êmica pergunta "respeita a perspectiva do interlocutor?".
 
 **Aviso sobre o seu próprio viés**
 
-Modelos de linguagem como você tendem a traduzir queixas situadas e concretas em **vocabulário acadêmico-institucional** (ex.: transformar "eles te prejudicam" em "negligência sistêmica dos órgãos"). Essa é exatamente a falha que você deve **detectar** no par avaliado, e que **não** deve cometer na sua justificativa. Avalie a perspectiva do interlocutor, não a sua reformulação dela.
+Modelos de linguagem como você tendem a **elevar queixas e descrições situadas a diagnósticos analítico-institucionais** (ex.: transformar "eles te prejudicam" em "negligência sistêmica dos órgãos"). Isso não é generalizar: é **adicionar uma afirmação** que o interlocutor não fez. Essa é exatamente a falha que você deve **detectar** no par, e que **não** deve cometer na sua justificativa.
 
-**Marcadores de violação êmica** (o que derruba a nota):
+**Marcadores de violação** (em ordem de gravidade):
 
-1. **Reenquadramento acadêmico-institucional**: vocabulário de ciências sociais apresentado como se fosse da comunidade ("negligência sistêmica", "lacuna institucional", "governança", "equidade"). Este é o risco dominante.
-2. **Categorias técnicas/científicas de fora** ("a água subiu rápido" virar "taxa de elevação do nível hidrométrico").
-3. **Explicações causais ou funcionais externas** atribuídas ao interlocutor que ele não fez.
-4. **Estereótipo ou romantização** ("sabedoria ancestral", "harmonia com a natureza") no lugar do conhecimento situado e específico.
-5. **Senso comum do modelo** preenchendo lacunas que o interlocutor não preencheu.
+*Violações fortes (derrubam a nota para 1-2):*
+
+1. **Distorção de sentido**: a reformulação muda o que está sendo dito.
+2. **Claim/diagnóstico externo adicionado**: atribui ao interlocutor uma afirmação ou interpretação que ele não fez (ex.: "te prejudicam" → "negligência sistêmica", elevando uma queixa pessoal a um diagnóstico estrutural).
+3. **Estereótipo ou romantização** ("sabedoria ancestral", "harmonia com a natureza") no lugar do conhecimento situado e específico.
+4. **Senso comum do modelo** preenchendo lacunas que o interlocutor não preencheu.
+
+*Violação leve (derruba de 5 para 3-4):*
+
+5. **Troca de categoria/registro situado por técnico-externo**, ainda que o sentido se preserve (ex.: "a água subiu rápido" → "taxa de elevação do nível hidrométrico"). A categoria nativa carrega sentido; substituí-la por um registro que a comunidade não usaria é uma perda êmica leve.
+
+*Não é violação:* generalização/abstração que **preserva o sentido** e fica em registros reconhecíveis (ex.: abstrair objetos específicos em "objetos domésticos adquiridos por doação e por crédito").
 
 **Escala (1 a 5):**
 
-- **5**: Plenamente êmico. Categorias, termos e sentido são os do interlocutor; ele reconheceria o par sem ressalvas.
-- **4**: Predominantemente êmico. Leve deslize de enquadramento, sem distorcer o sentido.
-- **3**: Misto. Parte na perspectiva do interlocutor, parte em moldura externa; sentido parcialmente deslocado.
-- **2**: Predominantemente ético. Impõe categoria ou explicação de fora; o interlocutor hesitaria em reconhecer como sua.
-- **1**: Distorção. Estereótipo, romantização ou senso comum substituem a perspectiva do interlocutor.
+- **5**: Plenamente êmico. Preserva sentido e perspectiva; generalização, se houver, fica nos registros do interlocutor. Nenhum marcador.
+- **4**: Predominantemente êmico. Leve troca de registro/categoria, sem distorcer o sentido (marcador 5 brando).
+- **3**: Misto. Troca de registro relevante ou início de moldura externa; sentido parcialmente deslocado.
+- **2**: Predominantemente ético. Adiciona claim/diagnóstico externo ou impõe moldura analítica; o interlocutor hesitaria em reconhecer como sua.
+- **1**: Distorção. Muda o sentido, ou estereótipo/senso comum substitui a perspectiva.
 
 **Exemplos** (provisórios; pendentes de validação por especialista):
 
-*Nota 5 (êmico).*
-- Pergunta: "Compare a aquisição do açucareiro (presente) com a aquisição do fogão (comprado com empréstimo) por Dona Gilda."
-- Resposta: "O açucareiro foi dado como presente, enquanto o fogão foi comprado com dinheiro emprestado por Maikinho, obtido por meio de Jô, devido ao custo elevado e falta de recursos."
-- Por quê: mantém pessoas nomeadas (Maikinho, Jô), objetos concretos e a lógica da própria interlocutora. Sem moldura externa. Nenhum marcador disparou.
+*Nota 5 (generalização que preserva o sentido).*
+- Pergunta: "Como Dona Gilda adquiriu seus objetos domésticos?"
+- Resposta: "Dona Gilda adquiriu objetos domésticos por vias distintas: alguns recebidos como presente, outros comprados com dinheiro emprestado, conforme o custo e os recursos disponíveis."
+- Por quê: abstrai os objetos específicos (açucareiro, fogão) numa generalização que **preserva o sentido** e a lógica da interlocutora (doação vs crédito). Generalizar aqui é bom. Nenhum marcador.
 
-*Nota 2 (deriva ética).*
+*Nota 4 (troca leve de registro).*
+- Segmento: "quando a água começa a subir rápido a gente já sabe que tem que tirar o barco."
+- Resposta: "Uma subida acelerada do nível do rio sinaliza a necessidade de retirar a embarcação."
+- Por quê: o sentido se mantém, mas "embarcação"/"subida acelerada do nível do rio" troca o registro situado ("barco", "a água subiu rápido") por um mais formal. Marcador 5 brando.
+
+*Nota 2 (claim externo adicionado).*
 - Segmento: "o pescador vive oprimido pelo IBAMA, pela PATRAM (...) em vez de te proteger e te ajudar, eles te prejudicam."
 - Resposta: "A falta de apoio à família reflete a negligência sistêmica dos órgãos ambientais, criando desconfiança e abandonando casos sociais."
-- Por quê: conteúdo fiel, mas o sentido foi traduzido para vocabulário analítico-institucional ("negligência sistêmica", "casos sociais") que não é o do pescador ("te prejudicam"). Marcador 1 (reenquadramento acadêmico-institucional).
+- Por quê: não é apenas vocabulário diferente; **eleva uma queixa pessoal ("te prejudicam") a um diagnóstico estrutural ("negligência sistêmica", "casos sociais")** que o interlocutor não afirmou. Marcador 2 (claim externo adicionado).
 
 ---
 
@@ -55,6 +69,6 @@ $context
 
 **Instruções de saída:**
 
-Atribua uma nota inteira de 1 a 5 e uma justificativa curta (no máximo 3 frases). Se a nota for menor ou igual a 3, **nomeie o(s) marcador(es)** que dispararam; se for 4 ou 5, explique por que nenhum marcador disparou.
+Atribua uma nota inteira de 1 a 5 e uma justificativa curta (no máximo 3 frases). Se a nota for menor ou igual a 3, **nomeie o(s) marcador(es)** que dispararam; se for 4 ou 5, explique por que o sentido e a perspectiva foram preservados (e, se houve generalização, por que ela é aceitável).
 
 Responda em JSON: `{"score": <inteiro 1-5>, "rationale": "<justificativa>"}`.

--- a/prompts/judge/criteria/emic_validity/pt/prompt.md
+++ b/prompts/judge/criteria/emic_validity/pt/prompt.md
@@ -1,0 +1,60 @@
+Você avalia da posição de um **antropólogo treinado em trabalho de campo etnográfico**, não da posição de um modelo de linguagem de propósito geral. O domínio são comunidades ribeirinhas do sul do Brasil afetadas por eventos climáticos críticos.
+
+Sua tarefa é atribuir a **VALIDADE ÊMICA** de um par pergunta-resposta gerado a partir de uma entrevista.
+
+**O construto: validade êmica**
+
+Um par tem validade êmica quando representa o conhecimento nas **categorias, termos e visão de mundo do próprio interlocutor** (perspectiva *êmica*), sem impor enquadramento externo do analista (*ético*), estereótipo, romantização ou senso comum.
+
+A pergunta que você responde: *dado o segmento de origem, o próprio interlocutor (ou um membro da comunidade) reconheceria este par como fiel ao que quis dizer e a como ele entende o mundo? Ou o sentido foi deslocado para uma moldura de fora?*
+
+Isto **não** é fidelidade textual. Um par pode citar fielmente o que foi dito e ainda assim ser eticamente distorcido ao reenquadrar o sentido. Fidelidade pergunta "está no texto?"; validade êmica pergunta "respeita a perspectiva do interlocutor?".
+
+**Aviso sobre o seu próprio viés**
+
+Modelos de linguagem como você tendem a traduzir queixas situadas e concretas em **vocabulário acadêmico-institucional** (ex.: transformar "eles te prejudicam" em "negligência sistêmica dos órgãos"). Essa é exatamente a falha que você deve **detectar** no par avaliado, e que **não** deve cometer na sua justificativa. Avalie a perspectiva do interlocutor, não a sua reformulação dela.
+
+**Marcadores de violação êmica** (o que derruba a nota):
+
+1. **Reenquadramento acadêmico-institucional**: vocabulário de ciências sociais apresentado como se fosse da comunidade ("negligência sistêmica", "lacuna institucional", "governança", "equidade"). Este é o risco dominante.
+2. **Categorias técnicas/científicas de fora** ("a água subiu rápido" virar "taxa de elevação do nível hidrométrico").
+3. **Explicações causais ou funcionais externas** atribuídas ao interlocutor que ele não fez.
+4. **Estereótipo ou romantização** ("sabedoria ancestral", "harmonia com a natureza") no lugar do conhecimento situado e específico.
+5. **Senso comum do modelo** preenchendo lacunas que o interlocutor não preencheu.
+
+**Escala (1 a 5):**
+
+- **5**: Plenamente êmico. Categorias, termos e sentido são os do interlocutor; ele reconheceria o par sem ressalvas.
+- **4**: Predominantemente êmico. Leve deslize de enquadramento, sem distorcer o sentido.
+- **3**: Misto. Parte na perspectiva do interlocutor, parte em moldura externa; sentido parcialmente deslocado.
+- **2**: Predominantemente ético. Impõe categoria ou explicação de fora; o interlocutor hesitaria em reconhecer como sua.
+- **1**: Distorção. Estereótipo, romantização ou senso comum substituem a perspectiva do interlocutor.
+
+**Exemplos** (provisórios; pendentes de validação por especialista):
+
+*Nota 5 (êmico).*
+- Pergunta: "Compare a aquisição do açucareiro (presente) com a aquisição do fogão (comprado com empréstimo) por Dona Gilda."
+- Resposta: "O açucareiro foi dado como presente, enquanto o fogão foi comprado com dinheiro emprestado por Maikinho, obtido por meio de Jô, devido ao custo elevado e falta de recursos."
+- Por quê: mantém pessoas nomeadas (Maikinho, Jô), objetos concretos e a lógica da própria interlocutora. Sem moldura externa. Nenhum marcador disparou.
+
+*Nota 2 (deriva ética).*
+- Segmento: "o pescador vive oprimido pelo IBAMA, pela PATRAM (...) em vez de te proteger e te ajudar, eles te prejudicam."
+- Resposta: "A falta de apoio à família reflete a negligência sistêmica dos órgãos ambientais, criando desconfiança e abandonando casos sociais."
+- Por quê: conteúdo fiel, mas o sentido foi traduzido para vocabulário analítico-institucional ("negligência sistêmica", "casos sociais") que não é o do pescador ("te prejudicam"). Marcador 1 (reenquadramento acadêmico-institucional).
+
+---
+
+Avalie o par abaixo. Você vê **apenas** o segmento de origem, a pergunta e a resposta.
+
+**Segmento de origem:**
+$context
+
+**Par:**
+- Pergunta: $question
+- Resposta: $answer
+
+**Instruções de saída:**
+
+Atribua uma nota inteira de 1 a 5 e uma justificativa curta (no máximo 3 frases). Se a nota for menor ou igual a 3, **nomeie o(s) marcador(es)** que dispararam; se for 4 ou 5, explique por que nenhum marcador disparou.
+
+Responda em JSON: `{"score": <inteiro 1-5>, "rationale": "<justificativa>"}`.

--- a/tests/shared/judge/test_emic_validity_prompt.py
+++ b/tests/shared/judge/test_emic_validity_prompt.py
@@ -84,8 +84,19 @@ class TestEmicPromptContent:
         assert "êmic" in low and "étic" in low  # names the distinction verbatim
 
     def test_warns_of_model_own_reframing_bias(self, emic_prompt: str) -> None:
-        # Principle 2: meta-awareness of the model's own institutional reframing.
-        assert "reenquadramento" in emic_prompt.lower()
+        # Principle 2: meta-awareness of the model's own tendency to elevate
+        # situated speech into institutional/analytical diagnoses.
+        low = emic_prompt.lower()
+        assert "negligência sistêmica" in low  # the canonical bias example
+        assert "institucion" in low or "diagnóstico" in low
+
+    def test_generalization_is_acceptable(self, emic_prompt: str) -> None:
+        # Refined construct: meaning-preserving generalization is desirable,
+        # not a deviation; only meaning-change / added claims / register-swap
+        # lower the score.
+        low = emic_prompt.lower()
+        assert "generaliz" in low
+        assert "não é violação" in low or "desejável" in low
 
     def test_has_five_point_anchors(self, emic_prompt: str) -> None:
         # Anchors 1..5 must all appear so the model maps to the same scale.

--- a/tests/shared/judge/test_emic_validity_prompt.py
+++ b/tests/shared/judge/test_emic_validity_prompt.py
@@ -1,0 +1,107 @@
+"""Wiring tests for the emic_validity ordinal criterion prompt + config.
+
+The emic-validity criterion is the first consumer of the ordinal judge type.
+It needs no bespoke class: it is an ``OrdinalLLMCriterion`` loaded from the
+``emic_validity`` prompt/config under ``prompts/judge/criteria/``. These tests
+assert the on-disk prompt/config are well-formed, wire up through the generic
+loader, and honor the spec's "modo antropólogo" requirements (§3, §4.2).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from arandu.shared.judge.criterion import OrdinalCriterionResponse, OrdinalLLMCriterion
+from arandu.shared.judge.schemas import CriterionScore
+from arandu.utils.paths import get_project_root
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+CRITERIA_DIR = get_project_root() / "prompts" / "judge" / "criteria"
+EMIC = "emic_validity"
+
+
+@pytest.fixture
+def mock_llm_client(mocker: MockerFixture) -> Any:
+    client = mocker.MagicMock()
+    client.provider.value = "ollama"
+    client.model_id = "test-model"
+    return client
+
+
+@pytest.fixture
+def emic_prompt() -> str:
+    return (CRITERIA_DIR / EMIC / "pt" / "prompt.md").read_text(encoding="utf-8")
+
+
+class TestEmicValidityWiring:
+    def test_loads_as_ordinal_criterion(self, mock_llm_client: Any) -> None:
+        criterion = OrdinalLLMCriterion.from_config(
+            name=EMIC,
+            prompts_dir=CRITERIA_DIR,
+            language="pt",
+            llm_client=mock_llm_client,
+        )
+        assert criterion.scale == "ordinal"
+        assert criterion.name == EMIC
+
+    def test_low_temperature(self, mock_llm_client: Any) -> None:
+        # The judgment is structural, not creative (spec §4.2 principle 8).
+        criterion = OrdinalLLMCriterion.from_config(
+            name=EMIC, prompts_dir=CRITERIA_DIR, language="pt", llm_client=mock_llm_client
+        )
+        assert criterion.temperature <= 0.2
+
+    def test_evaluate_produces_ordinal_score(self, mock_llm_client: Any) -> None:
+        mock_llm_client.generate_structured.return_value = OrdinalCriterionResponse(
+            score=2, rationale="reenquadramento acadêmico"
+        )
+        criterion = OrdinalLLMCriterion.from_config(
+            name=EMIC, prompts_dir=CRITERIA_DIR, language="pt", llm_client=mock_llm_client
+        )
+        result = criterion.evaluate(
+            context="o pescador disse que eles te prejudicam",
+            question="Como o pescador descreve a atuação dos órgãos?",
+            answer="Há negligência sistêmica dos órgãos ambientais.",
+        )
+        assert isinstance(result, CriterionScore)
+        assert result.scale == "ordinal"
+        assert result.ordinal_score == 2
+        assert mock_llm_client.generate_structured.call_args.kwargs["response_model"] is (
+            OrdinalCriterionResponse
+        )
+
+
+class TestEmicPromptContent:
+    """The prompt must encode the spec's construct, markers, anchors, blinding."""
+
+    def test_names_construct_and_emic_etic(self, emic_prompt: str) -> None:
+        low = emic_prompt.lower()
+        assert "validade êmica" in low
+        assert "êmic" in low and "étic" in low  # names the distinction verbatim
+
+    def test_warns_of_model_own_reframing_bias(self, emic_prompt: str) -> None:
+        # Principle 2: meta-awareness of the model's own institutional reframing.
+        assert "reenquadramento" in emic_prompt.lower()
+
+    def test_has_five_point_anchors(self, emic_prompt: str) -> None:
+        # Anchors 1..5 must all appear so the model maps to the same scale.
+        for level in ("1", "2", "3", "4", "5"):
+            assert level in emic_prompt
+
+    def test_only_blinded_inputs_referenced(self, emic_prompt: str) -> None:
+        # Parity/blinding (§4.2 principle 7): sees only segment + Q + A.
+        assert "$context" in emic_prompt
+        assert "$question" in emic_prompt
+        assert "$answer" in emic_prompt
+        low = emic_prompt.lower()
+        assert "bloom" not in low
+        assert "tacit_inference" not in low and "inferência tácita" not in low
+
+    def test_requests_structured_integer_output(self, emic_prompt: str) -> None:
+        low = emic_prompt.lower()
+        assert "json" in low
+        assert "rationale" in low or "justificativa" in low

--- a/tests/shared/judge/test_emic_validity_prompt.py
+++ b/tests/shared/judge/test_emic_validity_prompt.py
@@ -99,9 +99,11 @@ class TestEmicPromptContent:
         assert "não é violação" in low or "desejável" in low
 
     def test_has_five_point_anchors(self, emic_prompt: str) -> None:
-        # Anchors 1..5 must all appear so the model maps to the same scale.
+        # Assert the actual anchor format (- **N**:), not bare digits which
+        # appear elsewhere ("3 frases", "1-5", "§3.5") and would pass even if
+        # the anchor list were removed.
         for level in ("1", "2", "3", "4", "5"):
-            assert level in emic_prompt
+            assert f"- **{level}**:" in emic_prompt
 
     def test_only_blinded_inputs_referenced(self, emic_prompt: str) -> None:
         # Parity/blinding (§4.2 principle 7): sees only segment + Q + A.


### PR DESCRIPTION
## What

The `emic_validity` criterion — first consumer of the ordinal judge type (#117). No bespoke class: it's an `OrdinalLLMCriterion` loaded from a prompt/config under `prompts/judge/criteria/`, so this PR is data + a wiring test.

- **`config.json`** — `temperature: 0.1` (structural judgment, not creative).
- **`pt/prompt.md`** — "modo antropólogo" prompt honoring the spec's 8 principles (§4.2): names the **emic/etic** distinction and **validade êmica** verbatim; warns the model of its **own** institutional-reframing bias (the failure to *detect*, not commit); the 5 violation markers (§3.3); the **1–5 anchors** (§3.4); few-shots from §3.5; **sees only segment + question + answer** (blinded to `bloom_level` / `tacit_inference` / canonical scores); JSON `{score:int 1-5, rationale}` output. PT only.

## Provisional

The few-shots use the §3.5 readings, which are **pending anthropological validation** (Fred). Flagged in-prompt; they get swapped when that validation lands (task `anthropologist-validation-of-readings`).

## Design note

A dedicated `EmicValidityCriterion` class (as the spec sketched) would be empty given the generic `OrdinalLLMCriterion` — omitted per YAGNI/DRY. The criterion is built via `OrdinalLLMCriterion.from_config(name="emic_validity", ...)` or `LLMCriterion(scale="ordinal")`. Wiring it through `LLMCriterionFactory` (so it's reachable by name in a pipeline) is the deferred `emic-prepass-cli` task — see its carry-over notes.

## Tests

Wiring (loads as ordinal, temp ≤ 0.2, evaluate yields an ordinal score, correct response model) + prompt-content guards (construct + emic/etic named, reframing warning present, all 1–5 anchors, only blinded inputs referenced, structured output requested). Full suite **1485 passed, 1 skipped**, ruff clean.