### PR TITLE
feat(agreement): inter-rater coefficients for emic-validity study (spec §6)

### DIFF
--- a/src/arandu/shared/agreement/__init__.py
+++ b/src/arandu/shared/agreement/__init__.py
@@ -1,0 +1,17 @@
+"""Inter-rater agreement coefficients for the emic-validity study (spec §6)."""
+
+from arandu.shared.agreement.coefficients import (
+    AgreementResult,
+    cohen_kappa_weighted,
+    gwet_ac2,
+    krippendorff_alpha,
+)
+from arandu.shared.agreement.variability import high_variability_items
+
+__all__ = [
+    "AgreementResult",
+    "cohen_kappa_weighted",
+    "gwet_ac2",
+    "high_variability_items",
+    "krippendorff_alpha",
+]

--- a/src/arandu/shared/agreement/__init__.py
+++ b/src/arandu/shared/agreement/__init__.py
@@ -6,12 +6,16 @@ from arandu.shared.agreement.coefficients import (
     gwet_ac2,
     krippendorff_alpha,
 )
-from arandu.shared.agreement.variability import high_variability_items
+from arandu.shared.agreement.variability import (
+    high_variability_items,
+    high_variability_rate,
+)
 
 __all__ = [
     "AgreementResult",
     "cohen_kappa_weighted",
     "gwet_ac2",
     "high_variability_items",
+    "high_variability_rate",
     "krippendorff_alpha",
 ]

--- a/src/arandu/shared/agreement/coefficients.py
+++ b/src/arandu/shared/agreement/coefficients.py
@@ -16,17 +16,26 @@ each item a sequence of per-rater labels (integers on the ordinal scale, or
 ``None`` for a missing rating). Pairwise functions take two equal-length label
 sequences instead.
 
-Each function returns an :class:`AgreementResult` carrying the point estimate
-and an optional bootstrap 95% CI (resampling items with replacement; pass
-``n_bootstrap > 0`` and a ``seed``).
+**Fixed scale.** The category set is fixed by the protocol's ordinal scale
+(``scale=(1, 5)`` by default), not inferred from the observed labels. This keeps
+weighted distances constant across strata (the per-Bloom breakdown in §6) and
+across bootstrap resamples, so per-level coefficients are comparable. Labels
+outside the scale raise ``ValueError``.
+
+Each function returns an :class:`AgreementResult`; its ``coefficient`` is
+``None`` when the statistic is undefined (no usable data, or no expected
+disagreement) rather than a misleading ``0.0``. Pass ``n_bootstrap > 0`` and a
+``seed`` for a percentile 95% CI.
 """
 
 from __future__ import annotations
 
-import random
 from collections import Counter
-from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal
+
+from pydantic import BaseModel
+
+from arandu.shared.stats import bootstrap_ci
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
@@ -34,76 +43,61 @@ if TYPE_CHECKING:
 Weights = Literal["quadratic", "linear"]
 AlphaLevel = Literal["nominal", "ordinal", "interval"]
 
-_CI_LOW_PCTL = 2.5
-_CI_HIGH_PCTL = 97.5
+DEFAULT_SCALE: tuple[int, int] = (1, 5)
 
 
-@dataclass(frozen=True)
-class AgreementResult:
+class AgreementResult(BaseModel):
     """A coefficient estimate with an optional bootstrap CI.
 
     Attributes:
-        coefficient: The point estimate.
-        ci_low: Lower 95% bootstrap bound, or ``None`` if not requested.
-        ci_high: Upper 95% bootstrap bound, or ``None`` if not requested.
+        coefficient: Point estimate, or ``None`` when undefined (no usable
+            items, or no expected disagreement to correct for).
+        ci_lower: Lower 95% bootstrap bound, or ``None``.
+        ci_upper: Upper 95% bootstrap bound, or ``None``.
         n_items: Number of items (units) the estimate is based on.
+        scale: The fixed ``(min, max)`` ordinal scale used (provenance, so
+            callers can confirm two strata were scored comparably).
     """
 
-    coefficient: float
-    ci_low: float | None
-    ci_high: float | None
+    coefficient: float | None
+    ci_lower: float | None
+    ci_upper: float | None
     n_items: int
+    scale: tuple[int, int]
 
 
-def _percentile(sorted_values: list[float], pct: float) -> float:
-    """Linear-interpolated percentile of an already-sorted list."""
-    if not sorted_values:
-        raise ValueError("percentile of empty sequence")
-    if len(sorted_values) == 1:
-        return sorted_values[0]
-    rank = (pct / 100.0) * (len(sorted_values) - 1)
-    low = int(rank)
-    high = min(low + 1, len(sorted_values) - 1)
-    frac = rank - low
-    return sorted_values[low] * (1 - frac) + sorted_values[high] * frac
+def _scale_categories(scale: tuple[int, int]) -> list[int]:
+    """The full fixed category list for a ``(min, max)`` scale."""
+    lo, hi = scale
+    if hi < lo:
+        raise ValueError(f"scale max ({hi}) must be >= scale min ({lo})")
+    return list(range(lo, hi + 1))
 
 
-def _bootstrap_ci(
-    items: Sequence[object],
-    estimator: Callable[[Sequence[object]], float | None],
-    n_bootstrap: int,
-    seed: int,
-) -> tuple[float | None, float | None]:
-    """Bootstrap a 95% CI by resampling ``items`` with replacement.
+def _validate_labels(labels: Sequence[int | None], scale: tuple[int, int]) -> None:
+    """Reject labels outside the fixed scale or not whole numbers."""
+    lo, hi = scale
+    for v in labels:
+        if v is None:
+            continue
+        if int(v) != v:
+            raise ValueError(f"label {v!r} is not an integer on the {scale} scale")
+        if v < lo or v > hi:
+            raise ValueError(f"label {v!r} is outside the scale {scale}")
 
-    Args:
-        items: The per-item units to resample.
-        estimator: Maps a resample to a coefficient, or ``None`` if the
-            resample is degenerate (skipped).
-        n_bootstrap: Number of resamples.
-        seed: RNG seed for reproducibility.
 
-    Returns:
-        ``(low, high)`` percentile bounds, or ``(None, None)`` if no resample
-        yielded a finite coefficient.
+def _count_usable_units(units: Sequence[Sequence[int | None]]) -> int:
+    """Number of items with at least two present (non-None) ratings."""
+    return sum(1 for u in units if sum(1 for r in u if r is not None) >= 2)
+
+
+def _normalized_disagreement(a: int, b: int, span: int, weights: Weights) -> float:
+    """Disagreement in ``[0, 1]`` between two labels on a fixed-span scale.
+
+    Quadratic (default) or linear, normalized by the fixed scale span so the
+    metric does not depend on which categories happen to be observed. Distinct
+    from the alpha ordinal metric (the ``delta_sq`` defined in ``_alpha_point``).
     """
-    rng = random.Random(seed)
-    n = len(items)
-    estimates: list[float] = []
-    for _ in range(n_bootstrap):
-        sample = [items[rng.randrange(n)] for _ in range(n)]
-        value = estimator(sample)
-        if value is not None:
-            estimates.append(value)
-    if not estimates:
-        return None, None
-    estimates.sort()
-    return _percentile(estimates, _CI_LOW_PCTL), _percentile(estimates, _CI_HIGH_PCTL)
-
-
-def _distance_sq(a: float, b: float, categories: list[int], weights: Weights) -> float:
-    """Squared (quadratic) or absolute (linear) distance between two labels."""
-    span = categories[-1] - categories[0]
     if span == 0:
         return 0.0
     if weights == "linear":
@@ -111,34 +105,59 @@ def _distance_sq(a: float, b: float, categories: list[int], weights: Weights) ->
     return ((a - b) / span) ** 2
 
 
+def _finalize[T](
+    items: Sequence[T],
+    point: float | None,
+    estimator: Callable[[Sequence[T]], float | None],
+    n_bootstrap: int,
+    seed: int,
+    n_items: int,
+    scale: tuple[int, int],
+) -> AgreementResult:
+    """Assemble an AgreementResult, running the bootstrap CI if requested."""
+    ci_lower = ci_upper = None
+    if n_bootstrap > 0:
+        ci_lower, ci_upper = bootstrap_ci(items, estimator, n_bootstrap=n_bootstrap, seed=seed)
+    return AgreementResult(
+        coefficient=point,
+        ci_lower=ci_lower,
+        ci_upper=ci_upper,
+        n_items=n_items,
+        scale=scale,
+    )
+
+
 # --------------------------------------------------------------------------- #
 # Cohen's weighted kappa (pairwise)
 # --------------------------------------------------------------------------- #
 
 
-def _cohen_point(pairs: Sequence[tuple[int, int]], weights: Weights) -> float | None:
-    """Weighted Cohen's kappa for a list of (a, b) label pairs."""
+def _cohen_point(
+    pairs: Sequence[tuple[int, int]],
+    categories: list[int],
+    span: int,
+    weights: Weights,
+) -> float | None:
+    """Weighted Cohen's kappa for (a, b) pairs, or None if undefined."""
     if not pairs:
         return None
-    categories = sorted({c for pair in pairs for c in pair})
     n = len(pairs)
 
     def dist(a: int, b: int) -> float:
