### PR TITLE
fix(slurm): aggressive docker prune in transcription job (match kg step)

### DIFF
--- a/scripts/slurm/transcription/job_common.sh
+++ b/scripts/slurm/transcription/job_common.sh
@@ -163,10 +163,14 @@ fi
 # Build Docker image (if needed)
 # -----------------------------------------------------------------------------
 echo ""
-echo "Pruning Docker build cache, unused images, and volumes to free disk space..."
+echo "Pruning all unused Docker data (images, containers, volumes, build cache) to free disk space..."
+# Match the kg/ step's aggressive reclaim: `system prune -af --volumes`
+# also removes STOPPED CONTAINERS (whose writable layers can fill the
+# node's docker storage), which the previous builder/image/volume trio
+# left behind -> caused job 793351's "No space left on device" at the
+# apt-get ffmpeg build step.
+docker system prune -af --volumes 2>/dev/null || true
 docker builder prune -af 2>/dev/null || true
-docker image prune -af 2>/dev/null || true
-docker volume prune -f 2>/dev/null || true
 
 echo ""
 echo "Building Docker image..."


### PR DESCRIPTION
## Summary

The transcription SLURM job's pre-build cleanup (`scripts/slurm/transcription/job_common.sh`) pruned only build cache, unused images, and volumes — it **left stopped containers behind**, whose writable layers fill the compute node's docker storage.

On a node with accumulated stopped containers this caused `docker compose build` to die at the `apt-get install ffmpeg` step with **`No space left on device`** (dry-run transcription job 793351), even though `/home` had 39 TB free — because docker storage is node-local, not on `/home`.

## Fix

Replace the `builder` / `image` / `volume` prune trio with the same reclaim the **kg** step already uses (`scripts/slurm/kg/kg_common.sh`):

```sh
docker system prune -af --volumes   # also removes stopped containers
docker builder prune -af
```

`docker system prune -af` removes stopped containers + unused images/networks, which the previous trio missed.

## Test plan

- [x] Deployed to PCAD (rsync + md5 verify) and resubmitted the dry-run transcription (job 793352, tupi, 8 cores) with the fix live.
- [ ] Confirm 793352 clears the docker build step (no "No space left on device").