### PR TITLE
feat(emic): arandu emic-prepass — ordinal scoring of approved CEP pairs (spec §5)

### DIFF
--- a/src/arandu/cli/app.py
+++ b/src/arandu/cli/app.py
@@ -50,6 +50,7 @@ def main(
 # Register commands from submodules
 from arandu.cli.answer import answer  # noqa: E402
 from arandu.cli.chunking import chunk  # noqa: E402
+from arandu.cli.emic_prepass import emic_prepass  # noqa: E402
 from arandu.cli.judge_answers import judge_answers  # noqa: E402
 from arandu.cli.kg import build_kg, kg_build_retriever_index, kg_link_passages  # noqa: E402
 from arandu.cli.manage import (  # noqa: E402
@@ -87,6 +88,7 @@ app.command()(kg_build_retriever_index)
 app.command()(retrieve)
 app.command()(answer)
 app.command()(judge_answers)
+app.command()(emic_prepass)
 app.command()(rag_analysis)
 app.command()(generate_non_answerable)
 app.command()(replicate)

--- a/src/arandu/cli/emic_prepass.py
+++ b/src/arandu/cli/emic_prepass.py
@@ -1,0 +1,80 @@
+"""CLI command: ``arandu emic-prepass`` — ordinal emic-validity scoring of approved CEP pairs.
+
+Runs the ``emic_validity`` ordinal criterion over the canonical-approved pairs
+of a populated run and writes per-source ordinal scores under
+``results/<id>/emic_prepass/outputs/<source>.json``. The scores bound the
+sampling bands for the stratified human-comparison sample (the annotators are
+the ground truth; this is a sampling aid).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Annotated
+
+import typer
+
+from arandu.shared.emic.batch import run_emic_prepass_batch
+from arandu.shared.emic.settings import EmicPrepassSettings
+from arandu.utils.logger import print_error, print_info, print_success, print_warning
+
+logger = logging.getLogger(__name__)
+
+
+def emic_prepass(
+    pipeline_id: Annotated[
+        str,
+        typer.Option(
+            "--id",
+            help=(
+                "Pipeline ID for the run. The cep/ stage must be populated and "
+                "judged; only canonical-approved pairs (is_valid) are scored."
+            ),
+        ),
+    ],
+    rerun: Annotated[
+        bool,
+        typer.Option(
+            "--rerun/--resume",
+            help=(
+                "--rerun discards the checkpoint and re-scores every source. "
+                "--resume (default) skips sources already completed."
+            ),
+        ),
+    ] = False,
+) -> None:
+    """Score canonical-approved CEP pairs for emic validity (ordinal 1-5).
+
+    Builds the ``emic_validity`` ordinal criterion standalone (not a judge-qa
+    pipeline stage) and runs it over each approved pair's segment + question +
+    answer, persisting per-source ``EmicSourceScores`` for the stratified
+    sample builder.
+
+    LLM configuration is read from ``ARANDU_EMIC_PREPASS_*`` env vars; see
+    :class:`EmicPrepassSettings`. The score is a sampling aid, not ground
+    truth — the human annotators are the reference.
+    """
+    settings = EmicPrepassSettings()
+    print_info(f"Run: {pipeline_id}")
+    print_info(
+        f"Emic LLM: provider={settings.provider}, model={settings.model_id}, "
+        f"language={settings.language}, temperature={settings.temperature}"
+    )
+    if rerun:
+        print_warning("--rerun: clearing checkpoint; every source will be re-scored.")
+
+    try:
+        result = run_emic_prepass_batch(pipeline_id=pipeline_id, settings=settings, rerun=rerun)
+    except FileNotFoundError as exc:
+        print_error(str(exc))
+        raise typer.Exit(code=1) from exc
+    except (RuntimeError, ValueError) as exc:
+        print_error(f"Invalid emic-prepass configuration: {exc}")
+        raise typer.Exit(code=1) from exc
+
+    if result.failed_pairs:
+        print_warning(f"Failed pairs: {result.failed_pairs} (LLM errors; see logs).")
+    print_success(
+        f"Scored {result.scored_pairs}/{result.approved_pairs} approved pairs "
+        f"across {result.sources} source(s)."
+    )

--- a/src/arandu/cli/emic_prepass.py
+++ b/src/arandu/cli/emic_prepass.py
@@ -71,10 +71,24 @@ def emic_prepass(
     except (RuntimeError, ValueError) as exc:
         print_error(f"Invalid emic-prepass configuration: {exc}")
         raise typer.Exit(code=1) from exc
+    except OSError as exc:
+        print_error(f"I/O error during emic pre-pass: {exc}")
+        raise typer.Exit(code=1) from exc
 
+    if result.failed_sources:
+        print_warning(
+            f"{result.failed_sources} source(s) failed to load and were skipped (see logs)."
+        )
+    if result.unjudged_pairs:
+        print_warning(
+            f"{result.unjudged_pairs} pair(s) had no judge verdict and were skipped; "
+            "the run may not have been fully judged (`arandu judge-qa`)."
+        )
     if result.failed_pairs:
-        print_warning(f"Failed pairs: {result.failed_pairs} (LLM errors; see logs).")
+        print_warning(f"{result.failed_pairs} approved pair(s) errored while scoring (see logs).")
     print_success(
-        f"Scored {result.scored_pairs}/{result.approved_pairs} approved pairs "
-        f"across {result.sources} source(s)."
+        f"Scored {result.scored_pairs}/{result.approved_pairs} approved pairs this run "
+        f"across {result.completed_sources} new source(s); "
+        f"{result.resumed_sources} resumed, {result.failed_sources} failed "
+        f"({result.sources} total)."
     )

--- a/src/arandu/shared/emic/__init__.py
+++ b/src/arandu/shared/emic/__init__.py
@@ -1,0 +1,13 @@
+"""Emic-validity pre-pass: ordinal scoring of approved CEP pairs (spec §5)."""
+
+from arandu.shared.emic.batch import run_emic_prepass_batch
+from arandu.shared.emic.schemas import EmicPrepassResult, EmicScore, EmicSourceScores
+from arandu.shared.emic.settings import EmicPrepassSettings
+
+__all__ = [
+    "EmicPrepassResult",
+    "EmicPrepassSettings",
+    "EmicScore",
+    "EmicSourceScores",
+    "run_emic_prepass_batch",
+]

--- a/src/arandu/shared/emic/batch.py
+++ b/src/arandu/shared/emic/batch.py
@@ -121,29 +121,42 @@ def run_emic_prepass_batch(
         checkpoint_filename=CHECKPOINT_FILENAME,
     )
     checkpoint_path = results_mgr.run_dir / CHECKPOINT_FILENAME
-    if rerun and checkpoint_path.exists():
-        checkpoint_path.unlink()
+    if rerun:
+        if checkpoint_path.exists():
+            checkpoint_path.unlink()
+        # Resetting only the checkpoint would leave per-source outputs from a
+        # prior run in outputs_dir. If the CEP stage was regenerated with a
+        # different (e.g. smaller) corpus since, those orphaned files would be
+        # globbed as live scores by the stratified sample builder. Clear them.
+        for stale in results_mgr.outputs_dir.glob("*.json"):
+            stale.unlink()
     checkpoint = CheckpointManager(checkpoint_path)
 
     cep_paths = sorted(cep_outputs.glob("*_cep_qa.json"))
     checkpoint.set_total_files(len(cep_paths))
 
-    approved = scored = failed = 0
+    completed_sources = resumed_sources = failed_sources = 0
+    approved = scored = failed = unjudged = 0
     for path in cep_paths:
         ckpt_key = path.stem
         if checkpoint.is_completed(ckpt_key):
+            resumed_sources += 1
             continue
         try:
             record = QARecordCEP.model_validate_json(path.read_text(encoding="utf-8"))
         except (OSError, ValidationError) as exc:
             logger.warning("Skipping %s: load failed: %s", path.name, exc)
             checkpoint.mark_failed(ckpt_key, f"load failed: {exc}")
+            failed_sources += 1
             continue
 
         scores: list[EmicScore] = []
         for idx, pair in enumerate(record.qa_pairs):
+            if pair.is_valid is None:
+                unjudged += 1  # never judged; can't be canonically approved
+                continue
             if not pair.is_valid:
-                continue  # only canonical-approved pairs enter the emic pre-pass
+                continue  # judged and rejected — only approved pairs are scored
             approved += 1
             result = criterion.evaluate(
                 context=pair.context,
@@ -170,18 +183,42 @@ def run_emic_prepass_batch(
             scores=scores,
         ).save(results_mgr.outputs_dir / f"{path.stem}.json")
         checkpoint.mark_completed(ckpt_key)
+        completed_sources += 1
+
+    if unjudged:
+        logger.warning(
+            "%d pair(s) had no judge verdict (is_valid is None) and were skipped; "
+            "the run may not have been fully judged via `arandu judge-qa`.",
+            unjudged,
+        )
+
+    # Mirror the judge-answers convention: record progress and finalize the run
+    # so run_metadata flips to COMPLETED and the run enters the global index
+    # (otherwise it is stuck IN_PROGRESS and invisible to get_latest_run /
+    # list_runs). A load failure marks the run FAILED but is non-fatal.
+    results_mgr.update_progress(completed_sources + resumed_sources, failed_sources, len(cep_paths))
+    results_mgr.complete_run(success=(failed_sources == 0))
 
     logger.info(
-        "Emic pre-pass complete: %d sources, %d approved pairs, %d scored, %d failed.",
+        "Emic pre-pass complete: %d/%d sources scored (%d resumed, %d failed), "
+        "%d approved pairs, %d scored, %d failed, %d unjudged.",
+        completed_sources,
         len(cep_paths),
+        resumed_sources,
+        failed_sources,
         approved,
         scored,
         failed,
+        unjudged,
     )
     return EmicPrepassResult(
         pipeline_id=pipeline_id,
         sources=len(cep_paths),
+        completed_sources=completed_sources,
+        resumed_sources=resumed_sources,
+        failed_sources=failed_sources,
         approved_pairs=approved,
         scored_pairs=scored,
         failed_pairs=failed,
+        unjudged_pairs=unjudged,
     )

--- a/src/arandu/shared/emic/batch.py
+++ b/src/arandu/shared/emic/batch.py
@@ -1,0 +1,187 @@
+"""Batch orchestrator for ``arandu emic-prepass`` (spec §5).
+
+Runs the ``emic_validity`` ordinal criterion over the canonical-approved CEP
+pairs of a populated run and writes per-source ordinal scores under
+``results/<id>/emic_prepass/outputs/<source>.json``. These scores feed the
+stratified sample builder (they bound the sampling bands; the human annotators
+remain the ground truth).
+
+The criterion is built standalone via ``OrdinalLLMCriterion.from_config`` — it
+is not wired into the ``judge-qa`` pipeline (that, with a filter threshold, is
+the separate ``emic-filter-stage`` task).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import TYPE_CHECKING
+
+from pydantic import ValidationError
+
+from arandu.qa.schemas import QARecordCEP
+from arandu.shared.checkpoint import CheckpointManager
+from arandu.shared.config import ResultsConfig
+from arandu.shared.emic.schemas import EmicPrepassResult, EmicScore, EmicSourceScores
+from arandu.shared.emic.settings import EmicPrepassSettings
+from arandu.shared.judge.criterion import OrdinalLLMCriterion
+from arandu.shared.llm_client import LLMClient, LLMProvider
+from arandu.shared.results_manager import ResultsManager
+from arandu.shared.schemas import PipelineType
+from arandu.utils.paths import get_project_root
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+CHECKPOINT_FILENAME = "emic_prepass_checkpoint.json"
+EMIC_CRITERION_NAME = "emic_validity"
+
+
+def _build_llm_client(settings: EmicPrepassSettings) -> LLMClient:
+    """Construct the unified LLMClient from emic-prepass settings."""
+    try:
+        provider_enum = LLMProvider(settings.provider)
+    except ValueError as exc:
+        raise ValueError(
+            f"Unknown emic-prepass provider {settings.provider!r}. "
+            f"Valid: {[p.value for p in LLMProvider]}."
+        ) from exc
+
+    api_key = os.environ.get(settings.api_key_env)
+    if not api_key and provider_enum is not LLMProvider.OLLAMA:
+        raise RuntimeError(
+            f"emic-prepass provider {settings.provider!r} requires "
+            f"{settings.api_key_env} to be set, or switch "
+            f"ARANDU_EMIC_PREPASS_PROVIDER to 'ollama'."
+        )
+    if provider_enum is LLMProvider.CUSTOM and not settings.base_url:
+        raise ValueError(
+            "provider='custom' requires a base URL. Set "
+            "ARANDU_EMIC_PREPASS_BASE_URL or pass base_url=... explicitly."
+        )
+
+    return LLMClient(
+        provider=provider_enum,
+        model_id=settings.model_id,
+        api_key=api_key,
+        base_url=settings.base_url,
+    )
+
+
+def run_emic_prepass_batch(
+    pipeline_id: str,
+    *,
+    settings: EmicPrepassSettings | None = None,
+    base_dir: Path | None = None,
+    rerun: bool = False,
+) -> EmicPrepassResult:
+    """Score the canonical-approved CEP pairs of ``pipeline_id`` for emic validity.
+
+    Args:
+        pipeline_id: Run identifier. The ``cep`` stage must be populated and
+            judged (only pairs with ``is_valid`` are scored).
+        settings: Emic-prepass configuration. Defaults to
+            :class:`EmicPrepassSettings` (reads ``ARANDU_EMIC_PREPASS_*``).
+        base_dir: Override the project ``results/`` root.
+        rerun: If True, clear the checkpoint so every source is re-scored.
+
+    Returns:
+        :class:`EmicPrepassResult` summary.
+
+    Raises:
+        FileNotFoundError: If the cep stage outputs aren't present.
+        RuntimeError: If a cloud-provider API key env var is unset.
+    """
+    resolved = settings if settings is not None else EmicPrepassSettings()
+    base = base_dir if base_dir is not None else ResultsConfig().base_dir
+
+    cep_outputs = base / pipeline_id / "cep" / "outputs"
+    if not cep_outputs.exists():
+        raise FileNotFoundError(
+            f"CEP outputs not found for pipeline_id {pipeline_id!r}: {cep_outputs}. "
+            f"Run `arandu generate-cep-qa` and `arandu judge-qa` first."
+        )
+
+    llm_client = _build_llm_client(resolved)
+    criterion = OrdinalLLMCriterion.from_config(
+        name=EMIC_CRITERION_NAME,
+        prompts_dir=get_project_root() / "prompts" / "judge" / "criteria",
+        language=resolved.language,
+        llm_client=llm_client,
+        temperature=resolved.temperature,
+        max_tokens=resolved.max_tokens,
+    )
+
+    results_mgr = ResultsManager(base, PipelineType.EMIC_PREPASS, pipeline_id=pipeline_id)
+    results_mgr.create_run(
+        resolved,
+        input_source=str(cep_outputs),
+        checkpoint_filename=CHECKPOINT_FILENAME,
+    )
+    checkpoint_path = results_mgr.run_dir / CHECKPOINT_FILENAME
+    if rerun and checkpoint_path.exists():
+        checkpoint_path.unlink()
+    checkpoint = CheckpointManager(checkpoint_path)
+
+    cep_paths = sorted(cep_outputs.glob("*_cep_qa.json"))
+    checkpoint.set_total_files(len(cep_paths))
+
+    approved = scored = failed = 0
+    for path in cep_paths:
+        ckpt_key = path.stem
+        if checkpoint.is_completed(ckpt_key):
+            continue
+        try:
+            record = QARecordCEP.model_validate_json(path.read_text(encoding="utf-8"))
+        except (OSError, ValidationError) as exc:
+            logger.warning("Skipping %s: load failed: %s", path.name, exc)
+            checkpoint.mark_failed(ckpt_key, f"load failed: {exc}")
+            continue
+
+        scores: list[EmicScore] = []
+        for idx, pair in enumerate(record.qa_pairs):
+            if not pair.is_valid:
+                continue  # only canonical-approved pairs enter the emic pre-pass
+            approved += 1
+            result = criterion.evaluate(
+                context=pair.context,
+                question=pair.question,
+                answer=pair.answer,
+            )
+            if result.ordinal_score is None:
+                failed += 1
+            else:
+                scored += 1
+            scores.append(
+                EmicScore(
+                    pair_index=idx,
+                    bloom_level=pair.bloom_level,
+                    emic_score=result.ordinal_score,
+                    rationale=result.rationale,
+                    error=result.error,
+                )
+            )
+
+        EmicSourceScores(
+            source_file_id=record.source_file_id,
+            source_filename=record.source_filename,
+            scores=scores,
+        ).save(results_mgr.outputs_dir / f"{path.stem}.json")
+        checkpoint.mark_completed(ckpt_key)
+
+    logger.info(
+        "Emic pre-pass complete: %d sources, %d approved pairs, %d scored, %d failed.",
+        len(cep_paths),
+        approved,
+        scored,
+        failed,
+    )
+    return EmicPrepassResult(
+        pipeline_id=pipeline_id,
+        sources=len(cep_paths),
+        approved_pairs=approved,
+        scored_pairs=scored,
+        failed_pairs=failed,
+    )

--- a/src/arandu/shared/emic/schemas.py
+++ b/src/arandu/shared/emic/schemas.py
@@ -45,10 +45,35 @@ class EmicSourceScores(BaseModel):
 
 
 class EmicPrepassResult(BaseModel):
-    """Summary of an emic pre-pass run."""
+    """Summary of an emic pre-pass run.
+
+    Source-level counters (``completed_sources``/``resumed_sources``/
+    ``failed_sources``) account for *this* invocation; ``sources`` is the total
+    number of CEP source files seen. Pair-level counters
+    (``approved_pairs``/``scored_pairs``/``failed_pairs``/``unjudged_pairs``)
+    likewise reflect only the sources processed this run (resumed sources are
+    not re-counted), so a no-op ``--resume`` legitimately reports zero pairs.
+
+    Attributes:
+        pipeline_id: Run identifier.
+        sources: Total CEP source files discovered.
+        completed_sources: Sources scored and persisted this invocation.
+        resumed_sources: Sources skipped because already checkpointed.
+        failed_sources: Sources that failed to load (skipped, no output).
+        approved_pairs: Canonical-approved pairs encountered this run.
+        scored_pairs: Approved pairs that received an ordinal score.
+        failed_pairs: Approved pairs whose LLM call errored.
+        unjudged_pairs: Pairs skipped because the run was never judged
+            (``is_valid is None``); a non-zero value signals a missing
+            ``arandu judge-qa`` step.
+    """
 
     pipeline_id: str
     sources: int
+    completed_sources: int = 0
+    resumed_sources: int = 0
+    failed_sources: int = 0
     approved_pairs: int
     scored_pairs: int
     failed_pairs: int
+    unjudged_pairs: int = 0

--- a/src/arandu/shared/emic/schemas.py
+++ b/src/arandu/shared/emic/schemas.py
@@ -1,0 +1,54 @@
+"""Schemas for the emic-validity pre-pass artifacts (spec §5)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pydantic import BaseModel, Field
+
+
+class EmicScore(BaseModel):
+    """One ordinal emic-validity score for a canonical-approved QA pair.
+
+    Attributes:
+        pair_index: Index of the pair within its source ``QARecordCEP``
+            (a stable per-source key for the sample builder).
+        bloom_level: The pair's Bloom level (carried for stratification).
+        emic_score: Ordinal label in ``{1..5}``, or ``None`` if the LLM call
+            errored for this pair.
+        rationale: The judge's short justification.
+        error: Error message when ``emic_score`` is ``None``.
+    """
+
+    pair_index: int = Field(..., ge=0)
+    bloom_level: str
+    emic_score: int | None
+    rationale: str
+    error: str | None = None
+
+
+class EmicSourceScores(BaseModel):
+    """Emic pre-pass scores for one source interview's approved pairs."""
+
+    source_file_id: str
+    source_filename: str
+    scores: list[EmicScore]
+
+    def save(self, path: str | Path) -> None:
+        """Write the per-source scores to JSON."""
+        Path(path).write_text(self.model_dump_json(indent=2), encoding="utf-8")
+
+    @classmethod
+    def load(cls, path: str | Path) -> EmicSourceScores:
+        """Load per-source scores from JSON."""
+        return cls.model_validate_json(Path(path).read_text(encoding="utf-8"))
+
+
+class EmicPrepassResult(BaseModel):
+    """Summary of an emic pre-pass run."""
+
+    pipeline_id: str
+    sources: int
+    approved_pairs: int
+    scored_pairs: int
+    failed_pairs: int

--- a/src/arandu/shared/emic/settings.py
+++ b/src/arandu/shared/emic/settings.py
@@ -1,0 +1,47 @@
+"""Pydantic settings for ``arandu emic-prepass`` (env prefix ``ARANDU_EMIC_PREPASS_``)."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import Field, field_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class EmicPrepassSettings(BaseSettings):
+    """LLM settings for the ordinal emic-validity pre-pass (spec §5).
+
+    The pre-pass runs the ``emic_validity`` ordinal criterion over the
+    canonical-approved CEP pairs to produce per-pair scores that feed the
+    stratified sample. The score is a sampling aid, **not** ground truth (the
+    human annotators are the reference), so a modest model is fine.
+
+    Attributes:
+        provider: LLM provider (``ollama`` default; ``openai`` or ``custom``
+            for cloud / OpenAI-compatible endpoints).
+        model_id: Model identifier.
+        api_key_env: Env var holding the API key (ignored for ollama).
+        base_url: Base URL override; required when ``provider == "custom"``.
+        temperature: Sampling temperature. Default 0.1 — the emic judgment is
+            structural, not creative (spec §4.2 principle 8).
+        max_tokens: Cap on each criterion response.
+        language: Prompt language; selects
+            ``prompts/judge/criteria/emic_validity/<lang>/prompt.md``.
+            Only ``pt`` ships today.
+    """
+
+    provider: str = Field(default="ollama")
+    model_id: str = Field(default="qwen3:14b")
+    api_key_env: str = Field(default="OPENAI_API_KEY")
+    base_url: str | None = Field(default=None)
+    temperature: float = Field(default=0.1, ge=0.0, le=2.0)
+    max_tokens: int = Field(default=2048, gt=0)
+    language: Literal["pt"] = Field(default="pt")
+
+    model_config = SettingsConfigDict(env_prefix="ARANDU_EMIC_PREPASS_", extra="ignore")
+
+    @field_validator("provider", mode="before")
+    @classmethod
+    def _normalize_provider(cls, v: str) -> str:
+        """Lowercase the provider so env-var case doesn't break dispatch."""
+        return v.lower() if isinstance(v, str) else v

--- a/src/arandu/shared/schemas.py
+++ b/src/arandu/shared/schemas.py
@@ -200,6 +200,7 @@ class PipelineType(StrEnum):
     JUDGE_ANSWERS = "judge_answers"
     ANALYSIS = "analysis"
     NON_ANSWERABLE = "non_answerable"
+    EMIC_PREPASS = "emic_prepass"
     EVALUATION = "evaluation"
 
 

--- a/tests/shared/emic/test_batch.py
+++ b/tests/shared/emic/test_batch.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -19,8 +20,10 @@ if TYPE_CHECKING:
     from pytest_mock import MockerFixture
 
 
-def _pair(question: str, *, approved: bool, bloom: str = "analyze") -> QAPairCEP:
-    validation = JudgePipelineResult(stage_results={}, passed=approved)
+def _pair(
+    question: str, *, approved: bool, bloom: str = "analyze", judged: bool = True
+) -> QAPairCEP:
+    validation = JudgePipelineResult(stage_results={}, passed=approved) if judged else None
     return QAPairCEP(
         question=question,
         answer="resposta situada do interlocutor",
@@ -83,6 +86,10 @@ class TestEmicPrepassBatch:
         assert result.scored_pairs == 2
         assert result.failed_pairs == 0
         assert result.sources == 1
+        assert result.completed_sources == 1
+        assert result.resumed_sources == 0
+        assert result.failed_sources == 0
+        assert result.unjudged_pairs == 0
 
         out = EmicSourceScores.load(
             tmp_path / "run1" / "emic_prepass" / "outputs" / "src1_cep_qa.json"
@@ -111,6 +118,10 @@ class TestEmicPrepassBatch:
         second = run_emic_prepass_batch("run2", settings=settings, base_dir=tmp_path)
         assert mock_emic_client.generate_structured.call_count == calls_after_first
         assert second.scored_pairs == 0  # nothing re-scored on resume
+        assert second.approved_pairs == 0  # resumed sources are not re-counted
+        assert second.completed_sources == 0
+        assert second.resumed_sources == 1  # the prior run's source is accounted for
+        assert second.sources == 1
 
     def test_rerun_rescores(
         self, tmp_path: Path, mock_emic_client: Any, settings: EmicPrepassSettings
@@ -140,3 +151,81 @@ class TestEmicPrepassBatch:
         )
         assert out.scores[0].emic_score is None
         assert out.scores[0].error is not None
+
+    def test_unjudged_pairs_are_skipped_and_flagged(
+        self, tmp_path: Path, mock_emic_client: Any, settings: EmicPrepassSettings
+    ) -> None:
+        # A run that was CEP-populated but never judge-qa'd: is_valid is None
+        # for every pair, so nothing is scored and the result flags the gap
+        # instead of reporting a clean 0/0 success.
+        cep_outputs = tmp_path / "run5" / "cep" / "outputs"
+        _write_cep_record(
+            cep_outputs,
+            "src1",
+            [_pair("Q1", approved=False, judged=False), _pair("Q2", approved=False, judged=False)],
+        )
+
+        result = run_emic_prepass_batch("run5", settings=settings, base_dir=tmp_path)
+
+        assert result.unjudged_pairs == 2
+        assert result.approved_pairs == 0
+        assert result.scored_pairs == 0
+        assert mock_emic_client.generate_structured.call_count == 0  # nothing scored
+        assert result.completed_sources == 1  # source still processed (empty scores)
+        out = EmicSourceScores.load(
+            tmp_path / "run5" / "emic_prepass" / "outputs" / "src1_cep_qa.json"
+        )
+        assert out.scores == []
+
+    def test_load_failure_counts_failed_source_and_marks_run_failed(
+        self, tmp_path: Path, mock_emic_client: Any, settings: EmicPrepassSettings
+    ) -> None:
+
+        cep_outputs = tmp_path / "run6" / "cep" / "outputs"
+        _write_cep_record(cep_outputs, "good", [_pair("Q", approved=True)])
+        # A corrupt CEP artifact must be counted, not silently dropped.
+        (cep_outputs / "broken_cep_qa.json").write_text("{not valid json", encoding="utf-8")
+
+        result = run_emic_prepass_batch("run6", settings=settings, base_dir=tmp_path)
+
+        assert result.sources == 2
+        assert result.completed_sources == 1
+        assert result.failed_sources == 1
+        assert not (tmp_path / "run6" / "emic_prepass" / "outputs" / "broken_cep_qa.json").exists()
+
+        metadata = json.loads(
+            (tmp_path / "run6" / "emic_prepass" / "run_metadata.json").read_text(encoding="utf-8")
+        )
+        assert metadata["status"] == "failed"  # a failed source marks the run FAILED
+
+    def test_run_marked_completed_on_success(
+        self, tmp_path: Path, mock_emic_client: Any, settings: EmicPrepassSettings
+    ) -> None:
+
+        cep_outputs = tmp_path / "run7" / "cep" / "outputs"
+        _write_cep_record(cep_outputs, "src1", [_pair("Q", approved=True)])
+
+        run_emic_prepass_batch("run7", settings=settings, base_dir=tmp_path)
+
+        metadata = json.loads(
+            (tmp_path / "run7" / "emic_prepass" / "run_metadata.json").read_text(encoding="utf-8")
+        )
+        assert metadata["status"] == "completed"  # no longer stuck IN_PROGRESS
+
+    def test_rerun_clears_stale_outputs(
+        self, tmp_path: Path, mock_emic_client: Any, settings: EmicPrepassSettings
+    ) -> None:
+        cep_outputs = tmp_path / "run8" / "cep" / "outputs"
+        _write_cep_record(cep_outputs, "src1", [_pair("Q", approved=True)])
+        run_emic_prepass_batch("run8", settings=settings, base_dir=tmp_path)
+
+        # Simulate a stale output from a prior, larger corpus that is no longer
+        # present in cep/outputs.
+        outputs_dir = tmp_path / "run8" / "emic_prepass" / "outputs"
+        stale = outputs_dir / "removed_source_cep_qa.json"
+        stale.write_text("{}", encoding="utf-8")
+
+        run_emic_prepass_batch("run8", settings=settings, base_dir=tmp_path, rerun=True)
+
+        assert not stale.exists()  # --rerun purged the orphaned scores
+        assert (outputs_dir / "src1_cep_qa.json").exists()  # live source re-scored

--- a/tests/shared/emic/test_batch.py
+++ b/tests/shared/emic/test_batch.py
@@ -1,0 +1,142 @@
+"""Tests for the emic-validity pre-pass batch (spec §5)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from arandu.qa.schemas import QAPairCEP, QARecordCEP
+from arandu.shared.emic.batch import run_emic_prepass_batch
+from arandu.shared.emic.schemas import EmicSourceScores
+from arandu.shared.emic.settings import EmicPrepassSettings
+from arandu.shared.judge.criterion import OrdinalCriterionResponse
+from arandu.shared.judge.schemas import JudgePipelineResult
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from pytest_mock import MockerFixture
+
+
+def _pair(question: str, *, approved: bool, bloom: str = "analyze") -> QAPairCEP:
+    validation = JudgePipelineResult(stage_results={}, passed=approved)
+    return QAPairCEP(
+        question=question,
+        answer="resposta situada do interlocutor",
+        context="o interlocutor disse algo concreto sobre o rio",
+        question_type="conceptual",
+        confidence=0.9,
+        bloom_level=bloom,
+        validation=validation,
+    )
+
+
+def _write_cep_record(cep_outputs: Path, file_id: str, pairs: list[QAPairCEP]) -> None:
+    record = QARecordCEP(
+        source_gdrive_id=file_id,
+        source_filename=f"{file_id}.mp4",
+        transcription_text="t",
+        qa_pairs=pairs,
+        model_id="test-model",
+        provider="ollama",
+        total_pairs=len(pairs),
+    )
+    cep_outputs.mkdir(parents=True, exist_ok=True)
+    record.save(cep_outputs / f"{file_id}_cep_qa.json")
+
+
+@pytest.fixture
+def mock_emic_client(mocker: MockerFixture) -> Any:
+    """Patch the batch's LLM client builder; every call scores ordinal 2."""
+    client = mocker.MagicMock()
+    client.generate_structured.return_value = OrdinalCriterionResponse(
+        score=2, rationale="reenquadramento institucional"
+    )
+    mocker.patch("arandu.shared.emic.batch._build_llm_client", return_value=client)
+    return client
+
+
+@pytest.fixture
+def settings() -> EmicPrepassSettings:
+    return EmicPrepassSettings(provider="ollama", model_id="test-model")
+
+
+class TestEmicPrepassBatch:
+    def test_scores_only_approved_pairs(
+        self, tmp_path: Path, mock_emic_client: Any, settings: EmicPrepassSettings
+    ) -> None:
+        cep_outputs = tmp_path / "run1" / "cep" / "outputs"
+        _write_cep_record(
+            cep_outputs,
+            "src1",
+            [
+                _pair("Q approved", approved=True),
+                _pair("Q rejected", approved=False),
+                _pair("Q approved 2", approved=True, bloom="evaluate"),
+            ],
+        )
+
+        result = run_emic_prepass_batch("run1", settings=settings, base_dir=tmp_path)
+
+        assert result.approved_pairs == 2  # the rejected pair is skipped
+        assert result.scored_pairs == 2
+        assert result.failed_pairs == 0
+        assert result.sources == 1
+
+        out = EmicSourceScores.load(
+            tmp_path / "run1" / "emic_prepass" / "outputs" / "src1_cep_qa.json"
+        )
+        assert [s.pair_index for s in out.scores] == [0, 2]  # original indices preserved
+        assert all(s.emic_score == 2 for s in out.scores)
+        assert {s.bloom_level for s in out.scores} == {"analyze", "evaluate"}
+
+    def test_missing_cep_stage_raises(
+        self, tmp_path: Path, mock_emic_client: Any, settings: EmicPrepassSettings
+    ) -> None:
+        with pytest.raises(FileNotFoundError, match="CEP outputs not found"):
+            run_emic_prepass_batch("absent", settings=settings, base_dir=tmp_path)
+
+    def test_resume_skips_completed_sources(
+        self, tmp_path: Path, mock_emic_client: Any, settings: EmicPrepassSettings
+    ) -> None:
+        cep_outputs = tmp_path / "run2" / "cep" / "outputs"
+        _write_cep_record(cep_outputs, "src1", [_pair("Q", approved=True)])
+
+        run_emic_prepass_batch("run2", settings=settings, base_dir=tmp_path)
+        calls_after_first = mock_emic_client.generate_structured.call_count
+        assert calls_after_first == 1
+
+        # Second run resumes: the source is already checkpointed, no new calls.
+        second = run_emic_prepass_batch("run2", settings=settings, base_dir=tmp_path)
+        assert mock_emic_client.generate_structured.call_count == calls_after_first
+        assert second.scored_pairs == 0  # nothing re-scored on resume
+
+    def test_rerun_rescores(
+        self, tmp_path: Path, mock_emic_client: Any, settings: EmicPrepassSettings
+    ) -> None:
+        cep_outputs = tmp_path / "run3" / "cep" / "outputs"
+        _write_cep_record(cep_outputs, "src1", [_pair("Q", approved=True)])
+
+        run_emic_prepass_batch("run3", settings=settings, base_dir=tmp_path)
+        run_emic_prepass_batch("run3", settings=settings, base_dir=tmp_path, rerun=True)
+        assert mock_emic_client.generate_structured.call_count == 2
+
+    def test_llm_error_records_failed_pair(
+        self, tmp_path: Path, mocker: MockerFixture, settings: EmicPrepassSettings
+    ) -> None:
+        client = mocker.MagicMock()
+        client.generate_structured.side_effect = RuntimeError("llm down")
+        mocker.patch("arandu.shared.emic.batch._build_llm_client", return_value=client)
+
+        cep_outputs = tmp_path / "run4" / "cep" / "outputs"
+        _write_cep_record(cep_outputs, "src1", [_pair("Q", approved=True)])
+
+        result = run_emic_prepass_batch("run4", settings=settings, base_dir=tmp_path)
+        assert result.failed_pairs == 1
+        assert result.scored_pairs == 0
+        out = EmicSourceScores.load(
+            tmp_path / "run4" / "emic_prepass" / "outputs" / "src1_cep_qa.json"
+        )
+        assert out.scores[0].emic_score is None
+        assert out.scores[0].error is not None

--- a/tests/shared/test_results_manager.py
+++ b/tests/shared/test_results_manager.py
@@ -781,6 +781,7 @@ class TestPipelineType:
             "judge_answers",
             "analysis",
             "non_answerable",
+            "emic_prepass",
             "evaluation",
         }
         actual = {p.value for p in PipelineType}


### PR DESCRIPTION
## What

`arandu emic-prepass --id <run>` — a standalone pre-pass that runs the `emic_validity` ordinal criterion (#120) over a run's **canonical-approved** CEP pairs and writes per-source ordinal scores under `results/<id>/emic_prepass/outputs/<source>.json`. These bound the sampling bands for the stratified human-comparison sample (the annotators are ground truth; the LLM score is a sampling aid).

- **`shared/emic/`** — `EmicPrepassSettings` (`ARANDU_EMIC_PREPASS_*`, temp 0.1), `EmicScore`/`EmicSourceScores`/`EmicPrepassResult`, and `run_emic_prepass_batch` mirroring the `judge-answers` pattern (ResultsManager + checkpoint resume).
- Builds the criterion **standalone** via `OrdinalLLMCriterion.from_config` — it is *not* a `judge-qa` pipeline stage (that, with a data-dependent filter threshold, is the `emic-filter-stage` task). So the PR #117 review's factory scale-plumbing carry-over is **not needed here**.
- Only `is_valid` (canonical-approved) pairs are scored; the original `pair_index` + `bloom_level` are persisted so the stratified-sample builder can key and stratify.
- `cli/emic_prepass.py` (`--id`, `--rerun/--resume`), registered in `app.py`; `PipelineType.EMIC_PREPASS` added.

## Tests

Batch over a tmp run with a mocked LLM: approved-only filtering, original index + bloom preservation, resume vs `--rerun`, and LLM-error → failed-pair (score `None` + error). Full suite **1534 passed, 1 skipped**, ruff clean.

## Scope

Produces the scores the `stratified-sample-builder` consumes. The `emic-analysis` CLI (agreement coefficients over the annotated sample) and the `emic-filter-stage` (threshold-based filtering) remain separate downstream tasks.