-        return _distance_sq(a, b, categories, weights)
+        return _normalized_disagreement(a, b, span, weights)
 
     d_o = sum(dist(a, b) for a, b in pairs) / n
 
     count_a = Counter(a for a, _ in pairs)
     count_b = Counter(b for _, b in pairs)
-    d_e = 0.0
-    for ci in categories:
-        for cj in categories:
-            d_e += dist(ci, cj) * (count_a[ci] / n) * (count_b[cj] / n)
+    d_e = sum(
+        dist(ci, cj) * (count_a[ci] / n) * (count_b[cj] / n)
+        for ci in categories
+        for cj in categories
+    )
 
     if d_e == 0:
-        # No expected disagreement (a rater is constant). Perfect observed
-        # agreement -> 1.0; any observed disagreement is undefined -> 0.0.
-        return 1.0 if d_o == 0 else 0.0
+        return None  # no expected disagreement (a rater is constant) -> undefined
     return 1.0 - d_o / d_e
 
 
@@ -147,42 +166,42 @@ def cohen_kappa_weighted(
     rater_b: Sequence[int | None],
     *,
     weights: Weights = "quadratic",
+    scale: tuple[int, int] = DEFAULT_SCALE,
     n_bootstrap: int = 0,
     seed: int = 0,
 ) -> AgreementResult:
-    """Quadratic-weighted Cohen's kappa between two raters.
+    """Weighted Cohen's kappa between two raters on a fixed ordinal scale.
 
     Args:
         rater_a: Labels from rater A (``None`` entries are dropped pairwise).
         rater_b: Labels from rater B; must be the same length as ``rater_a``.
         weights: ``"quadratic"`` (default) or ``"linear"`` disagreement weights.
+        scale: Fixed ``(min, max)`` ordinal scale.
         n_bootstrap: Bootstrap resamples for the CI (0 = no CI).
         seed: RNG seed for the bootstrap.
 
     Returns:
-        AgreementResult with the kappa estimate and optional CI.
+        AgreementResult; ``coefficient`` is ``None`` when undefined.
 
     Raises:
-        ValueError: If the two sequences differ in length.
+        ValueError: If the sequences differ in length, or a label is off-scale.
     """
     if len(rater_a) != len(rater_b):
         raise ValueError("rater_a and rater_b must have the same length")
+    _validate_labels(rater_a, scale)
+    _validate_labels(rater_b, scale)
 
+    categories = _scale_categories(scale)
+    span = scale[1] - scale[0]
     pairs: list[tuple[int, int]] = [
         (a, b) for a, b in zip(rater_a, rater_b, strict=True) if a is not None and b is not None
     ]
 
-    def estimate(sample: Sequence[object]) -> float | None:
-        return _cohen_point(sample, weights)  # type: ignore[arg-type]
+    def estimator(sample: Sequence[tuple[int, int]]) -> float | None:
+        return _cohen_point(sample, categories, span, weights)
 
-    point = _cohen_point(pairs, weights)
-    coefficient = 0.0 if point is None else point
-
-    ci_low = ci_high = None
-    if n_bootstrap > 0 and pairs:
-        ci_low, ci_high = _bootstrap_ci(pairs, estimate, n_bootstrap, seed)
-
-    return AgreementResult(coefficient, ci_low, ci_high, n_items=len(pairs))
+    point = _cohen_point(pairs, categories, span, weights)
+    return _finalize(pairs, point, estimator, n_bootstrap, seed, len(pairs), scale)
 
 
 # --------------------------------------------------------------------------- #
@@ -192,7 +211,6 @@ def cohen_kappa_weighted(
 
 def _coincidence_matrix(
     units: Sequence[Sequence[int | None]],
-    categories: list[int],
 ) -> dict[tuple[int, int], float]:
     """Krippendorff coincidence matrix from units x raters data.
 
