### PR TITLE
feat(qa): stratified human-comparison sample builder (spec §5)

### DIFF
--- a/src/arandu/cli/app.py
+++ b/src/arandu/cli/app.py
@@ -51,6 +51,7 @@ def main(
 from arandu.cli.answer import answer  # noqa: E402
 from arandu.cli.chunking import chunk  # noqa: E402
 from arandu.cli.emic_prepass import emic_prepass  # noqa: E402
+from arandu.cli.human_eval import build_human_eval_sample  # noqa: E402
 from arandu.cli.judge_answers import judge_answers  # noqa: E402
 from arandu.cli.kg import build_kg, kg_build_retriever_index, kg_link_passages  # noqa: E402
 from arandu.cli.manage import (  # noqa: E402
@@ -89,6 +90,7 @@ app.command()(retrieve)
 app.command()(answer)
 app.command()(judge_answers)
 app.command()(emic_prepass)
+app.command()(build_human_eval_sample)
 app.command()(rag_analysis)
 app.command()(generate_non_answerable)
 app.command()(replicate)

--- a/src/arandu/cli/human_eval.py
+++ b/src/arandu/cli/human_eval.py
@@ -1,0 +1,74 @@
+"""CLI command: ``arandu build-human-eval-sample`` — stratified 80-pair sample (spec §5).
+
+Builds the human-comparison study sample (4 Bloom x 2 emic bands x 10) from the
+emic pre-pass scores of a run, joining each pair's CEP payload, and writes
+``sample.jsonl`` + ``sample_manifest.json`` under
+``results/<id>/human_eval/outputs/``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Annotated
+
+import typer
+
+from arandu.shared.human_eval.batch import run_build_sample_batch
+from arandu.utils.logger import print_error, print_info, print_success, print_warning
+
+logger = logging.getLogger(__name__)
+
+
+def build_human_eval_sample(
+    pipeline_id: Annotated[
+        str,
+        typer.Option(
+            "--id",
+            help=(
+                "Pipeline ID for the run. The emic_prepass and cep stages must both be populated."
+            ),
+        ),
+    ],
+    seed: Annotated[
+        int,
+        typer.Option(
+            "--seed",
+            help="RNG seed for the deterministic selection (recorded in the manifest).",
+        ),
+    ],
+) -> None:
+    """Build the stratified human-comparison sample (80 pairs) for a run.
+
+    Pools the canonical-approved pairs scored by ``arandu emic-prepass``, bands
+    them by emic validity (duvidosa <=3 / limpa >=4), and draws 10 pairs from
+    each of the 8 cells (4 Bloom levels x 2 bands) with a fixed seed. The
+    emic score is a sampling aid to cover the bands, not ground truth; the
+    human annotators remain the reference. Writes the sample + manifest under
+    ``results/<id>/human_eval/outputs/``.
+    """
+    print_info(f"Run: {pipeline_id} | seed: {seed}")
+
+    try:
+        manifest = run_build_sample_batch(pipeline_id=pipeline_id, seed=seed)
+    except FileNotFoundError as exc:
+        print_error(str(exc))
+        raise typer.Exit(code=1) from exc
+    except ValueError as exc:
+        print_error(f"Could not build a balanced sample: {exc}")
+        raise typer.Exit(code=1) from exc
+    except OSError as exc:
+        print_error(f"I/O error building the human-eval sample: {exc}")
+        raise typer.Exit(code=1) from exc
+
+    excluded_bloom_total = sum(manifest.excluded_bloom.values())
+    if manifest.excluded_none_score or excluded_bloom_total:
+        print_warning(
+            f"Excluded from frame: {manifest.excluded_none_score} null-score pair(s), "
+            f"{excluded_bloom_total} out-of-frame-Bloom pair(s) "
+            f"({manifest.excluded_bloom or 'none'})."
+        )
+    print_success(
+        f"Built {manifest.total_items} pairs across {len(manifest.cell_counts)} cells "
+        f"({manifest.per_cell}/cell). Sample + manifest under "
+        f"results/{pipeline_id}/human_eval/outputs/."
+    )

--- a/src/arandu/shared/human_eval/__init__.py
+++ b/src/arandu/shared/human_eval/__init__.py
@@ -1,0 +1,19 @@
+"""Human-comparison study: stratified 80-pair sample builder (spec §5)."""
+
+from arandu.shared.human_eval.batch import run_build_sample_batch
+from arandu.shared.human_eval.sampling import InsufficientCellError, PoolEntry, build_sample
+from arandu.shared.human_eval.schemas import (
+    HumanEvalSampleConfig,
+    SampleItem,
+    SampleManifest,
+)
+
+__all__ = [
+    "HumanEvalSampleConfig",
+    "InsufficientCellError",
+    "PoolEntry",
+    "SampleItem",
+    "SampleManifest",
+    "build_sample",
+    "run_build_sample_batch",
+]

--- a/src/arandu/shared/human_eval/batch.py
+++ b/src/arandu/shared/human_eval/batch.py
@@ -20,6 +20,7 @@ from arandu.shared.human_eval.sampling import (
     FRAME_BLOOM_LEVELS,
     PER_CELL,
     PoolEntry,
+    all_cell_ids,
     build_sample,
     population_by_cell,
 )
@@ -37,8 +38,14 @@ MANIFEST_FILENAME = "sample_manifest.json"
 
 
 def _pool_sha256(pool: list[PoolEntry]) -> str:
-    """Hash the in-frame pool (sorted by key) for reproducibility provenance."""
-    lines = sorted(f"{e.pair_id}|{e.bloom_level}|{e.emic_score}" for e in pool)
+    """Hash the full in-frame pool (incl. payload) for reproducibility provenance.
+
+    Canonical JSON per entry, sorted, so the digest is order-independent and
+    changes if any payload text (segment/question/answer) drifts -- not just the
+    ids/scores -- letting an auditor detect a CEP regeneration under the same
+    pair ids.
+    """
+    lines = sorted(e.model_dump_json() for e in pool)
     return hashlib.sha256("\n".join(lines).encode("utf-8")).hexdigest()
 
 
@@ -68,8 +75,8 @@ def run_build_sample_batch(
             or a referenced CEP pair cannot be resolved.
     """
     base = base_dir if base_dir is not None else ResultsConfig().base_dir
-    emic_outputs = base / pipeline_id / "emic_prepass" / "outputs"
-    cep_outputs = base / pipeline_id / "cep" / "outputs"
+    emic_outputs = base / pipeline_id / PipelineType.EMIC_PREPASS.value / "outputs"
+    cep_outputs = base / pipeline_id / PipelineType.CEP.value / "outputs"
     if not emic_outputs.exists():
         raise FileNotFoundError(
             f"Emic pre-pass outputs not found for pipeline_id {pipeline_id!r}: {emic_outputs}. "
@@ -82,6 +89,7 @@ def run_build_sample_batch(
         )
 
     pool: list[PoolEntry] = []
+    seen_pair_ids: set[str] = set()
     excluded_none = 0
     excluded_bloom: dict[str, int] = {}
     for emic_path in sorted(emic_outputs.glob("*_cep_qa.json")):
@@ -105,10 +113,18 @@ def run_build_sample_batch(
                     f"pair_index {score.pair_index} out of range for {cep_path.name} "
                     f"({len(record.qa_pairs)} pairs); emic/cep stages are out of sync."
                 )
+            pair_id = f"{scores.source_file_id}:{score.pair_index}"
+            if pair_id in seen_pair_ids:
+                raise ValueError(
+                    f"Duplicate pair_id {pair_id!r} while pooling {emic_path.name}; the "
+                    f"emic_prepass outputs likely contain a stale or duplicate file for this "
+                    f"source. Clean results/{pipeline_id}/emic_prepass/outputs/ and re-run."
+                )
+            seen_pair_ids.add(pair_id)
             pair = record.qa_pairs[score.pair_index]
             pool.append(
                 PoolEntry(
-                    pair_id=f"{scores.source_file_id}:{score.pair_index}",
+                    pair_id=pair_id,
                     source_file_id=scores.source_file_id,
                     pair_index=score.pair_index,
                     segment=pair.context,
@@ -118,6 +134,14 @@ def run_build_sample_batch(
                     emic_score=score.emic_score,
                 )
             )
+
+    if not pool:
+        raise ValueError(
+            f"No in-frame approved pairs found for {pipeline_id!r} "
+            f"({excluded_none} null-score, {sum(excluded_bloom.values())} out-of-frame-Bloom "
+            f"excluded). Check that `arandu judge-qa` + `arandu emic-prepass` ran and produced "
+            f"scored, in-frame ({', '.join(FRAME_BLOOM_LEVELS)}) pairs."
+        )
 
     population = population_by_cell(pool)
     pool_hash = _pool_sha256(pool)
@@ -142,7 +166,7 @@ def run_build_sample_batch(
         seed=seed,
         total_items=len(items),
         per_cell=per_cell,
-        cell_counts=_count_by_cell(items),
+        cell_counts=dict.fromkeys(all_cell_ids(), per_cell),
         population_by_cell=population,
         excluded_none_score=excluded_none,
         excluded_bloom=excluded_bloom,
@@ -170,11 +194,3 @@ def _write_sample(path: Path, items: list[SampleItem]) -> None:
         for item in items:
             fh.write(item.model_dump_json())
             fh.write("\n")
-
-
-def _count_by_cell(items: list[SampleItem]) -> dict[str, int]:
-    """Tally selected items per cell id."""
-    counts: dict[str, int] = {}
-    for item in items:
-        counts[item.cell_id] = counts.get(item.cell_id, 0) + 1
-    return counts

--- a/src/arandu/shared/human_eval/batch.py
+++ b/src/arandu/shared/human_eval/batch.py
@@ -1,0 +1,180 @@
+"""Batch orchestrator for ``arandu build-human-eval-sample`` (spec §5).
+
+Builds the in-frame pool from the emic pre-pass outputs (dropping null-score
+and out-of-frame-Bloom pairs), joins each pair's CEP payload (segment +
+question + answer), runs the deterministic stratified sampler, and persists the
+80-pair sample + a provenance manifest under
+``results/<id>/human_eval/outputs/``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from typing import TYPE_CHECKING
+
+from arandu.qa.schemas import QARecordCEP
+from arandu.shared.config import ResultsConfig
+from arandu.shared.emic.schemas import EmicSourceScores
+from arandu.shared.human_eval.sampling import (
+    FRAME_BLOOM_LEVELS,
+    PER_CELL,
+    PoolEntry,
+    build_sample,
+    population_by_cell,
+)
+from arandu.shared.human_eval.schemas import HumanEvalSampleConfig, SampleItem, SampleManifest
+from arandu.shared.results_manager import ResultsManager
+from arandu.shared.schemas import PipelineType
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+SAMPLE_FILENAME = "sample.jsonl"
+MANIFEST_FILENAME = "sample_manifest.json"
+
+
+def _pool_sha256(pool: list[PoolEntry]) -> str:
+    """Hash the in-frame pool (sorted by key) for reproducibility provenance."""
+    lines = sorted(f"{e.pair_id}|{e.bloom_level}|{e.emic_score}" for e in pool)
+    return hashlib.sha256("\n".join(lines).encode("utf-8")).hexdigest()
+
+
+def run_build_sample_batch(
+    pipeline_id: str,
+    *,
+    seed: int,
+    base_dir: Path | None = None,
+    per_cell: int = PER_CELL,
+) -> SampleManifest:
+    """Build the stratified human-comparison sample for ``pipeline_id``.
+
+    Args:
+        pipeline_id: Run identifier. Both the ``emic_prepass`` and ``cep``
+            stages must be populated.
+        seed: RNG seed for the deterministic selection (recorded in the run
+            metadata and the manifest).
+        base_dir: Override the project ``results/`` root.
+        per_cell: Pairs to draw per cell (default 10 -> 80 total).
+
+    Returns:
+        The :class:`SampleManifest` describing the build.
+
+    Raises:
+        FileNotFoundError: If the emic_prepass or cep stage outputs are absent.
+        ValueError: If a stratification cell has fewer than ``per_cell`` pairs,
+            or a referenced CEP pair cannot be resolved.
+    """
+    base = base_dir if base_dir is not None else ResultsConfig().base_dir
+    emic_outputs = base / pipeline_id / "emic_prepass" / "outputs"
+    cep_outputs = base / pipeline_id / "cep" / "outputs"
+    if not emic_outputs.exists():
+        raise FileNotFoundError(
+            f"Emic pre-pass outputs not found for pipeline_id {pipeline_id!r}: {emic_outputs}. "
+            f"Run `arandu emic-prepass --id {pipeline_id}` first."
+        )
+    if not cep_outputs.exists():
+        raise FileNotFoundError(
+            f"CEP outputs not found for pipeline_id {pipeline_id!r}: {cep_outputs}. "
+            f"The sample payload (segment/question/answer) is joined from the CEP records."
+        )
+
+    pool: list[PoolEntry] = []
+    excluded_none = 0
+    excluded_bloom: dict[str, int] = {}
+    for emic_path in sorted(emic_outputs.glob("*_cep_qa.json")):
+        scores = EmicSourceScores.load(emic_path)
+        cep_path = cep_outputs / emic_path.name
+        if not cep_path.exists():
+            raise ValueError(
+                f"Emic scores reference {emic_path.name} but the matching CEP record "
+                f"{cep_path} is missing; cannot build the annotation payload."
+            )
+        record = QARecordCEP.load(cep_path)
+        for score in scores.scores:
+            if score.emic_score is None:
+                excluded_none += 1
+                continue
+            if score.bloom_level not in FRAME_BLOOM_LEVELS:
+                excluded_bloom[score.bloom_level] = excluded_bloom.get(score.bloom_level, 0) + 1
+                continue
+            if score.pair_index >= len(record.qa_pairs):
+                raise ValueError(
+                    f"pair_index {score.pair_index} out of range for {cep_path.name} "
+                    f"({len(record.qa_pairs)} pairs); emic/cep stages are out of sync."
+                )
+            pair = record.qa_pairs[score.pair_index]
+            pool.append(
+                PoolEntry(
+                    pair_id=f"{scores.source_file_id}:{score.pair_index}",
+                    source_file_id=scores.source_file_id,
+                    pair_index=score.pair_index,
+                    segment=pair.context,
+                    question=pair.question,
+                    answer=pair.answer,
+                    bloom_level=score.bloom_level,
+                    emic_score=score.emic_score,
+                )
+            )
+
+    population = population_by_cell(pool)
+    pool_hash = _pool_sha256(pool)
+
+    results_mgr = ResultsManager(base, PipelineType.HUMAN_EVAL, pipeline_id=pipeline_id)
+    results_mgr.create_run(
+        HumanEvalSampleConfig(seed=seed, per_cell=per_cell),
+        input_source=str(emic_outputs),
+    )
+
+    # build_sample may raise InsufficientCellError (a ValueError); let it
+    # propagate after marking the run failed so the metadata reflects reality.
+    try:
+        items = build_sample(pool, seed=seed, per_cell=per_cell)
+    except ValueError:
+        results_mgr.complete_run(success=False, error="insufficient pairs in a cell")
+        raise
+
+    _write_sample(results_mgr.outputs_dir / SAMPLE_FILENAME, items)
+    manifest = SampleManifest(
+        pipeline_id=pipeline_id,
+        seed=seed,
+        total_items=len(items),
+        per_cell=per_cell,
+        cell_counts=_count_by_cell(items),
+        population_by_cell=population,
+        excluded_none_score=excluded_none,
+        excluded_bloom=excluded_bloom,
+        pool_sha256=pool_hash,
+    )
+    manifest.save(results_mgr.outputs_dir / MANIFEST_FILENAME)
+
+    results_mgr.update_progress(len(items), 0, len(items))
+    results_mgr.complete_run(success=True)
+
+    logger.info(
+        "Built human-eval sample: %d items across %d cells (pool=%d, excluded none=%d, bloom=%d).",
+        len(items),
+        len(manifest.cell_counts),
+        len(pool),
+        excluded_none,
+        sum(excluded_bloom.values()),
+    )
+    return manifest
+
+
+def _write_sample(path: Path, items: list[SampleItem]) -> None:
+    """Write the sample as JSONL (one :class:`SampleItem` per line)."""
+    with path.open("w", encoding="utf-8") as fh:
+        for item in items:
+            fh.write(item.model_dump_json())
+            fh.write("\n")
+
+
+def _count_by_cell(items: list[SampleItem]) -> dict[str, int]:
+    """Tally selected items per cell id."""
+    counts: dict[str, int] = {}
+    for item in items:
+        counts[item.cell_id] = counts.get(item.cell_id, 0) + 1
+    return counts

--- a/src/arandu/shared/human_eval/sampling.py
+++ b/src/arandu/shared/human_eval/sampling.py
@@ -1,0 +1,135 @@
+"""Deterministic stratified sampler for the human-comparison study (spec §5).
+
+Pure selection logic with no I/O: given an in-frame pool of approved pairs
+(each carrying its emic pre-pass ordinal score and annotation payload), build
+the 80-pair sample stratified as 4 Bloom levels x 2 emic bands x 10 pairs.
+Frame construction (dropping null-score and out-of-frame-Bloom pairs, joining
+the CEP payload) happens upstream in ``batch.py``.
+"""
+
+from __future__ import annotations
+
+import random
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, Field
+
+from arandu.shared.human_eval.schemas import SampleItem
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+# The four Bloom levels the agreement study stratifies over (spec §5). The CEP
+# generator can also emit ``apply`` / ``create``; those are out-of-frame and
+# dropped during pool construction (see batch.py).
+FRAME_BLOOM_LEVELS: tuple[str, ...] = ("remember", "understand", "analyze", "evaluate")
+BANDS: tuple[str, ...] = ("duvidosa", "limpa")
+PER_CELL: int = 10
+DUBIOUS_MAX_SCORE: int = 3  # emic_score <= 3 -> duvidosa; >= 4 -> limpa
+
+
+class PoolEntry(BaseModel):
+    """One in-frame approved pair eligible for sampling.
+
+    Attributes:
+        pair_id: Stable key ``"{source_file_id}:{pair_index}"``.
+        source_file_id: Source interview id.
+        pair_index: Index into the source ``QARecordCEP.qa_pairs``.
+        segment: Source transcript segment (annotation payload).
+        question: The generated question.
+        answer: The generated answer.
+        bloom_level: Bloom level; must be one of :data:`FRAME_BLOOM_LEVELS`.
+        emic_score: Ordinal emic score {1..5} (banding key; never None here).
+    """
+
+    pair_id: str
+    source_file_id: str
+    pair_index: int = Field(..., ge=0)
+    segment: str
+    question: str
+    answer: str
+    bloom_level: str
+    emic_score: int = Field(..., ge=1, le=5)
+
+
+def band_for(emic_score: int) -> str:
+    """Return the emic band for an ordinal score (``duvidosa`` <=3, ``limpa`` >=4)."""
+    return "duvidosa" if emic_score <= DUBIOUS_MAX_SCORE else "limpa"
+
+
+def cell_id_for(bloom_level: str, band: str) -> str:
+    """Return the ``"{bloom_level}:{band}"`` cell key."""
+    return f"{bloom_level}:{band}"
+
+
+def all_cell_ids() -> list[str]:
+    """Return the 8 cell ids in a stable order (Bloom x band)."""
+    return [cell_id_for(bloom, band) for bloom in FRAME_BLOOM_LEVELS for band in BANDS]
+
+
+def population_by_cell(pool: Iterable[PoolEntry]) -> dict[str, int]:
+    """Count in-frame pool entries per cell (all 8 cells present, zero-filled)."""
+    counts = dict.fromkeys(all_cell_ids(), 0)
+    for entry in pool:
+        counts[cell_id_for(entry.bloom_level, band_for(entry.emic_score))] += 1
+    return counts
+
+
+class InsufficientCellError(ValueError):
+    """Raised when a stratification cell has fewer than ``PER_CELL`` pairs."""
+
+
+def build_sample(pool: list[PoolEntry], seed: int, *, per_cell: int = PER_CELL) -> list[SampleItem]:
+    """Build the stratified sample deterministically.
+
+    Bands each pool entry, groups into the 8 cells (4 Bloom x 2 bands), and
+    draws exactly ``per_cell`` from each with a seeded RNG. The pool is sorted
+    by ``pair_id`` first, so the result is independent of input/file order:
+    same seed + same pool always yields the same sample. ``duvidosa`` is thus
+    over-sampled to 50/50 against ``limpa`` regardless of population skew.
+
+    Args:
+        pool: In-frame approved pairs (Bloom in :data:`FRAME_BLOOM_LEVELS`,
+            non-null score). Frame filtering is the caller's responsibility.
+        seed: RNG seed; recorded in the manifest for reproducibility.
+        per_cell: Pairs to draw per cell (default 10 -> 80 total).
+
+    Returns:
+        ``8 * per_cell`` :class:`SampleItem` objects, grouped by cell in
+        :func:`all_cell_ids` order with ``slot_id`` 0..per_cell-1 per cell.
+
+    Raises:
+        InsufficientCellError: If any cell has fewer than ``per_cell`` entries;
+            the message names the cell, its available count, and remediation.
+    """
+    by_cell: dict[str, list[PoolEntry]] = {cid: [] for cid in all_cell_ids()}
+    for entry in pool:
+        by_cell[cell_id_for(entry.bloom_level, band_for(entry.emic_score))].append(entry)
+
+    rng = random.Random(seed)
+    items: list[SampleItem] = []
+    for cell_id in all_cell_ids():
+        entries = sorted(by_cell[cell_id], key=lambda e: e.pair_id)
+        if len(entries) < per_cell:
+            raise InsufficientCellError(
+                f"Cell {cell_id!r} has only {len(entries)} approved pair(s) but {per_cell} "
+                f"are required. Remediate by approving more pairs (larger CEP/judge pool) "
+                f"or revisiting the emic bands; cells are never back-filled from other cells."
+            )
+        chosen = rng.sample(entries, per_cell)
+        for slot_id, entry in enumerate(chosen):
+            items.append(
+                SampleItem(
+                    pair_id=entry.pair_id,
+                    source_file_id=entry.source_file_id,
+                    pair_index=entry.pair_index,
+                    segment=entry.segment,
+                    question=entry.question,
+                    answer=entry.answer,
+                    bloom_level=entry.bloom_level,
+                    emic_prepass_score=entry.emic_score,
+                    cell_id=cell_id,
+                    slot_id=slot_id,
+                )
+            )
+    return items

--- a/src/arandu/shared/human_eval/sampling.py
+++ b/src/arandu/shared/human_eval/sampling.py
@@ -9,7 +9,7 @@ the CEP payload) happens upstream in ``batch.py``.
 
 from __future__ import annotations
 
-import random
+import hashlib
 from typing import TYPE_CHECKING
 
 from pydantic import BaseModel, Field
@@ -79,24 +79,39 @@ class InsufficientCellError(ValueError):
     """Raised when a stratification cell has fewer than ``PER_CELL`` pairs."""
 
 
+def _selection_key(seed: int, pair_id: str) -> str:
+    """Return the seeded selection key for a pair.
+
+    A SHA-256 of ``"{seed}:{pair_id}"`` gives a uniform pseudo-random ordering
+    keyed by the seed. Unlike :func:`random.sample`, this is stable across
+    Python versions/platforms and depends only on the pair itself (not on other
+    cells' sizes or iteration order), so reproducibility is airtight.
+    """
+    return hashlib.sha256(f"{seed}:{pair_id}".encode()).hexdigest()
+
+
 def build_sample(pool: list[PoolEntry], seed: int, *, per_cell: int = PER_CELL) -> list[SampleItem]:
     """Build the stratified sample deterministically.
 
     Bands each pool entry, groups into the 8 cells (4 Bloom x 2 bands), and
-    draws exactly ``per_cell`` from each with a seeded RNG. The pool is sorted
-    by ``pair_id`` first, so the result is independent of input/file order:
-    same seed + same pool always yields the same sample. ``duvidosa`` is thus
-    over-sampled to 50/50 against ``limpa`` regardless of population skew.
+    deterministically draws ``per_cell`` from each by ordering the cell's
+    entries on a seeded SHA-256 key (:func:`_selection_key`) and taking the
+    first ``per_cell``. The ordering depends only on the seed and each pair's
+    id, so the result is independent of input/file order AND of other cells'
+    sizes, and is stable across Python versions: same seed + same pool always
+    yields the same sample. ``duvidosa`` is over-sampled to 50/50 against
+    ``limpa`` regardless of population skew.
 
     Args:
         pool: In-frame approved pairs (Bloom in :data:`FRAME_BLOOM_LEVELS`,
             non-null score). Frame filtering is the caller's responsibility.
-        seed: RNG seed; recorded in the manifest for reproducibility.
+        seed: Selection seed; recorded in the manifest for reproducibility.
         per_cell: Pairs to draw per cell (default 10 -> 80 total).
 
     Returns:
         ``8 * per_cell`` :class:`SampleItem` objects, grouped by cell in
-        :func:`all_cell_ids` order with ``slot_id`` 0..per_cell-1 per cell.
+        :func:`all_cell_ids` order with ``slot_id`` 0..per_cell-1 per cell
+        (slot order is the deterministic selection-key rank).
 
     Raises:
         InsufficientCellError: If any cell has fewer than ``per_cell`` entries;
@@ -106,18 +121,19 @@ def build_sample(pool: list[PoolEntry], seed: int, *, per_cell: int = PER_CELL) 
     for entry in pool:
         by_cell[cell_id_for(entry.bloom_level, band_for(entry.emic_score))].append(entry)
 
-    rng = random.Random(seed)
     items: list[SampleItem] = []
     for cell_id in all_cell_ids():
-        entries = sorted(by_cell[cell_id], key=lambda e: e.pair_id)
+        entries = by_cell[cell_id]
         if len(entries) < per_cell:
             raise InsufficientCellError(
                 f"Cell {cell_id!r} has only {len(entries)} approved pair(s) but {per_cell} "
                 f"are required. Remediate by approving more pairs (larger CEP/judge pool) "
                 f"or revisiting the emic bands; cells are never back-filled from other cells."
             )
-        chosen = rng.sample(entries, per_cell)
-        for slot_id, entry in enumerate(chosen):
+        # pair_id is the tiebreaker so the order is total even on a (vanishingly
+        # unlikely) key collision.
+        ordered = sorted(entries, key=lambda e: (_selection_key(seed, e.pair_id), e.pair_id))
+        for slot_id, entry in enumerate(ordered[:per_cell]):
             items.append(
                 SampleItem(
                     pair_id=entry.pair_id,

--- a/src/arandu/shared/human_eval/schemas.py
+++ b/src/arandu/shared/human_eval/schemas.py
@@ -1,0 +1,90 @@
+"""Schemas for the stratified human-comparison sample (spec §5)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pydantic import BaseModel, Field
+
+
+class HumanEvalSampleConfig(BaseModel):
+    """Config snapshotted into ``run_metadata.json`` for a sample build.
+
+    Attributes:
+        seed: RNG seed driving the deterministic selection.
+        per_cell: Pairs drawn per stratification cell.
+    """
+
+    seed: int
+    per_cell: int
+
+
+class SampleItem(BaseModel):
+    """One pair selected into the 80-pair human-comparison sample.
+
+    Carries the blinded annotation payload (segment + question + answer) plus
+    the stratification bookkeeping. Deliberately excludes ``tacit_inference``
+    and the canonical judge scores; further blinding (hiding ``bloom_level`` /
+    ``emic_prepass_score`` from the annotator) is the annotation instrument's
+    responsibility, not this artifact's.
+
+    Attributes:
+        pair_id: Stable canonical key ``"{source_file_id}:{pair_index}"``.
+        source_file_id: Source interview id (joins back to the CEP record).
+        pair_index: Index into the source ``QARecordCEP.qa_pairs``.
+        segment: Source transcript segment the QA pair was generated from.
+        question: The generated question.
+        answer: The generated answer.
+        bloom_level: Bloom level (stratification dimension).
+        emic_prepass_score: Ordinal emic band hint {1..5} from the pre-pass.
+        cell_id: ``"{bloom_level}:{band}"`` stratification cell.
+        slot_id: 0-based slot within the cell (0..9).
+    """
+
+    pair_id: str
+    source_file_id: str
+    pair_index: int = Field(..., ge=0)
+    segment: str
+    question: str
+    answer: str
+    bloom_level: str
+    emic_prepass_score: int = Field(..., ge=1, le=5)
+    cell_id: str
+    slot_id: int = Field(..., ge=0)
+
+
+class SampleManifest(BaseModel):
+    """Provenance + reproducibility record for a built sample.
+
+    Attributes:
+        pipeline_id: Run identifier.
+        seed: RNG seed (makes the selection reproducible).
+        total_items: Number of items in the sample (8 cells x per_cell).
+        per_cell: Target pairs per cell.
+        cell_counts: Selected count per ``cell_id`` (each equals ``per_cell``).
+        population_by_cell: In-frame available count per ``cell_id`` (the pool
+            each cell was sampled from).
+        excluded_none_score: Approved pairs dropped for a null emic score.
+        excluded_bloom: Approved pairs dropped per out-of-frame Bloom level
+            (``apply`` / ``create``), keyed by level.
+        pool_sha256: Hash of the in-frame pool keys + scores (provenance).
+    """
+
+    pipeline_id: str
+    seed: int
+    total_items: int
+    per_cell: int
+    cell_counts: dict[str, int]
+    population_by_cell: dict[str, int]
+    excluded_none_score: int = 0
+    excluded_bloom: dict[str, int] = Field(default_factory=dict)
+    pool_sha256: str
+
+    def save(self, path: str | Path) -> None:
+        """Write the manifest to JSON."""
+        Path(path).write_text(self.model_dump_json(indent=2), encoding="utf-8")
+
+    @classmethod
+    def load(cls, path: str | Path) -> SampleManifest:
+        """Load a manifest from JSON."""
+        return cls.model_validate_json(Path(path).read_text(encoding="utf-8"))

--- a/src/arandu/shared/schemas.py
+++ b/src/arandu/shared/schemas.py
@@ -201,6 +201,7 @@ class PipelineType(StrEnum):
     ANALYSIS = "analysis"
     NON_ANSWERABLE = "non_answerable"
     EMIC_PREPASS = "emic_prepass"
+    HUMAN_EVAL = "human_eval"
     EVALUATION = "evaluation"
 
 

--- a/tests/shared/human_eval/test_batch.py
+++ b/tests/shared/human_eval/test_batch.py
@@ -1,0 +1,160 @@
+"""Tests for the human-eval sample batch (spec §5)."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from arandu.qa.schemas import QAPairCEP, QARecordCEP
+from arandu.shared.emic.schemas import EmicScore, EmicSourceScores
+from arandu.shared.human_eval.batch import run_build_sample_batch
+from arandu.shared.human_eval.schemas import SampleItem, SampleManifest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+FRAME = ("remember", "understand", "analyze", "evaluate")
+
+
+def _frame_specs(per_cell: int) -> list[tuple[str, int | None]]:
+    """``per_cell`` duvidosa (score 2) + ``per_cell`` limpa (score 5) for each Bloom."""
+    specs: list[tuple[str, int | None]] = []
+    for bloom in FRAME:
+        specs += [(bloom, 2)] * per_cell
+        specs += [(bloom, 5)] * per_cell
+    return specs
+
+
+def _write_source(
+    base: Path, pipeline_id: str, source_id: str, specs: list[tuple[str, int | None]]
+) -> None:
+    cep_outputs = base / pipeline_id / "cep" / "outputs"
+    emic_outputs = base / pipeline_id / "emic_prepass" / "outputs"
+    cep_outputs.mkdir(parents=True, exist_ok=True)
+    emic_outputs.mkdir(parents=True, exist_ok=True)
+
+    pairs = [
+        QAPairCEP(
+            question=f"q{i}",
+            answer=f"a{i}",
+            context=f"segment {i}",
+            question_type="conceptual",
+            confidence=0.9,
+            bloom_level=bloom,
+        )
+        for i, (bloom, _score) in enumerate(specs)
+    ]
+    QARecordCEP(
+        source_gdrive_id=source_id,
+        source_filename=f"{source_id}.mp4",
+        transcription_text="t",
+        qa_pairs=pairs,
+        model_id="m",
+        provider="ollama",
+        total_pairs=len(pairs),
+    ).save(cep_outputs / f"{source_id}_cep_qa.json")
+
+    scores = [
+        EmicScore(pair_index=i, bloom_level=bloom, emic_score=score, rationale="r")
+        for i, (bloom, score) in enumerate(specs)
+    ]
+    EmicSourceScores(
+        source_file_id=source_id, source_filename=f"{source_id}.mp4", scores=scores
+    ).save(emic_outputs / f"{source_id}_cep_qa.json")
+
+
+def _load_sample(base: Path, pipeline_id: str) -> list[SampleItem]:
+    path = base / pipeline_id / "human_eval" / "outputs" / "sample.jsonl"
+    return [SampleItem.model_validate_json(line) for line in path.read_text().splitlines()]
+
+
+class TestRunBuildSampleBatch:
+    def test_happy_path_counts_and_manifest(self, tmp_path: Path) -> None:
+        _write_source(tmp_path, "run1", "s1", _frame_specs(2))
+
+        manifest = run_build_sample_batch("run1", seed=42, base_dir=tmp_path, per_cell=2)
+
+        assert manifest.total_items == 16  # 8 cells x 2
+        assert len(manifest.cell_counts) == 8
+        assert all(c == 2 for c in manifest.cell_counts.values())
+        assert manifest.seed == 42
+        assert manifest.pool_sha256  # provenance recorded
+
+        sample = _load_sample(tmp_path, "run1")
+        assert len(sample) == 16
+        # run finalized as COMPLETED
+        meta = json.loads(
+            (tmp_path / "run1" / "human_eval" / "run_metadata.json").read_text(encoding="utf-8")
+        )
+        assert meta["status"] == "completed"
+
+    def test_excludes_out_of_frame_bloom_and_null_score(self, tmp_path: Path) -> None:
+        specs = [*_frame_specs(2), ("apply", 5), ("create", 2), ("remember", None)]
+        _write_source(tmp_path, "run2", "s1", specs)
+
+        manifest = run_build_sample_batch("run2", seed=1, base_dir=tmp_path, per_cell=2)
+
+        assert manifest.total_items == 16  # exclusions don't change the sample size
+        assert manifest.excluded_none_score == 1
+        assert manifest.excluded_bloom == {"apply": 1, "create": 1}
+
+    def test_payload_is_blinded(self, tmp_path: Path) -> None:
+        _write_source(tmp_path, "run3", "s1", _frame_specs(2))
+        run_build_sample_batch("run3", seed=1, base_dir=tmp_path, per_cell=2)
+        item = _load_sample(tmp_path, "run3")[0]
+        assert item.segment and item.question and item.answer  # payload present
+        assert item.pair_id == f"{item.source_file_id}:{item.pair_index}"
+        # SampleItem deliberately carries no tacit_inference / canonical scores
+        dumped = item.model_dump()
+        assert "tacit_inference" not in dumped
+        assert "weighted_score" not in dumped
+
+    def test_insufficient_cell_raises_and_marks_failed(self, tmp_path: Path) -> None:
+        # remember:limpa gets only 1 limpa pair while per_cell=2.
+        specs = _frame_specs(2)
+        specs.remove(("remember", 5))  # drop one of the two remember-limpa pairs
+        _write_source(tmp_path, "run4", "s1", specs)
+
+        with pytest.raises(ValueError, match="remember:limpa"):
+            run_build_sample_batch("run4", seed=1, base_dir=tmp_path, per_cell=2)
+
+        meta = json.loads(
+            (tmp_path / "run4" / "human_eval" / "run_metadata.json").read_text(encoding="utf-8")
+        )
+        assert meta["status"] == "failed"
+
+    def test_reproducible_across_runs(self, tmp_path: Path) -> None:
+        _write_source(tmp_path, "run5", "s1", _frame_specs(5))  # slack so selection is non-trivial
+        run_build_sample_batch("run5", seed=7, base_dir=tmp_path, per_cell=2)
+        first = [(i.pair_id, i.cell_id, i.slot_id) for i in _load_sample(tmp_path, "run5")]
+        run_build_sample_batch("run5", seed=7, base_dir=tmp_path, per_cell=2)
+        second = [(i.pair_id, i.cell_id, i.slot_id) for i in _load_sample(tmp_path, "run5")]
+        assert first == second
+
+    def test_missing_emic_stage_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError, match="Emic pre-pass outputs not found"):
+            run_build_sample_batch("absent", seed=1, base_dir=tmp_path, per_cell=2)
+
+    def test_missing_cep_stage_raises(self, tmp_path: Path) -> None:
+        # emic outputs present, cep dir absent.
+        emic_outputs = tmp_path / "run6" / "emic_prepass" / "outputs"
+        emic_outputs.mkdir(parents=True)
+        EmicSourceScores(
+            source_file_id="s1",
+            source_filename="s1.mp4",
+            scores=[EmicScore(pair_index=0, bloom_level="remember", emic_score=2, rationale="r")],
+        ).save(emic_outputs / "s1_cep_qa.json")
+
+        with pytest.raises(FileNotFoundError, match="CEP outputs not found"):
+            run_build_sample_batch("run6", seed=1, base_dir=tmp_path, per_cell=2)
+
+    def test_manifest_roundtrips(self, tmp_path: Path) -> None:
+        _write_source(tmp_path, "run7", "s1", _frame_specs(2))
+        run_build_sample_batch("run7", seed=3, base_dir=tmp_path, per_cell=2)
+        manifest = SampleManifest.load(
+            tmp_path / "run7" / "human_eval" / "outputs" / "sample_manifest.json"
+        )
+        assert manifest.seed == 3
+        assert sum(manifest.cell_counts.values()) == 16

--- a/tests/shared/human_eval/test_batch.py
+++ b/tests/shared/human_eval/test_batch.py
@@ -150,6 +150,63 @@ class TestRunBuildSampleBatch:
         with pytest.raises(FileNotFoundError, match="CEP outputs not found"):
             run_build_sample_batch("run6", seed=1, base_dir=tmp_path, per_cell=2)
 
+    def test_empty_pool_raises_cause_specific(self, tmp_path: Path) -> None:
+        # All approved pairs are out-of-frame Bloom or null-score -> empty frame.
+        _write_source(tmp_path, "run8", "s1", [("apply", 5), ("create", 2), ("remember", None)])
+        with pytest.raises(ValueError, match="No in-frame approved pairs"):
+            run_build_sample_batch("run8", seed=1, base_dir=tmp_path, per_cell=2)
+
+    def test_duplicate_pair_id_raises(self, tmp_path: Path) -> None:
+        # Two emic files whose EmicSourceScores share the same source_file_id +
+        # pair_index collide on pair_id (e.g. a stale duplicate emic output).
+        emic_outputs = tmp_path / "run9" / "emic_prepass" / "outputs"
+        cep_outputs = tmp_path / "run9" / "cep" / "outputs"
+        emic_outputs.mkdir(parents=True)
+        cep_outputs.mkdir(parents=True)
+        for name in ("a", "b"):
+            QARecordCEP(
+                source_gdrive_id="dup",
+                source_filename="dup.mp4",
+                transcription_text="t",
+                qa_pairs=[
+                    QAPairCEP(
+                        question="q",
+                        answer="a",
+                        context="seg",
+                        question_type="conceptual",
+                        confidence=0.9,
+                        bloom_level="remember",
+                    )
+                ],
+                model_id="m",
+                provider="ollama",
+                total_pairs=1,
+            ).save(cep_outputs / f"{name}_cep_qa.json")
+            EmicSourceScores(
+                source_file_id="dup",
+                source_filename="dup.mp4",
+                scores=[
+                    EmicScore(pair_index=0, bloom_level="remember", emic_score=2, rationale="r")
+                ],
+            ).save(emic_outputs / f"{name}_cep_qa.json")
+
+        with pytest.raises(ValueError, match="Duplicate pair_id"):
+            run_build_sample_batch("run9", seed=1, base_dir=tmp_path, per_cell=2)
+
+    def test_pool_hash_changes_when_payload_drifts(self, tmp_path: Path) -> None:
+        # Same pair ids/bloom/score but different CEP text -> different pool hash.
+        _write_source(tmp_path, "runA", "s1", _frame_specs(2))
+        h1 = run_build_sample_batch("runA", seed=1, base_dir=tmp_path, per_cell=2).pool_sha256
+        # Rewrite the CEP records with mutated payload text, same indices/blooms.
+        cep_outputs = tmp_path / "runA" / "cep" / "outputs"
+        for cep_file in cep_outputs.glob("*_cep_qa.json"):
+            rec = QARecordCEP.load(cep_file)
+            for p in rec.qa_pairs:
+                p.context = p.context + " (edited)"
+            rec.save(cep_file)
+        h2 = run_build_sample_batch("runA", seed=1, base_dir=tmp_path, per_cell=2).pool_sha256
+        assert h1 != h2
+
     def test_manifest_roundtrips(self, tmp_path: Path) -> None:
         _write_source(tmp_path, "run7", "s1", _frame_specs(2))
         run_build_sample_batch("run7", seed=3, base_dir=tmp_path, per_cell=2)

--- a/tests/shared/human_eval/test_sampling.py
+++ b/tests/shared/human_eval/test_sampling.py
@@ -1,0 +1,127 @@
+"""Tests for the pure stratified sampler (spec §5)."""
+
+from __future__ import annotations
+
+import pytest
+
+from arandu.shared.human_eval.sampling import (
+    BANDS,
+    FRAME_BLOOM_LEVELS,
+    InsufficientCellError,
+    PoolEntry,
+    band_for,
+    build_sample,
+)
+
+DUBIOUS_SCORE = 2
+CLEAN_SCORE = 5
+
+
+def _entry(idx: int, bloom: str, score: int) -> PoolEntry:
+    return PoolEntry(
+        pair_id=f"src:{idx}",
+        source_file_id="src",
+        pair_index=idx,
+        segment=f"segment {idx}",
+        question=f"q {idx}",
+        answer=f"a {idx}",
+        bloom_level=bloom,
+        emic_score=score,
+    )
+
+
+def _pool(per_cell_available: int) -> list[PoolEntry]:
+    """Build a pool with ``per_cell_available`` entries in each of the 8 cells."""
+    pool: list[PoolEntry] = []
+    idx = 0
+    for bloom in FRAME_BLOOM_LEVELS:
+        for score in (DUBIOUS_SCORE, CLEAN_SCORE):
+            for _ in range(per_cell_available):
+                pool.append(_entry(idx, bloom, score))
+                idx += 1
+    return pool
+
+
+class TestBandFor:
+    @pytest.mark.parametrize(
+        ("score", "band"),
+        [(1, "duvidosa"), (3, "duvidosa"), (4, "limpa"), (5, "limpa")],
+    )
+    def test_boundary(self, score: int, band: str) -> None:
+        assert band_for(score) == band
+
+
+class TestBuildSample:
+    def test_stratification_exact_ten_per_cell(self) -> None:
+        sample = build_sample(_pool(15), seed=42)
+        assert len(sample) == 80  # 8 cells x 10
+        counts: dict[str, int] = {}
+        for item in sample:
+            counts[item.cell_id] = counts.get(item.cell_id, 0) + 1
+        assert len(counts) == 8
+        assert all(c == 10 for c in counts.values())
+        # 50/50 band balance regardless of (here equal) population
+        duvidosa = sum(1 for i in sample if i.cell_id.endswith("duvidosa"))
+        limpa = sum(1 for i in sample if i.cell_id.endswith("limpa"))
+        assert duvidosa == 40
+        assert limpa == 40
+
+    def test_slot_ids_zero_to_nine_per_cell(self) -> None:
+        sample = build_sample(_pool(15), seed=7)
+        by_cell: dict[str, list[int]] = {}
+        for item in sample:
+            by_cell.setdefault(item.cell_id, []).append(item.slot_id)
+        for slots in by_cell.values():
+            assert sorted(slots) == list(range(10))
+
+    def test_oversamples_dubious_against_skewed_population(self) -> None:
+        # Population skewed 20 limpa / 11 duvidosa per bloom, yet the sample is 50/50.
+        pool: list[PoolEntry] = []
+        idx = 0
+        for bloom in FRAME_BLOOM_LEVELS:
+            for _ in range(11):
+                pool.append(_entry(idx, bloom, DUBIOUS_SCORE))
+                idx += 1
+            for _ in range(20):
+                pool.append(_entry(idx, bloom, CLEAN_SCORE))
+                idx += 1
+        sample = build_sample(pool, seed=1)
+        assert sum(1 for i in sample if i.cell_id.endswith("duvidosa")) == 40
+        assert sum(1 for i in sample if i.cell_id.endswith("limpa")) == 40
+
+    def test_reproducible_same_seed_same_pool(self) -> None:
+        pool = _pool(15)
+        a = build_sample(pool, seed=99)
+        b = build_sample(pool, seed=99)
+        assert [(i.pair_id, i.cell_id, i.slot_id) for i in a] == [
+            (i.pair_id, i.cell_id, i.slot_id) for i in b
+        ]
+
+    def test_order_independent_reproducibility(self) -> None:
+        pool = _pool(15)
+        shuffled = list(reversed(pool))
+        a = build_sample(pool, seed=5)
+        b = build_sample(shuffled, seed=5)
+        # Selection is sorted by pair_id first, so input order cannot change it.
+        assert {i.pair_id for i in a} == {i.pair_id for i in b}
+
+    def test_different_seed_selects_different_pairs(self) -> None:
+        pool = _pool(30)  # plenty of slack so two seeds almost surely differ
+        a = {i.pair_id for i in build_sample(pool, seed=1)}
+        b = {i.pair_id for i in build_sample(pool, seed=2)}
+        assert a != b
+
+    def test_insufficient_cell_raises_named_error(self) -> None:
+        pool = _pool(15)
+        # Drop one cell (analyze:limpa) down to 9 available.
+        pool = [
+            p
+            for p in pool
+            if not (p.bloom_level == "analyze" and band_for(p.emic_score) == "limpa")
+        ]
+        pool += [_entry(900 + k, "analyze", CLEAN_SCORE) for k in range(9)]
+        with pytest.raises(InsufficientCellError, match="analyze:limpa"):
+            build_sample(pool, seed=1)
+
+    def test_bands_constant_is_two(self) -> None:
+        assert BANDS == ("duvidosa", "limpa")

--- a/tests/shared/human_eval/test_sampling.py
+++ b/tests/shared/human_eval/test_sampling.py
@@ -125,3 +125,17 @@ class TestBuildSample:
 
     def test_bands_constant_is_two(self) -> None:
         assert BANDS == ("duvidosa", "limpa")
+
+    def test_cell_selection_independent_of_other_cells(self) -> None:
+        # Per-cell deterministic selection: changing one cell's population must
+        # not perturb the selection of an unrelated cell (guards against the
+        # shared-RNG cross-cell coupling).
+        base = _pool(15)
+        extra = [_entry(1000 + k, "remember", DUBIOUS_SCORE) for k in range(20)]
+        a = {i.pair_id for i in build_sample(base, seed=3) if i.cell_id == "evaluate:limpa"}
+        b = {
+            i.pair_id
+            for i in build_sample([*base, *extra], seed=3)
+            if i.cell_id == "evaluate:limpa"
+        }
+        assert a == b

--- a/tests/shared/test_results_manager.py
+++ b/tests/shared/test_results_manager.py
@@ -782,6 +782,7 @@ class TestPipelineType:
             "analysis",
             "non_answerable",
             "emic_prepass",
+            "human_eval",
             "evaluation",
         }
         actual = {p.value for p in PipelineType}


### PR DESCRIPTION
## What

`arandu build-human-eval-sample --id <id> --seed <int>` — the deterministic builder for the 80-pair human-comparison (inter-rater agreement) sample, spec §5. Unblocked by the merged emic pre-pass (#123).

Pools the canonical-approved pairs scored by `emic-prepass`, bands each by emic validity (`duvidosa ≤3` / `limpa ≥4`), and draws **10 pairs from each of 8 cells** (4 Bloom × 2 bands), over-sampling `duvidosa` to 50/50 regardless of population skew.

## Structure (mirrors `shared/emic/`)

- **`shared/human_eval/sampling.py`** — pure `build_sample(pool, seed)`. Pool sorted by `pair_id` first, so the result is independent of file/glob order: same seed + pool → same sample. `InsufficientCellError` names a deficient cell + remediation; cells are never back-filled.
- **`shared/human_eval/batch.py`** — builds the in-frame pool from `emic_prepass` outputs (drops null-score + out-of-frame-Bloom pairs, counted in the manifest), joins each pair's CEP payload (`segment`/`question`/`answer`), and persists `sample.jsonl` + `sample_manifest.json` (seed, per-cell counts, population, exclusions, pool sha256) via `ResultsManager`; run finalized `COMPLETED`/`FAILED`.
- `PipelineType.HUMAN_EVAL`; `cli/human_eval.py` wired into `app`.

## Decisions flagged for review

- **Bloom frame = `{remember, understand, analyze, evaluate}`** per spec §5's 8 cells. The CEP generator also emits `apply`/`create`; those approved pairs are **excluded from the frame** (logged in the manifest's `excluded_bloom`). *(Confirmed in brainstorming.)*
- **`pair_id = "{source_file_id}:{pair_index}"`** — no stable id exists on `QAPairCEP`. Readable + joinable back to the CEP record.
- **`SampleItem` uses English field names** (`segment`/`question`/`answer`) matching the source `QAPair` fields + codebase convention. The spec text named PT fields (`segmento_origem`/`pergunta`/`resposta`); PT presentation + further blinding (hiding `bloom_level`/`emic_prepass_score`) is the **annotation-instrument** task's responsibility, not this internal artifact's. One-line rename if you'd rather the JSONL be PT.
- **No `--output` flag** — the path is owned by `ResultsManager` (`results/<id>/human_eval/outputs/`), consistent with every other Phase C/D CLI.

## Tests

20 new tests, LLM-free: pure-sampler (reproducibility, order-independence, exact 10/cell, 50/50 over-sampling, banding boundary, insufficient-cell error) + batch over fixtures (counts/manifest, exclusions, payload blinding, insufficient-cell → FAILED, missing-stage errors, manifest roundtrip). Full suite **1388 passed** (pre-existing `plotly`/`sentence_transformers` optional-dep collection gaps excluded, identical on `main`).

## Note

Lands the code; a real run needs `test-kg-04` to have `emic_prepass` outputs (separate smoke-run step). **Unblocks `annotation-instrument`** (consumes `sample.jsonl`).