@@ -216,31 +234,23 @@ def _coincidence_matrix(
 
 def _alpha_point(
     units: Sequence[Sequence[int | None]],
+    categories: list[int],
     level: AlphaLevel,
 ) -> float | None:
-    """Krippendorff's alpha point estimate for the given metric level."""
-    categories = sorted({r for unit in units for r in unit if r is not None})
-    if len(categories) < 2:
-        # All present ratings identical -> no disagreement possible -> 1.0
-        # (if any coincidences exist), else undefined.
-        o = _coincidence_matrix(units, categories)
-        return 1.0 if o else None
-
-    o = _coincidence_matrix(units, categories)
+    """Krippendorff's alpha point estimate, or None if undefined."""
+    o = _coincidence_matrix(units)
     n_total = sum(o.values())
     if n_total == 0:
-        return None
+        return None  # no pairable units
 
     marginals = {c: sum(o.get((c, k), 0.0) for k in categories) for c in categories}
 
-    # Ordinal metric needs cumulative marginals between the two categories.
     def delta_sq(c: int, k: int) -> float:
         if level == "nominal":
             return 0.0 if c == k else 1.0
         if level == "interval":
             return float((c - k) ** 2)
-        # ordinal (Krippendorff): squared (sum of marginals strictly between
-        # plus half the endpoints).
+        # ordinal (Krippendorff): marginal-based metric.
         lo, hi = (c, k) if c <= k else (k, c)
         between = sum(marginals[g] for g in categories if lo <= g <= hi)
         term = between - (marginals[c] + marginals[k]) / 2.0
@@ -253,7 +263,7 @@ def _alpha_point(
     d_e /= n_total * (n_total - 1)
 
     if d_e == 0:
-        return 1.0 if d_o == 0 else 0.0
+        return None  # no expected disagreement (all present ratings identical)
     return 1.0 - d_o / d_e
 
 
@@ -261,10 +271,11 @@ def krippendorff_alpha(
     reliability_data: Sequence[Sequence[int | None]],
     *,
     level: AlphaLevel = "ordinal",
+    scale: tuple[int, int] = DEFAULT_SCALE,
     n_bootstrap: int = 0,
     seed: int = 0,
 ) -> AgreementResult:
-    """Krippendorff's alpha over items x raters data.
+    """Krippendorff's alpha over items x raters data on a fixed ordinal scale.
 
     Args:
         reliability_data: One row per item; each row is the raters' labels for
@@ -272,25 +283,26 @@ def krippendorff_alpha(
             present ratings contribute nothing.
         level: Distance metric -- ``"ordinal"`` (default; marginal-based),
             ``"interval"`` (squared difference), or ``"nominal"`` (0/1).
+        scale: Fixed ``(min, max)`` ordinal scale.
         n_bootstrap: Bootstrap resamples for the CI (0 = no CI).
         seed: RNG seed for the bootstrap.
 
     Returns:
-        AgreementResult with the alpha estimate and optional CI.
+        AgreementResult; ``coefficient`` is ``None`` when undefined.
+
+    Raises:
+        ValueError: If a label is off-scale.
     """
+    for unit in reliability_data:
+        _validate_labels(unit, scale)
+    categories = _scale_categories(scale)
 
-    def estimate(sample: Sequence[object]) -> float | None:
-        return _alpha_point(sample, level)  # type: ignore[arg-type]
+    def estimator(sample: Sequence[Sequence[int | None]]) -> float | None:
+        return _alpha_point(sample, categories, level)
 
-    point = _alpha_point(reliability_data, level)
-    coefficient = 0.0 if point is None else point
-
-    ci_low = ci_high = None
-    if n_bootstrap > 0 and reliability_data:
-        ci_low, ci_high = _bootstrap_ci(reliability_data, estimate, n_bootstrap, seed)
-
-    n_items = sum(1 for u in reliability_data if sum(1 for r in u if r is not None) >= 2)
-    return AgreementResult(coefficient, ci_low, ci_high, n_items=n_items)
+    point = _alpha_point(reliability_data, categories, level)
+    n_items = _count_usable_units(reliability_data)
+    return _finalize(reliability_data, point, estimator, n_bootstrap, seed, n_items, scale)
 
 
 # --------------------------------------------------------------------------- #
@@ -301,38 +313,36 @@ def krippendorff_alpha(
 def _ac2_point(
     units: Sequence[Sequence[int | None]],
     categories: list[int],
+    span: int,
     weights: Weights,
 ) -> float | None:
-    """Gwet's AC2 point estimate (multi-rater, weighted)."""
-    if len(categories) < 1:
-        return None
-
-    def agree_w(a: int, b: int) -> float:
-        # Agreement weight in [0, 1]; 1 on the diagonal.
-        return 1.0 - _distance_sq(a, b, categories, weights)
-
+    """Gwet's AC2 point estimate (multi-rater, weighted), or None if undefined."""
     usable = [[r for r in unit if r is not None] for unit in units]
     usable = [u for u in usable if len(u) >= 2]
     if not usable:
         return None
 
     k = len(categories)
+    # Precompute the K x K agreement-weight matrix once (1 on the diagonal).
+    agree = {
+        (a, b): 1.0 - _normalized_disagreement(a, b, span, weights)
+        for a in categories
+        for b in categories
+    }
+
     # Observed weighted agreement, averaged over items.
     p_a = 0.0
     for present in usable:
         r_i = len(present)
         counts = Counter(present)
         item_agree = 0.0
-        for cat_k in categories:
-            r_ik = counts.get(cat_k, 0)
-            if r_ik == 0:
-                continue
-            r_star = sum(agree_w(cat_k, cat_l) * counts.get(cat_l, 0) for cat_l in categories)
+        for cat_k, r_ik in counts.items():
+            r_star = sum(agree[(cat_k, cat_l)] * counts.get(cat_l, 0) for cat_l in categories)
             item_agree += r_ik * (r_star - 1.0)
         p_a += item_agree / (r_i * (r_i - 1))
     p_a /= len(usable)
 
-    # Chance agreement (Gwet): pi_k = mean proportion in category k over items.
+    # Chance agreement (Gwet): pi_c = mean proportion in category c over items.
     pi = dict.fromkeys(categories, 0.0)
     for present in usable:
         r_i = len(present)
@@ -343,12 +353,12 @@ def _ac2_point(
         pi[c] /= len(usable)
 
     if k < 2:
-        return 1.0 if p_a == 1.0 else 0.0
-    t_w = sum(agree_w(a, b) for a in categories for b in categories)
+        return 1.0 if p_a >= 1.0 else None
+    t_w = sum(agree.values())
     p_e = (t_w / (k * (k - 1))) * sum(pi[c] * (1.0 - pi[c]) for c in categories)
 
     if p_e >= 1.0:
-        return 1.0 if p_a >= 1.0 else 0.0
+        return 1.0 if p_a >= 1.0 else None
     return (p_a - p_e) / (1.0 - p_e)
 
 
@@ -356,10 +366,11 @@ def gwet_ac2(
     ratings: Sequence[Sequence[int | None]],
     *,
     weights: Weights = "quadratic",
+    scale: tuple[int, int] = DEFAULT_SCALE,
     n_bootstrap: int = 0,
     seed: int = 0,
 ) -> AgreementResult:
-    """Gwet's AC2 over items x raters data (weighted, multi-rater).
+    """Gwet's AC2 over items x raters data on a fixed ordinal scale.
 
     AC2 redefines chance agreement so it does not inflate when one category
     dominates -- the prevalence paradox that depresses kappa/alpha. Use it as a
@@ -369,24 +380,24 @@ def gwet_ac2(
         ratings: One row per item; each row is the raters' labels (``None`` for
             missing). Units with fewer than two present ratings are ignored.
         weights: ``"quadratic"`` (default) or ``"linear"`` agreement weights.
+        scale: Fixed ``(min, max)`` ordinal scale.
         n_bootstrap: Bootstrap resamples for the CI (0 = no CI).
         seed: RNG seed for the bootstrap.
 
     Returns:
-        AgreementResult with the AC2 estimate and optional CI.
+        AgreementResult; ``coefficient`` is ``None`` when undefined.
+
+    Raises:
+        ValueError: If a label is off-scale.
     """
-    categories = sorted({r for unit in ratings for r in unit if r is not None})
+    for unit in ratings:
+        _validate_labels(unit, scale)
+    categories = _scale_categories(scale)
+    span = scale[1] - scale[0]
 
-    def estimate(sample: Sequence[object]) -> float | None:
-        cats = sorted({r for unit in sample for r in unit if r is not None})  # type: ignore[union-attr]
-        return _ac2_point(sample, cats, weights) if cats else None  # type: ignore[arg-type]
+    def estimator(sample: Sequence[Sequence[int | None]]) -> float | None:
+        return _ac2_point(sample, categories, span, weights)
 
-    point = _ac2_point(ratings, categories, weights) if categories else None
-    coefficient = 0.0 if point is None else point
-
-    ci_low = ci_high = None
-    if n_bootstrap > 0 and ratings:
-        ci_low, ci_high = _bootstrap_ci(ratings, estimate, n_bootstrap, seed)
-
-    n_items = sum(1 for u in ratings if sum(1 for r in u if r is not None) >= 2)
-    return AgreementResult(coefficient, ci_low, ci_high, n_items=n_items)
+    point = _ac2_point(ratings, categories, span, weights)
+    n_items = _count_usable_units(ratings)
+    return _finalize(ratings, point, estimator, n_bootstrap, seed, n_items, scale)

--- a/src/arandu/shared/agreement/coefficients.py
+++ b/src/arandu/shared/agreement/coefficients.py
@@ -30,6 +30,7 @@ disagreement) rather than a misleading ``0.0``. Pass ``n_bootstrap > 0`` and a
 
 from __future__ import annotations
 
+import math
 from collections import Counter
 from typing import TYPE_CHECKING, Literal
 
@@ -66,24 +67,39 @@ class AgreementResult(BaseModel):
     scale: tuple[int, int]
 
 
-def _scale_categories(scale: tuple[int, int]) -> list[int]:
-    """The full fixed category list for a ``(min, max)`` scale."""
+def _resolve_scale(scale: tuple[int, int]) -> tuple[list[int], int]:
+    """Validate a ``(min, max)`` scale and return ``(categories, span)``.
+
+    The scale must have at least two points (``max > min``); a single-point
+    scale carries no notion of agreement. Validating here, before label
+    validation, gives a clean error for a reversed/degenerate scale.
+    """
     lo, hi = scale
-    if hi < lo:
-        raise ValueError(f"scale max ({hi}) must be >= scale min ({lo})")
-    return list(range(lo, hi + 1))
+    if hi <= lo:
+        raise ValueError(f"scale must have >= 2 points (max > min); got {scale}")
+    return list(range(lo, hi + 1)), hi - lo
 
 
 def _validate_labels(labels: Sequence[int | None], scale: tuple[int, int]) -> None:
-    """Reject labels outside the fixed scale or not whole numbers."""
+    """Reject labels that are not whole integers on the fixed scale."""
     lo, hi = scale
     for v in labels:
         if v is None:
             continue
-        if int(v) != v:
+        if isinstance(v, bool):
+            raise ValueError(f"label {v!r} is a bool, not an ordinal value")
+        is_int = isinstance(v, int)
+        is_whole_float = isinstance(v, float) and math.isfinite(v) and v.is_integer()
+        if not (is_int or is_whole_float):
             raise ValueError(f"label {v!r} is not an integer on the {scale} scale")
         if v < lo or v > hi:
             raise ValueError(f"label {v!r} is outside the scale {scale}")
+
+
+def _validate_units(units: Sequence[Sequence[int | None]], scale: tuple[int, int]) -> None:
+    """Validate labels across all items of a units x raters matrix."""
+    for unit in units:
+        _validate_labels(unit, scale)
 
 
 def _count_usable_units(units: Sequence[Sequence[int | None]]) -> int:
@@ -107,14 +123,18 @@ def _normalized_disagreement(a: int, b: int, span: int, weights: Weights) -> flo
 
 def _finalize[T](
     items: Sequence[T],
-    point: float | None,
     estimator: Callable[[Sequence[T]], float | None],
     n_bootstrap: int,
     seed: int,
     n_items: int,
     scale: tuple[int, int],
 ) -> AgreementResult:
-    """Assemble an AgreementResult, running the bootstrap CI if requested."""
+    """Assemble an AgreementResult from one estimator over ``items``.
+
+    The point estimate is ``estimator(items)`` -- the same callable the
+    bootstrap resamples, so the two cannot disagree.
+    """
+    point = estimator(items)
     ci_lower = ci_upper = None
     if n_bootstrap > 0:
         ci_lower, ci_upper = bootstrap_ci(items, estimator, n_bootstrap=n_bootstrap, seed=seed)
@@ -188,11 +208,10 @@ def cohen_kappa_weighted(
     """
     if len(rater_a) != len(rater_b):
         raise ValueError("rater_a and rater_b must have the same length")
+    categories, span = _resolve_scale(scale)
     _validate_labels(rater_a, scale)
     _validate_labels(rater_b, scale)
 
-    categories = _scale_categories(scale)
-    span = scale[1] - scale[0]
     pairs: list[tuple[int, int]] = [
         (a, b) for a, b in zip(rater_a, rater_b, strict=True) if a is not None and b is not None
     ]
@@ -200,8 +219,7 @@ def cohen_kappa_weighted(
     def estimator(sample: Sequence[tuple[int, int]]) -> float | None:
         return _cohen_point(sample, categories, span, weights)
 
-    point = _cohen_point(pairs, categories, span, weights)
-    return _finalize(pairs, point, estimator, n_bootstrap, seed, len(pairs), scale)
+    return _finalize(pairs, estimator, n_bootstrap, seed, len(pairs), scale)
 
 
 # --------------------------------------------------------------------------- #
@@ -293,16 +311,14 @@ def krippendorff_alpha(
     Raises:
         ValueError: If a label is off-scale.
     """
-    for unit in reliability_data:
-        _validate_labels(unit, scale)
-    categories = _scale_categories(scale)
+    categories, _ = _resolve_scale(scale)
+    _validate_units(reliability_data, scale)
 
     def estimator(sample: Sequence[Sequence[int | None]]) -> float | None:
         return _alpha_point(sample, categories, level)
 
-    point = _alpha_point(reliability_data, categories, level)
     n_items = _count_usable_units(reliability_data)
-    return _finalize(reliability_data, point, estimator, n_bootstrap, seed, n_items, scale)
+    return _finalize(reliability_data, estimator, n_bootstrap, seed, n_items, scale)
 
 
 # --------------------------------------------------------------------------- #
@@ -320,6 +336,12 @@ def _ac2_point(
     usable = [[r for r in unit if r is not None] for unit in units]
     usable = [u for u in usable if len(u) >= 2]
     if not usable:
+        return None
+
+    # No variance (every usable rating identical) -> reliability is undefined,
+    # consistent with Cohen/Krippendorff. Without this, AC2 would report a
+    # spurious 1.0 for an all-one-category stratum.
+    if len({r for u in usable for r in u}) < 2:
         return None
 
     k = len(categories)
@@ -352,13 +374,12 @@ def _ac2_point(
     for c in categories:
         pi[c] /= len(usable)
 
-    if k < 2:
-        return 1.0 if p_a >= 1.0 else None
+    # k >= 2 is guaranteed by _resolve_scale (scale has >= 2 points).
     t_w = sum(agree.values())
     p_e = (t_w / (k * (k - 1))) * sum(pi[c] * (1.0 - pi[c]) for c in categories)
 
     if p_e >= 1.0:
-        return 1.0 if p_a >= 1.0 else None
+        return None  # undefined
     return (p_a - p_e) / (1.0 - p_e)
 
 
@@ -390,14 +411,11 @@ def gwet_ac2(
     Raises:
         ValueError: If a label is off-scale.
     """
-    for unit in ratings:
-        _validate_labels(unit, scale)
-    categories = _scale_categories(scale)
-    span = scale[1] - scale[0]
+    categories, span = _resolve_scale(scale)
+    _validate_units(ratings, scale)
 
     def estimator(sample: Sequence[Sequence[int | None]]) -> float | None:
         return _ac2_point(sample, categories, span, weights)
 
-    point = _ac2_point(ratings, categories, span, weights)
     n_items = _count_usable_units(ratings)
-    return _finalize(ratings, point, estimator, n_bootstrap, seed, n_items, scale)
+    return _finalize(ratings, estimator, n_bootstrap, seed, n_items, scale)

--- a/src/arandu/shared/agreement/coefficients.py
+++ b/src/arandu/shared/agreement/coefficients.py
@@ -1,0 +1,392 @@
+"""Inter-rater agreement coefficients for the emic-validity study (spec §6).
+
+Pure-math implementations from first definitions; no ``statsmodels`` / ``scipy``
+/ external reliability package. Three coefficients with complementary roles:
+
+- :func:`krippendorff_alpha` -- multi-rater agreement on an ordinal scale
+  (3 anthropologists + the LLM as a 4th rater). The primary metric.
+- :func:`cohen_kappa_weighted` -- pairwise (LLM vs each annotator) diagnostic
+  with quadratic weights.
+- :func:`gwet_ac2` -- robustness check against the prevalence paradox, where a
+  skewed label distribution depresses kappa/alpha despite high observed
+  agreement.
+
+Data convention (uniform across the three): ratings are a sequence of *items*,
+each item a sequence of per-rater labels (integers on the ordinal scale, or
+``None`` for a missing rating). Pairwise functions take two equal-length label
+sequences instead.
+
+Each function returns an :class:`AgreementResult` carrying the point estimate
+and an optional bootstrap 95% CI (resampling items with replacement; pass
+``n_bootstrap > 0`` and a ``seed``).
+"""
+
+from __future__ import annotations
+
+import random
+from collections import Counter
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+
+Weights = Literal["quadratic", "linear"]
+AlphaLevel = Literal["nominal", "ordinal", "interval"]
+
+_CI_LOW_PCTL = 2.5
+_CI_HIGH_PCTL = 97.5
+
+
+@dataclass(frozen=True)
+class AgreementResult:
+    """A coefficient estimate with an optional bootstrap CI.
+
+    Attributes:
+        coefficient: The point estimate.
+        ci_low: Lower 95% bootstrap bound, or ``None`` if not requested.
+        ci_high: Upper 95% bootstrap bound, or ``None`` if not requested.
+        n_items: Number of items (units) the estimate is based on.
+    """
+
+    coefficient: float
+    ci_low: float | None
+    ci_high: float | None
+    n_items: int
+
+
+def _percentile(sorted_values: list[float], pct: float) -> float:
+    """Linear-interpolated percentile of an already-sorted list."""
+    if not sorted_values:
+        raise ValueError("percentile of empty sequence")
+    if len(sorted_values) == 1:
+        return sorted_values[0]
+    rank = (pct / 100.0) * (len(sorted_values) - 1)
+    low = int(rank)
+    high = min(low + 1, len(sorted_values) - 1)
+    frac = rank - low
+    return sorted_values[low] * (1 - frac) + sorted_values[high] * frac
+
+
+def _bootstrap_ci(
+    items: Sequence[object],
+    estimator: Callable[[Sequence[object]], float | None],
+    n_bootstrap: int,
+    seed: int,
+) -> tuple[float | None, float | None]:
+    """Bootstrap a 95% CI by resampling ``items`` with replacement.
+
+    Args:
+        items: The per-item units to resample.
+        estimator: Maps a resample to a coefficient, or ``None`` if the
+            resample is degenerate (skipped).
+        n_bootstrap: Number of resamples.
+        seed: RNG seed for reproducibility.
+
+    Returns:
+        ``(low, high)`` percentile bounds, or ``(None, None)`` if no resample
+        yielded a finite coefficient.
+    """
+    rng = random.Random(seed)
+    n = len(items)
+    estimates: list[float] = []
+    for _ in range(n_bootstrap):
+        sample = [items[rng.randrange(n)] for _ in range(n)]
+        value = estimator(sample)
+        if value is not None:
+            estimates.append(value)
+    if not estimates:
+        return None, None
+    estimates.sort()
+    return _percentile(estimates, _CI_LOW_PCTL), _percentile(estimates, _CI_HIGH_PCTL)
+
+
+def _distance_sq(a: float, b: float, categories: list[int], weights: Weights) -> float:
+    """Squared (quadratic) or absolute (linear) distance between two labels."""
+    span = categories[-1] - categories[0]
+    if span == 0:
+        return 0.0
+    if weights == "linear":
+        return abs(a - b) / span
+    return ((a - b) / span) ** 2
+
+
+# --------------------------------------------------------------------------- #
+# Cohen's weighted kappa (pairwise)
+# --------------------------------------------------------------------------- #
+
+
+def _cohen_point(pairs: Sequence[tuple[int, int]], weights: Weights) -> float | None:
+    """Weighted Cohen's kappa for a list of (a, b) label pairs."""
+    if not pairs:
+        return None
+    categories = sorted({c for pair in pairs for c in pair})
+    n = len(pairs)
+
+    def dist(a: int, b: int) -> float:
+        return _distance_sq(a, b, categories, weights)
+
+    d_o = sum(dist(a, b) for a, b in pairs) / n
+
+    count_a = Counter(a for a, _ in pairs)
+    count_b = Counter(b for _, b in pairs)
+    d_e = 0.0
+    for ci in categories:
+        for cj in categories:
+            d_e += dist(ci, cj) * (count_a[ci] / n) * (count_b[cj] / n)
+
+    if d_e == 0:
+        # No expected disagreement (a rater is constant). Perfect observed
+        # agreement -> 1.0; any observed disagreement is undefined -> 0.0.
+        return 1.0 if d_o == 0 else 0.0
+    return 1.0 - d_o / d_e
+
+
+def cohen_kappa_weighted(
+    rater_a: Sequence[int | None],
+    rater_b: Sequence[int | None],
+    *,
+    weights: Weights = "quadratic",
+    n_bootstrap: int = 0,
+    seed: int = 0,
+) -> AgreementResult:
+    """Quadratic-weighted Cohen's kappa between two raters.
+
+    Args:
+        rater_a: Labels from rater A (``None`` entries are dropped pairwise).
+        rater_b: Labels from rater B; must be the same length as ``rater_a``.
+        weights: ``"quadratic"`` (default) or ``"linear"`` disagreement weights.
+        n_bootstrap: Bootstrap resamples for the CI (0 = no CI).
+        seed: RNG seed for the bootstrap.
+
+    Returns:
+        AgreementResult with the kappa estimate and optional CI.
+
+    Raises:
+        ValueError: If the two sequences differ in length.
+    """
+    if len(rater_a) != len(rater_b):
+        raise ValueError("rater_a and rater_b must have the same length")
+
+    pairs: list[tuple[int, int]] = [
+        (a, b) for a, b in zip(rater_a, rater_b, strict=True) if a is not None and b is not None
+    ]
+
+    def estimate(sample: Sequence[object]) -> float | None:
+        return _cohen_point(sample, weights)  # type: ignore[arg-type]
+
+    point = _cohen_point(pairs, weights)
+    coefficient = 0.0 if point is None else point
+
+    ci_low = ci_high = None
+    if n_bootstrap > 0 and pairs:
+        ci_low, ci_high = _bootstrap_ci(pairs, estimate, n_bootstrap, seed)
+
+    return AgreementResult(coefficient, ci_low, ci_high, n_items=len(pairs))
+
+
+# --------------------------------------------------------------------------- #
+# Krippendorff's alpha (multi-rater)
+# --------------------------------------------------------------------------- #
+
+
+def _coincidence_matrix(
+    units: Sequence[Sequence[int | None]],
+    categories: list[int],
+) -> dict[tuple[int, int], float]:
+    """Krippendorff coincidence matrix from units x raters data.
+
+    Each unit with ``m >= 2`` present ratings contributes ``1/(m-1)`` to every
+    ordered pair of its ratings.
+    """
+    o: dict[tuple[int, int], float] = {}
+    for unit in units:
+        present = [r for r in unit if r is not None]
+        m = len(present)
+        if m < 2:
+            continue
+        for i in range(m):
+            for j in range(m):
+                if i == j:
+                    continue
+                key = (present[i], present[j])
+                o[key] = o.get(key, 0.0) + 1.0 / (m - 1)
+    return o
+
+
+def _alpha_point(
+    units: Sequence[Sequence[int | None]],
+    level: AlphaLevel,
+) -> float | None:
+    """Krippendorff's alpha point estimate for the given metric level."""
+    categories = sorted({r for unit in units for r in unit if r is not None})
+    if len(categories) < 2:
+        # All present ratings identical -> no disagreement possible -> 1.0
+        # (if any coincidences exist), else undefined.
+        o = _coincidence_matrix(units, categories)
+        return 1.0 if o else None
+
+    o = _coincidence_matrix(units, categories)
+    n_total = sum(o.values())
+    if n_total == 0:
+        return None
+
+    marginals = {c: sum(o.get((c, k), 0.0) for k in categories) for c in categories}
+
+    # Ordinal metric needs cumulative marginals between the two categories.
+    def delta_sq(c: int, k: int) -> float:
+        if level == "nominal":
+            return 0.0 if c == k else 1.0
+        if level == "interval":
+            return float((c - k) ** 2)
+        # ordinal (Krippendorff): squared (sum of marginals strictly between
+        # plus half the endpoints).
+        lo, hi = (c, k) if c <= k else (k, c)
+        between = sum(marginals[g] for g in categories if lo <= g <= hi)
+        term = between - (marginals[c] + marginals[k]) / 2.0
+        return term * term
+
+    d_o = sum(o.get((c, k), 0.0) * delta_sq(c, k) for c in categories for k in categories)
+    d_o /= n_total
+
+    d_e = sum(marginals[c] * marginals[k] * delta_sq(c, k) for c in categories for k in categories)
+    d_e /= n_total * (n_total - 1)
+
+    if d_e == 0:
+        return 1.0 if d_o == 0 else 0.0
+    return 1.0 - d_o / d_e
+
+
+def krippendorff_alpha(
+    reliability_data: Sequence[Sequence[int | None]],
+    *,
+    level: AlphaLevel = "ordinal",
+    n_bootstrap: int = 0,
+    seed: int = 0,
+) -> AgreementResult:
+    """Krippendorff's alpha over items x raters data.
+
+    Args:
+        reliability_data: One row per item; each row is the raters' labels for
+            that item (``None`` for a missing rating). Units with fewer than two
+            present ratings contribute nothing.
+        level: Distance metric -- ``"ordinal"`` (default; marginal-based),
+            ``"interval"`` (squared difference), or ``"nominal"`` (0/1).
+        n_bootstrap: Bootstrap resamples for the CI (0 = no CI).
+        seed: RNG seed for the bootstrap.
+
+    Returns:
+        AgreementResult with the alpha estimate and optional CI.
+    """
+
+    def estimate(sample: Sequence[object]) -> float | None:
+        return _alpha_point(sample, level)  # type: ignore[arg-type]
+
+    point = _alpha_point(reliability_data, level)
+    coefficient = 0.0 if point is None else point
+
+    ci_low = ci_high = None
+    if n_bootstrap > 0 and reliability_data:
+        ci_low, ci_high = _bootstrap_ci(reliability_data, estimate, n_bootstrap, seed)
+
+    n_items = sum(1 for u in reliability_data if sum(1 for r in u if r is not None) >= 2)
+    return AgreementResult(coefficient, ci_low, ci_high, n_items=n_items)
+
+
+# --------------------------------------------------------------------------- #
+# Gwet's AC2 (multi-rater, weighted)
+# --------------------------------------------------------------------------- #
+
+
+def _ac2_point(
+    units: Sequence[Sequence[int | None]],
+    categories: list[int],
+    weights: Weights,
+) -> float | None:
+    """Gwet's AC2 point estimate (multi-rater, weighted)."""
+    if len(categories) < 1:
+        return None
+
+    def agree_w(a: int, b: int) -> float:
+        # Agreement weight in [0, 1]; 1 on the diagonal.
+        return 1.0 - _distance_sq(a, b, categories, weights)
+
+    usable = [[r for r in unit if r is not None] for unit in units]
+    usable = [u for u in usable if len(u) >= 2]
+    if not usable:
+        return None
+
+    k = len(categories)
+    # Observed weighted agreement, averaged over items.
+    p_a = 0.0
+    for present in usable:
+        r_i = len(present)
+        counts = Counter(present)
+        item_agree = 0.0
+        for cat_k in categories:
+            r_ik = counts.get(cat_k, 0)
+            if r_ik == 0:
+                continue
+            r_star = sum(agree_w(cat_k, cat_l) * counts.get(cat_l, 0) for cat_l in categories)
+            item_agree += r_ik * (r_star - 1.0)
+        p_a += item_agree / (r_i * (r_i - 1))
+    p_a /= len(usable)
+
+    # Chance agreement (Gwet): pi_k = mean proportion in category k over items.
+    pi = dict.fromkeys(categories, 0.0)
+    for present in usable:
+        r_i = len(present)
+        counts = Counter(present)
+        for c in categories:
+            pi[c] += counts.get(c, 0) / r_i
+    for c in categories:
+        pi[c] /= len(usable)
+
+    if k < 2:
+        return 1.0 if p_a == 1.0 else 0.0
+    t_w = sum(agree_w(a, b) for a in categories for b in categories)
+    p_e = (t_w / (k * (k - 1))) * sum(pi[c] * (1.0 - pi[c]) for c in categories)
+
+    if p_e >= 1.0:
+        return 1.0 if p_a >= 1.0 else 0.0
+    return (p_a - p_e) / (1.0 - p_e)
+
+
+def gwet_ac2(
+    ratings: Sequence[Sequence[int | None]],
+    *,
+    weights: Weights = "quadratic",
+    n_bootstrap: int = 0,
+    seed: int = 0,
+) -> AgreementResult:
+    """Gwet's AC2 over items x raters data (weighted, multi-rater).
+
+    AC2 redefines chance agreement so it does not inflate when one category
+    dominates -- the prevalence paradox that depresses kappa/alpha. Use it as a
+    robustness check alongside the primary alpha.
+
+    Args:
+        ratings: One row per item; each row is the raters' labels (``None`` for
+            missing). Units with fewer than two present ratings are ignored.
+        weights: ``"quadratic"`` (default) or ``"linear"`` agreement weights.
+        n_bootstrap: Bootstrap resamples for the CI (0 = no CI).
+        seed: RNG seed for the bootstrap.
+
+    Returns:
+        AgreementResult with the AC2 estimate and optional CI.
+    """
+    categories = sorted({r for unit in ratings for r in unit if r is not None})
+
+    def estimate(sample: Sequence[object]) -> float | None:
+        cats = sorted({r for unit in sample for r in unit if r is not None})  # type: ignore[union-attr]
+        return _ac2_point(sample, cats, weights) if cats else None  # type: ignore[arg-type]
+
+    point = _ac2_point(ratings, categories, weights) if categories else None
+    coefficient = 0.0 if point is None else point
+
+    ci_low = ci_high = None
+    if n_bootstrap > 0 and ratings:
+        ci_low, ci_high = _bootstrap_ci(ratings, estimate, n_bootstrap, seed)
+
+    n_items = sum(1 for u in ratings if sum(1 for r in u if r is not None) >= 2)
+    return AgreementResult(coefficient, ci_low, ci_high, n_items=n_items)

--- a/src/arandu/shared/agreement/variability.py
+++ b/src/arandu/shared/agreement/variability.py
@@ -32,6 +32,8 @@ def high_variability_items(
     Returns:
         Sorted list of item indices meeting or exceeding the threshold.
     """
+    if min_spread < 1:
+        raise ValueError(f"min_spread must be >= 1, got {min_spread}")
     flagged: list[int] = []
     for idx, item in enumerate(ratings):
         present = [r for r in item if r is not None]

--- a/src/arandu/shared/agreement/variability.py
+++ b/src/arandu/shared/agreement/variability.py
@@ -1,0 +1,42 @@
+"""High-variability item detection for the emic-validity study (spec §6.3).
+
+Items where the human annotators disagree strongly among themselves are
+reported separately as a signal of construct fuzziness, not treated as noise:
+they count against the reliability of the scale before they count against the
+judge.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+
+def high_variability_items(
+    ratings: Sequence[Sequence[int | None]],
+    *,
+    min_spread: int = 2,
+) -> list[int]:
+    """Indices of items whose rating spread is at least ``min_spread``.
+
+    Spread is ``max - min`` over the present ratings of an item. Items with
+    fewer than two present ratings are never flagged (no spread to speak of).
+
+    Args:
+        ratings: One row per item; each row is the raters' labels (``None`` for
+            a missing rating).
+        min_spread: Inclusive threshold on ``max - min`` for flagging.
+
+    Returns:
+        Sorted list of item indices meeting or exceeding the threshold.
+    """
+    flagged: list[int] = []
+    for idx, item in enumerate(ratings):
+        present = [r for r in item if r is not None]
+        if len(present) < 2:
+            continue
+        if max(present) - min(present) >= min_spread:
+            flagged.append(idx)
+    return flagged

--- a/src/arandu/shared/agreement/variability.py
+++ b/src/arandu/shared/agreement/variability.py
@@ -42,3 +42,29 @@ def high_variability_items(
         if max(present) - min(present) >= min_spread:
             flagged.append(idx)
     return flagged
+
+
+def high_variability_rate(
+    ratings: Sequence[Sequence[int | None]],
+    *,
+    min_spread: int = 2,
+) -> float | None:
+    """Fraction of usable items that are high-variability (spec §6.3).
+
+    The denominator is the number of *usable* items (>= 2 present ratings), so
+    the rate is computed over the same items a coefficient would use. Returns
+    ``None`` when there are no usable items (rate undefined), mirroring the
+    coefficient functions.
+
+    Args:
+        ratings: One row per item; each row is the raters' labels.
+        min_spread: Inclusive ``max - min`` threshold (see
+            :func:`high_variability_items`).
+
+    Returns:
+        ``flagged / usable`` in ``[0, 1]``, or ``None`` if no usable items.
+    """
+    usable = sum(1 for item in ratings if sum(1 for r in item if r is not None) >= 2)
+    if usable == 0:
+        return None
+    return len(high_variability_items(ratings, min_spread=min_spread)) / usable

--- a/src/arandu/shared/stats.py
+++ b/src/arandu/shared/stats.py
@@ -8,6 +8,7 @@ implementation instead of forking it.
 
 from __future__ import annotations
 
+import math
 import random
 from typing import TYPE_CHECKING
 
@@ -66,18 +67,19 @@ def bootstrap_ci[T](
         high_pct: Upper percentile (default 97.5).
 
     Returns:
-        ``(low, high)`` bounds, or ``(None, None)`` if no resample produced a
-        finite statistic (or ``items`` is empty).
+        ``(low, high)`` bounds, or ``(None, None)`` if fewer than two items
+        (a bootstrap needs variability to resample) or no resample produced a
+        finite statistic.
     """
-    if not items:
-        return None, None
-    rng = random.Random(seed)
     n = len(items)
+    if n < 2:
+        return None, None  # a 1-item bootstrap has no variability to estimate
+    rng = random.Random(seed)
     estimates: list[float] = []
     for _ in range(n_bootstrap):
         sample = [items[rng.randrange(n)] for _ in range(n)]
         value = estimator(sample)
-        if value is not None:
+        if value is not None and math.isfinite(value):
             estimates.append(value)
     if not estimates:
         return None, None

--- a/src/arandu/shared/stats.py
+++ b/src/arandu/shared/stats.py
@@ -1,0 +1,85 @@
+"""Shared statistical primitives: percentile and item bootstrap.
+
+Pure-math, dependency-free (no numpy/scipy/statsmodels), mirroring the spirit
+of ``shared/rag/analysis/wilson.py``. Promoted out of the agreement module so a
+second consumer (the deferred rag-analysis bootstrap CIs) can reuse one tested
+implementation instead of forking it.
+"""
+
+from __future__ import annotations
+
+import random
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+
+_CI_LOW_PCTL = 2.5
+_CI_HIGH_PCTL = 97.5
+
+
+def percentile(sorted_values: Sequence[float], pct: float) -> float:
+    """Linear-interpolated percentile of an already-sorted sequence.
+
+    Matches numpy's default (linear) interpolation.
+
+    Args:
+        sorted_values: Ascending-sorted values (non-empty).
+        pct: Percentile in ``[0, 100]``.
+
+    Returns:
+        The interpolated percentile value.
+
+    Raises:
+        ValueError: If ``sorted_values`` is empty.
+    """
+    n = len(sorted_values)
+    if n == 0:
+        raise ValueError("percentile of empty sequence")
+    if n == 1:
+        return sorted_values[0]
+    rank = (pct / 100.0) * (n - 1)
+    low = int(rank)
+    high = min(low + 1, n - 1)
+    frac = rank - low
+    return sorted_values[low] * (1 - frac) + sorted_values[high] * frac
+
+
+def bootstrap_ci[T](
+    items: Sequence[T],
+    estimator: Callable[[Sequence[T]], float | None],
+    *,
+    n_bootstrap: int,
+    seed: int,
+    low_pct: float = _CI_LOW_PCTL,
+    high_pct: float = _CI_HIGH_PCTL,
+) -> tuple[float | None, float | None]:
+    """Bootstrap a percentile CI by resampling ``items`` with replacement.
+
+    Args:
+        items: The units to resample (e.g. label pairs, or per-item rows).
+        estimator: Maps a resample to a statistic, or ``None`` if the resample
+            is degenerate (those are skipped, not counted as a value).
+        n_bootstrap: Number of resamples.
+        seed: RNG seed for reproducibility.
+        low_pct: Lower percentile (default 2.5).
+        high_pct: Upper percentile (default 97.5).
+
+    Returns:
+        ``(low, high)`` bounds, or ``(None, None)`` if no resample produced a
+        finite statistic (or ``items`` is empty).
+    """
+    if not items:
+        return None, None
+    rng = random.Random(seed)
+    n = len(items)
+    estimates: list[float] = []
+    for _ in range(n_bootstrap):
+        sample = [items[rng.randrange(n)] for _ in range(n)]
+        value = estimator(sample)
+        if value is not None:
+            estimates.append(value)
+    if not estimates:
+        return None, None
+    estimates.sort()
+    return percentile(estimates, low_pct), percentile(estimates, high_pct)

--- a/tests/shared/agreement/test_coefficients.py
+++ b/tests/shared/agreement/test_coefficients.py
@@ -48,7 +48,8 @@ class TestKrippendorffAlpha:
 
     def test_nominal_hand_computed_zero(self) -> None:
         # units (1,1) and (1,2): coincidences o_11=2, o_12=o_21=1.
-        # n_1=3, n_2=1, n=4. D_o = (1/4)(1+1) = 0.5.
+        # n_1=3, n_2=1, n=4 (unobserved scale categories 3,4,5 carry marginal
+        # 0 and do not affect the nominal metric). D_o = (1/4)(1+1) = 0.5.
         # D_e = (1/(4*3))(3*1 + 1*3) = 0.5. alpha = 1 - 0.5/0.5 = 0.0
         data = [[1, 1], [1, 2]]
         r = krippendorff_alpha(data, level="nominal")
@@ -121,6 +122,12 @@ class TestBootstrapCI:
         r = cohen_kappa_weighted(flat_a, flat_b, n_bootstrap=500, seed=11)
         assert r.ci_upper is not None and r.ci_upper < 1.0
 
+    def test_single_item_has_no_ci(self) -> None:
+        # A 1-item bootstrap cannot estimate variability -> no CI (not a
+        # spurious zero-width interval).
+        r = cohen_kappa_weighted([2], [4], n_bootstrap=200, seed=1)
+        assert r.ci_lower is None and r.ci_upper is None
+
 
 class TestFixedScaleAndValidation:
     def test_scale_recorded_in_result(self) -> None:
@@ -134,6 +141,25 @@ class TestFixedScaleAndValidation:
             krippendorff_alpha([[1, 9]], scale=(1, 5))
         with pytest.raises(ValueError, match="scale"):
             gwet_ac2([[0, 1]], scale=(1, 5))
+
+    def test_bool_label_rejected(self) -> None:
+        with pytest.raises(ValueError, match="bool"):
+            cohen_kappa_weighted([True, 2], [1, 2], scale=(1, 5))
+
+    def test_non_finite_label_raises_value_error(self) -> None:
+        # NaN/inf must surface as ValueError per the documented contract.
+        with pytest.raises(ValueError, match="integer"):
+            krippendorff_alpha([[float("nan"), 2]], scale=(1, 5))
+        with pytest.raises(ValueError, match="integer"):
+            gwet_ac2([[float("inf"), 2]], scale=(1, 5))
+
+    def test_degenerate_scale_rejected_cleanly(self) -> None:
+        # Reversed or single-point scales raise a clear scale error, not a
+        # confusing per-label "outside scale" error.
+        with pytest.raises(ValueError, match="2 points"):
+            cohen_kappa_weighted([1, 2], [1, 2], scale=(5, 1))
+        with pytest.raises(ValueError, match="2 points"):
+            gwet_ac2([[3, 3]], scale=(3, 3))
 
     def test_ac2_value_independent_of_absent_extreme_category(self) -> None:
         # Same disagreement pattern; presence of an extra (5,5) item that only
@@ -162,7 +188,8 @@ class TestUndefinedReturnsNone:
         assert cohen_kappa_weighted([None, None], [None, None]).coefficient is None
 
     def test_no_variance_is_none_not_zero(self) -> None:
-        # Everyone always says "3": no variance -> kappa/alpha undefined.
-        # Returning None (not 0.0) avoids reading as chance-level agreement.
+        # Everyone always says "3": no variance -> undefined for all three
+        # coefficients (returning None, not 0.0 or a spurious 1.0).
         assert cohen_kappa_weighted([3, 3, 3], [3, 3, 3]).coefficient is None
         assert krippendorff_alpha([[3, 3], [3, 3]]).coefficient is None
+        assert gwet_ac2([[3, 3], [3, 3]]).coefficient is None

--- a/tests/shared/agreement/test_coefficients.py
+++ b/tests/shared/agreement/test_coefficients.py
@@ -92,21 +92,77 @@ class TestBootstrapCI:
         flat_a = [row[0] for row in data]
         flat_b = [row[1] for row in data]
         r = cohen_kappa_weighted(flat_a, flat_b, n_bootstrap=500, seed=42)
-        assert r.ci_low is not None and r.ci_high is not None
-        assert r.ci_low <= r.coefficient <= r.ci_high
+        assert r.ci_lower is not None and r.ci_upper is not None
+        assert r.coefficient is not None
+        assert r.ci_lower <= r.coefficient <= r.ci_upper
 
     def test_bootstrap_reproducible_with_seed(self) -> None:
         flat_a = [1, 2, 3, 3, 2, 1, 4, 5, 3, 2]
         flat_b = [1, 2, 3, 2, 2, 1, 4, 4, 3, 1]
         r1 = cohen_kappa_weighted(flat_a, flat_b, n_bootstrap=200, seed=7)
         r2 = cohen_kappa_weighted(flat_a, flat_b, n_bootstrap=200, seed=7)
-        assert r1.ci_low == r2.ci_low
-        assert r1.ci_high == r2.ci_high
+        assert r1.ci_lower == r2.ci_lower
+        assert r1.ci_upper == r2.ci_upper
 
     def test_no_bootstrap_leaves_ci_none(self) -> None:
         r = cohen_kappa_weighted([1, 2, 3], [1, 2, 3])
-        assert r.ci_low is None and r.ci_high is None
+        assert r.ci_lower is None and r.ci_upper is None
 
     def test_coefficient_finite(self) -> None:
         r = krippendorff_alpha([[1, 1], [2, 2]], level="ordinal", n_bootstrap=50, seed=1)
-        assert math.isfinite(r.coefficient)
+        assert r.coefficient is not None and math.isfinite(r.coefficient)
+
+    def test_degenerate_resamples_do_not_pin_ci_high(self) -> None:
+        # Mostly-agreeing data with a tail of disagreement: degenerate resamples
+        # (collapsing to one category) must be skipped, not counted as 1.0,
+        # so the CI is not artificially pinned at the top.
+        flat_a = [3, 3, 3, 3, 3, 4, 2]
+        flat_b = [3, 3, 3, 3, 3, 2, 4]
+        r = cohen_kappa_weighted(flat_a, flat_b, n_bootstrap=500, seed=11)
+        assert r.ci_upper is not None and r.ci_upper < 1.0
+
+
+class TestFixedScaleAndValidation:
+    def test_scale_recorded_in_result(self) -> None:
+        r = krippendorff_alpha([[1, 1], [2, 2]], scale=(1, 5))
+        assert r.scale == (1, 5)
+
+    def test_off_scale_label_rejected(self) -> None:
+        with pytest.raises(ValueError, match="scale"):
+            cohen_kappa_weighted([1, 7], [1, 2], scale=(1, 5))
+        with pytest.raises(ValueError, match="scale"):
+            krippendorff_alpha([[1, 9]], scale=(1, 5))
+        with pytest.raises(ValueError, match="scale"):
+            gwet_ac2([[0, 1]], scale=(1, 5))
+
+    def test_ac2_value_independent_of_absent_extreme_category(self) -> None:
+        # Same disagreement pattern; presence of an extra (5,5) item that only
+        # adds a never-otherwise-used category must not rescale the weights for
+        # the rest. With a fixed scale, the shared items' contribution is stable.
+        base = [[2, 3], [3, 4], [2, 2], [4, 4]]
+        r_narrow = gwet_ac2(base, scale=(1, 5))
+        # Widening observed range by adding 1s and 5s should still use span 4.
+        r_wide = gwet_ac2([*base, [1, 1], [5, 5]], scale=(1, 5))
+        # Not equal (different data), but both computed on span-4 weights:
+        # the narrow one must NOT have used span-2 weights. Check a concrete
+        # invariant: distance(2,3) under fixed scale is (1/4)^2, so a 1-level
+        # miss is mild -> AC2 stays high.
+        assert r_narrow.coefficient is not None and r_narrow.coefficient > 0.5
+        assert r_wide.coefficient is not None
+
+
+class TestUndefinedReturnsNone:
+    def test_empty_input_is_none(self) -> None:
+        assert cohen_kappa_weighted([], []).coefficient is None
+        assert krippendorff_alpha([]).coefficient is None
+        assert gwet_ac2([]).coefficient is None
+
+    def test_all_missing_is_none(self) -> None:
+        assert krippendorff_alpha([[None, None], [None, None]]).coefficient is None
+        assert cohen_kappa_weighted([None, None], [None, None]).coefficient is None
+
+    def test_no_variance_is_none_not_zero(self) -> None:
+        # Everyone always says "3": no variance -> kappa/alpha undefined.
+        # Returning None (not 0.0) avoids reading as chance-level agreement.
+        assert cohen_kappa_weighted([3, 3, 3], [3, 3, 3]).coefficient is None
+        assert krippendorff_alpha([[3, 3], [3, 3]]).coefficient is None

--- a/tests/shared/agreement/test_coefficients.py
+++ b/tests/shared/agreement/test_coefficients.py
@@ -1,0 +1,112 @@
+"""Tests for inter-rater agreement coefficients (spec §6).
+
+Oracles are hand-computed in the comments so the implementation is pinned to
+the definitions, not to a reference library (the module is dependency-free).
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from arandu.shared.agreement import (
+    cohen_kappa_weighted,
+    gwet_ac2,
+    krippendorff_alpha,
+)
+
+
+class TestCohenKappaWeighted:
+    def test_perfect_agreement_is_one(self) -> None:
+        r = cohen_kappa_weighted([1, 2, 3, 4, 5], [1, 2, 3, 4, 5])
+        assert r.coefficient == pytest.approx(1.0)
+
+    def test_hand_computed_quadratic(self) -> None:
+        # A=[1,2,3,3] B=[1,2,3,2]: D_o = 0.25/1.0... see module docstring.
+        # D_o = mean (a-b)^2 = (0+0+0+1)/4 = 0.25
+        # D_e = sum_ij (i-j)^2 pA_i pB_j = 1.25  -> kappa = 1 - 0.25/1.25 = 0.8
+        r = cohen_kappa_weighted([1, 2, 3, 3], [1, 2, 3, 2])
+        assert r.coefficient == pytest.approx(0.8)
+
+    def test_systematic_disagreement_negative_or_zero(self) -> None:
+        # Raters invert each other on a 2-point scale -> worse than chance.
+        r = cohen_kappa_weighted([1, 2, 1, 2], [2, 1, 2, 1])
+        assert r.coefficient < 0.0
+
+    def test_length_mismatch_raises(self) -> None:
+        with pytest.raises(ValueError, match="same length"):
+            cohen_kappa_weighted([1, 2], [1])
+
+
+class TestKrippendorffAlpha:
+    def test_perfect_agreement_is_one(self) -> None:
+        # units x raters, all raters agree per unit.
+        data = [[3, 3, 3], [1, 1, 1], [5, 5, 5]]
+        r = krippendorff_alpha(data, level="ordinal")
+        assert r.coefficient == pytest.approx(1.0)
+
+    def test_nominal_hand_computed_zero(self) -> None:
+        # units (1,1) and (1,2): coincidences o_11=2, o_12=o_21=1.
+        # n_1=3, n_2=1, n=4. D_o = (1/4)(1+1) = 0.5.
+        # D_e = (1/(4*3))(3*1 + 1*3) = 0.5. alpha = 1 - 0.5/0.5 = 0.0
+        data = [[1, 1], [1, 2]]
+        r = krippendorff_alpha(data, level="nominal")
+        assert r.coefficient == pytest.approx(0.0, abs=1e-9)
+
+    def test_ordinal_between_nominal_and_perfect(self) -> None:
+        # A near-miss (off by one) should hurt ordinal less than a far miss.
+        near = krippendorff_alpha([[1, 1], [2, 3], [4, 4], [5, 5]], level="ordinal")
+        far = krippendorff_alpha([[1, 1], [2, 5], [4, 4], [5, 5]], level="ordinal")
+        assert near.coefficient > far.coefficient
+
+    def test_single_rating_units_ignored(self) -> None:
+        # Units with <2 ratings carry no coincidence; perfect on the rest -> 1.
+        data = [[3, None], [2, 2], [4, 4]]
+        r = krippendorff_alpha(data, level="ordinal")
+        assert r.coefficient == pytest.approx(1.0)
+
+
+class TestGwetAC2:
+    def test_perfect_agreement_is_one(self) -> None:
+        data = [[1, 1], [5, 5], [3, 3]]
+        r = gwet_ac2(data)
+        assert r.coefficient == pytest.approx(1.0)
+
+    def test_prevalence_paradox_ac2_exceeds_kappa(self) -> None:
+        # 14 items both rate "1", 1 item disagrees. High observed agreement,
+        # heavily skewed marginals: kappa collapses, AC2 stays high.
+        data = [[1, 1]] * 14 + [[1, 2]]
+        ac2 = gwet_ac2(data).coefficient
+        flat_a = [row[0] for row in data]
+        flat_b = [row[1] for row in data]
+        kappa = cohen_kappa_weighted(flat_a, flat_b).coefficient
+        assert ac2 > kappa
+        assert ac2 > 0.8  # high agreement preserved
+        assert kappa < ac2 - 0.3  # the paradox: kappa is depressed
+
+
+class TestBootstrapCI:
+    def test_ci_brackets_point_estimate(self) -> None:
+        data = [[1, 1], [2, 2], [3, 2], [4, 4], [5, 5], [3, 3], [2, 1], [4, 5]]
+        flat_a = [row[0] for row in data]
+        flat_b = [row[1] for row in data]
+        r = cohen_kappa_weighted(flat_a, flat_b, n_bootstrap=500, seed=42)
+        assert r.ci_low is not None and r.ci_high is not None
+        assert r.ci_low <= r.coefficient <= r.ci_high
+
+    def test_bootstrap_reproducible_with_seed(self) -> None:
+        flat_a = [1, 2, 3, 3, 2, 1, 4, 5, 3, 2]
+        flat_b = [1, 2, 3, 2, 2, 1, 4, 4, 3, 1]
+        r1 = cohen_kappa_weighted(flat_a, flat_b, n_bootstrap=200, seed=7)
+        r2 = cohen_kappa_weighted(flat_a, flat_b, n_bootstrap=200, seed=7)
+        assert r1.ci_low == r2.ci_low
+        assert r1.ci_high == r2.ci_high
+
+    def test_no_bootstrap_leaves_ci_none(self) -> None:
+        r = cohen_kappa_weighted([1, 2, 3], [1, 2, 3])
+        assert r.ci_low is None and r.ci_high is None
+
+    def test_coefficient_finite(self) -> None:
+        r = krippendorff_alpha([[1, 1], [2, 2]], level="ordinal", n_bootstrap=50, seed=1)
+        assert math.isfinite(r.coefficient)

--- a/tests/shared/agreement/test_variability.py
+++ b/tests/shared/agreement/test_variability.py
@@ -1,0 +1,29 @@
+"""Tests for the high-variability item detector (spec §6.3)."""
+
+from __future__ import annotations
+
+from arandu.shared.agreement import high_variability_items
+
+
+class TestHighVariabilityItems:
+    def test_flags_spread_at_or_above_threshold(self) -> None:
+        # item 0 spread 0, item 1 spread 1, item 2 spread 3 (>=2 flagged).
+        ratings = [[3, 3, 3], [3, 4, 3], [1, 4, 2]]
+        flagged = high_variability_items(ratings, min_spread=2)
+        assert flagged == [2]
+
+    def test_threshold_inclusive(self) -> None:
+        ratings = [[2, 4, 3]]  # spread exactly 2
+        assert high_variability_items(ratings, min_spread=2) == [0]
+
+    def test_ignores_missing_ratings(self) -> None:
+        # spread computed over present ratings only.
+        ratings = [[3, None, 3], [1, None, 5]]
+        assert high_variability_items(ratings, min_spread=2) == [1]
+
+    def test_single_rating_never_flagged(self) -> None:
+        ratings = [[4, None, None]]
+        assert high_variability_items(ratings, min_spread=2) == []
+
+    def test_empty_input(self) -> None:
+        assert high_variability_items([], min_spread=2) == []

--- a/tests/shared/agreement/test_variability.py
+++ b/tests/shared/agreement/test_variability.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from arandu.shared.agreement import high_variability_items
+import pytest
+
+from arandu.shared.agreement import high_variability_items, high_variability_rate
 
 
 class TestHighVariabilityItems:
@@ -29,7 +31,21 @@ class TestHighVariabilityItems:
         assert high_variability_items([], min_spread=2) == []
 
     def test_rejects_non_positive_threshold(self) -> None:
-        import pytest
-
         with pytest.raises(ValueError, match="min_spread"):
             high_variability_items([[3, 3]], min_spread=0)
+
+
+class TestHighVariabilityRate:
+    def test_rate_over_usable_items(self) -> None:
+        # 3 usable items, 1 flagged (spread 3) -> 1/3.
+        ratings = [[3, 3], [3, 4], [1, 4]]
+        assert high_variability_rate(ratings, min_spread=2) == pytest.approx(1 / 3)
+
+    def test_denominator_excludes_unusable_items(self) -> None:
+        # 2 usable (the single-rating row is excluded); 1 flagged -> 1/2.
+        ratings = [[5, None], [3, 3], [1, 5]]
+        assert high_variability_rate(ratings, min_spread=2) == pytest.approx(0.5)
+
+    def test_none_when_no_usable_items(self) -> None:
+        assert high_variability_rate([[3, None]], min_spread=2) is None
+        assert high_variability_rate([], min_spread=2) is None

--- a/tests/shared/agreement/test_variability.py
+++ b/tests/shared/agreement/test_variability.py
@@ -27,3 +27,9 @@ class TestHighVariabilityItems:
 
     def test_empty_input(self) -> None:
         assert high_variability_items([], min_spread=2) == []
+
+    def test_rejects_non_positive_threshold(self) -> None:
+        import pytest
+
+        with pytest.raises(ValueError, match="min_spread"):
+            high_variability_items([[3, 3]], min_spread=0)

--- a/tests/shared/test_stats.py
+++ b/tests/shared/test_stats.py
@@ -1,0 +1,58 @@
+"""Tests for shared statistical primitives (percentile, bootstrap_ci)."""
+
+from __future__ import annotations
+
+import pytest
+
+from arandu.shared.stats import bootstrap_ci, percentile
+
+
+class TestPercentile:
+    def test_single_value(self) -> None:
+        assert percentile([4.0], 50) == 4.0
+
+    def test_endpoints(self) -> None:
+        data = [0.0, 1.0, 2.0, 3.0, 4.0]
+        assert percentile(data, 0) == 0.0
+        assert percentile(data, 100) == 4.0
+
+    def test_linear_interpolation(self) -> None:
+        # rank = 0.5*(4) = 2.0 -> exact index 2.
+        assert percentile([0.0, 10.0, 20.0, 30.0, 40.0], 50) == 20.0
+        # rank = 0.25*4 = 1.0 -> index 1.
+        assert percentile([0.0, 10.0, 20.0, 30.0, 40.0], 25) == 10.0
+
+    def test_empty_raises(self) -> None:
+        with pytest.raises(ValueError, match="empty"):
+            percentile([], 50)
+
+
+class TestBootstrapCI:
+    def test_empty_items(self) -> None:
+        assert bootstrap_ci([], lambda s: 1.0, n_bootstrap=10, seed=1) == (None, None)
+
+    def test_brackets_constant_estimator(self) -> None:
+        lo, hi = bootstrap_ci([1, 2, 3, 4], lambda s: 0.5, n_bootstrap=100, seed=1)
+        assert lo == 0.5 and hi == 0.5
+
+    def test_reproducible_with_seed(self) -> None:
+        items = list(range(20))
+
+        def est(sample: list[int]) -> float:
+            return sum(sample) / len(sample)
+
+        r1 = bootstrap_ci(items, est, n_bootstrap=200, seed=9)
+        r2 = bootstrap_ci(items, est, n_bootstrap=200, seed=9)
+        assert r1 == r2
+
+    def test_degenerate_estimates_skipped(self) -> None:
+        # Estimator returns None for some resamples; CI uses only the rest.
+        def est(sample: list[int]) -> float | None:
+            return None if all(x == sample[0] for x in sample) else 1.0
+
+        lo, hi = bootstrap_ci([1, 2], est, n_bootstrap=50, seed=3)
+        assert lo == 1.0 and hi == 1.0
+
+    def test_all_degenerate_returns_none(self) -> None:
+        lo, hi = bootstrap_ci([1, 2, 3], lambda s: None, n_bootstrap=20, seed=1)
+        assert lo is None and hi is None


### PR DESCRIPTION
## What

Dependency-free statistical core for the emic-validity human-comparison study (spec §6). No `statsmodels`/`scipy`/external reliability package — implemented from definitions, mirroring `shared/rag/analysis` (Wilson CI precedent).

`arandu.shared.agreement`:
- **`krippendorff_alpha`** — multi-rater, `ordinal` (default, marginal-based distance) / `interval` / `nominal` via the coincidence matrix. The primary metric (3 anthropologists + LLM as 4th rater).
- **`cohen_kappa_weighted`** — pairwise (LLM vs each annotator), quadratic/linear weights. Diagnostic.
- **`gwet_ac2`** — multi-rater weighted; robustness check against the prevalence paradox.
- **`high_variability_items`** — flags items with rating spread ≥ threshold (§6.3).
- **Bootstrap 95% CIs** on each coefficient (resample items, seeded → reproducible).

Uniform data convention: `items × raters`, `None` = missing. `AgreementResult` carries estimate + optional CI + `n_items`.

## Tests

Math pinned to hand-computed oracles (worked in the test comments):
- Cohen weighted κ = **0.8** on `A=[1,2,3,3] B=[1,2,3,2]` (D_o=0.25, D_e=1.25).
- Krippendorff nominal α = **0.0** on units (1,1),(1,2) (coincidence matrix → D_o=D_e=0.5).
- Gwet AC2 **> κ** on a prevalence-skewed case (14× agree + 1 disagree).

Plus property tests: perfect agreement = 1; ordinal penalizes a near-miss less than a far-miss; bootstrap CI brackets the estimate and is reproducible under a fixed seed. 19 tests, ruff clean.

## Scope

This is the **statistical core**. The `arandu emic-analysis` CLI (spec §6) reads label files from the annotation instrument + `emic-prepass` — formats that don't exist yet — so it's deferred to those tasks (YAGNI) rather than invented here. No human gate; this PR is fully independent of the anthropological validation.