### PR TITLE
fix(rag): finish the mini-dry-run follow-up bugs (#5, #6, #7, #4)

### DIFF
--- a/src/arandu/kg/atlas_backend.py
+++ b/src/arandu/kg/atlas_backend.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
 
 from arandu.kg.schemas import KGConstructionResult
 from arandu.shared.llm_client import create_llm_client
+from arandu.shared.llm_settings import REASONING_MODEL_MAX_TOKENS
 from arandu.utils.paths import get_project_root
 
 logger = logging.getLogger(__name__)
@@ -100,13 +101,13 @@ ATLAS_DEFAULTS: dict[str, Any] = {
     "batch_size_triple": 3,
     "batch_size_concept": 16,
     "chunk_size": 8192,
-    # 8192 (not atlas-rag's own 2048 default): triple/concept extraction runs
-    # through reasoning models (qwen3:14b, gemini-2.5-flash) whose thinking
-    # tokens count against this budget, so 2048 truncates the JSON mid-output.
-    # The dry-run (2026-06-08) had to pre-empt this with
-    # `--backend-option max_new_tokens=8192`; making it the default removes
-    # that footgun. Mirrors the judge/answerer reasoning-model headroom.
-    "max_new_tokens": 8192,
+    # Not atlas-rag's own 2048 default: triple/concept extraction runs through
+    # reasoning models (qwen3:14b, gemini-2.5-flash) whose thinking tokens count
+    # against this budget, so 2048 truncates the JSON mid-output. The dry-run
+    # (2026-06-08) had to pre-empt this with `--backend-option
+    # max_new_tokens=8192`; making it the default removes that footgun. Uses the
+    # shared REASONING_MODEL_MAX_TOKENS so it tracks the judge/answerer headroom.
+    "max_new_tokens": REASONING_MODEL_MAX_TOKENS,
     "include_concept": True,
     "max_workers": 3,
 }

--- a/src/arandu/kg/atlas_backend.py
+++ b/src/arandu/kg/atlas_backend.py
@@ -100,7 +100,13 @@ ATLAS_DEFAULTS: dict[str, Any] = {
     "batch_size_triple": 3,
     "batch_size_concept": 16,
     "chunk_size": 8192,
-    "max_new_tokens": 2048,
+    # 8192 (not atlas-rag's own 2048 default): triple/concept extraction runs
+    # through reasoning models (qwen3:14b, gemini-2.5-flash) whose thinking
+    # tokens count against this budget, so 2048 truncates the JSON mid-output.
+    # The dry-run (2026-06-08) had to pre-empt this with
+    # `--backend-option max_new_tokens=8192`; making it the default removes
+    # that footgun. Mirrors the judge/answerer reasoning-model headroom.
+    "max_new_tokens": 8192,
     "include_concept": True,
     "max_workers": 3,
 }

--- a/src/arandu/kg/passage_offsets.py
+++ b/src/arandu/kg/passage_offsets.py
@@ -27,6 +27,7 @@ from typing import TYPE_CHECKING, Literal, Self
 from pydantic import BaseModel, Field
 
 from arandu.shared.config import ResultsConfig
+from arandu.shared.io import resolve_transcription_path
 from arandu.shared.schemas import EnrichedRecord
 
 if TYPE_CHECKING:
@@ -161,26 +162,23 @@ def build_passage_text_to_atlas_passage_id(
 def _load_source_text(transcription_dir: Path, file_id: str) -> str | None:
     """Load ``EnrichedRecord.transcription_text`` for ``file_id`` from disk.
 
-    The transcription stage today writes ``<file_id>_transcription.json``;
-    older / future runs may use the bare ``<file_id>.json``. Try both before
-    treating the source as missing.
+    The filename (``_transcription`` suffix, bare fallback) is resolved by
+    :func:`arandu.shared.io.resolve_transcription_path` — the single source of
+    the read-side convention.
 
     Returns ``None`` if no matching file exists or the file fails schema
     validation — callers treat that as an orphan passage (source dropped or
     drifted after KG construction).
     """
-    for candidate in (
-        transcription_dir / f"{file_id}_transcription.json",
-        transcription_dir / f"{file_id}.json",
-    ):
-        if candidate.exists():
-            try:
-                record = EnrichedRecord.model_validate_json(candidate.read_text())
-            except Exception as exc:
-                logger.warning("Skipping invalid EnrichedRecord %s: %s", candidate, exc)
-                return None
-            return record.transcription_text
-    return None
+    candidate = resolve_transcription_path(transcription_dir, file_id)
+    if candidate is None:
+        return None
+    try:
+        record = EnrichedRecord.model_validate_json(candidate.read_text())
+    except Exception as exc:
+        logger.warning("Skipping invalid EnrichedRecord %s: %s", candidate, exc)
+        return None
+    return record.transcription_text
 
 
 def _find_normalized(source: str, needle: str) -> tuple[int, int] | None:

--- a/src/arandu/qa/config.py
+++ b/src/arandu/qa/config.py
@@ -7,6 +7,8 @@ from pathlib import Path
 from pydantic import Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+from arandu.shared.llm_settings import REASONING_MODEL_MAX_TOKENS
+
 
 class QAConfig(BaseSettings):
     """Configuration settings for the QA generation pipeline.
@@ -58,7 +60,7 @@ class QAConfig(BaseSettings):
         description="Temperature for QA generation LLM",
     )
     max_tokens: int = Field(
-        default=8192,
+        default=REASONING_MODEL_MAX_TOKENS,
         ge=1,
         description=(
             "Max tokens for QA generation LLM. "
@@ -158,9 +160,9 @@ class CEPConfig(BaseSettings):
         description="Maximum reasoning hops to detect for multi-hop questions",
     )
     reasoning_max_tokens: int = Field(
-        default=8192,
+        default=REASONING_MODEL_MAX_TOKENS,
         ge=128,
-        le=8192,
+        le=REASONING_MODEL_MAX_TOKENS,
         description=(
             "Maximum tokens for reasoning enrichment responses. "
             "Defaults high for thinking models (Qwen3, DeepSeek-R1, Gemini 2.5) "
@@ -296,9 +298,9 @@ class JudgeConfig(BaseSettings):
         description="Temperature for judge LLM (low for consistent evaluation)",
     )
     max_tokens: int = Field(
-        default=8192,
+        default=REASONING_MODEL_MAX_TOKENS,
         ge=128,
-        le=8192,
+        le=REASONING_MODEL_MAX_TOKENS,
         description=(
             "Maximum tokens for judge responses. "
             "Defaults high for thinking models whose <think> blocks consume "

--- a/src/arandu/shared/io.py
+++ b/src/arandu/shared/io.py
@@ -103,6 +103,34 @@ def get_output_filename(original_name: str, suffix: str = "_transcription.json")
     return f"{path.stem}{suffix}"
 
 
+def resolve_transcription_path(transcription_dir: Path, file_id: str) -> Path | None:
+    """Return the on-disk transcription file for ``file_id``, or ``None``.
+
+    The transcription stage writes ``<file_id>_transcription.json`` (see
+    :func:`get_output_filename` and :func:`save_enriched_record`); older or
+    future runs may use the bare ``<file_id>.json``. Tries the suffixed form
+    first, then the bare form, and returns the first that exists. Single source
+    of the read-side filename convention so readers
+    (:func:`arandu.shared.rag.retrieve.factory._build_chunk_resolver`,
+    :func:`arandu.kg.passage_offsets._load_source_text`) don't each re-encode
+    it. Callers decide how to treat ``None`` (raise vs. skip).
+
+    Args:
+        transcription_dir: Directory holding the stage's ``*.json`` outputs.
+        file_id: Source file identifier (the transcription output stem).
+
+    Returns:
+        The first matching path, or ``None`` if neither candidate exists.
+    """
+    for candidate in (
+        transcription_dir / f"{file_id}_transcription.json",
+        transcription_dir / f"{file_id}.json",
+    ):
+        if candidate.exists():
+            return candidate
+    return None
+
+
 def get_mime_type(file_path: Path) -> str:
     """Get MIME type based on file extension.
 

--- a/src/arandu/shared/judge/criterion.py
+++ b/src/arandu/shared/judge/criterion.py
@@ -21,16 +21,17 @@ if TYPE_CHECKING:
 from pydantic import BaseModel, Field
 
 from arandu.shared.judge.schemas import CriterionScale, CriterionScore
+from arandu.shared.llm_settings import REASONING_MODEL_MAX_TOKENS
 from arandu.utils.text import validate_ordinal_score, validate_score
 
 ORDINAL_MIN = 1
 ORDINAL_MAX = 5
 
-# Default completion-token budget for LLM criteria. Sized for reasoning models
-# (Qwen3, Gemini 2.5, DeepSeek-R1) whose internal thinking tokens count against
-# this budget: a tight cap exhausts it during reasoning and truncates the JSON
-# response mid-string, surfacing as ``JSONDecodeError`` and a dropped verdict.
-DEFAULT_MAX_TOKENS = 8192
+# Default completion-token budget for LLM criteria. Aliases the shared
+# REASONING_MODEL_MAX_TOKENS so the judge tracks the same headroom as every
+# other stage (reasoning models' thinking tokens count against this budget; a
+# tight cap truncates the JSON verdict mid-string into a JSONDecodeError).
+DEFAULT_MAX_TOKENS = REASONING_MODEL_MAX_TOKENS
 
 logger = logging.getLogger(__name__)
 

--- a/src/arandu/shared/llm_settings.py
+++ b/src/arandu/shared/llm_settings.py
@@ -14,6 +14,15 @@ from typing import Literal
 from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+#: Token headroom sized for reasoning models (qwen3:14b, gemini-2.5-flash)
+#: whose internal thinking tokens count against the response budget. A tighter
+#: cap is exhausted mid-reasoning and truncates the (often JSON) response,
+#: surfacing downstream as a parse failure and a dropped result. Single source
+#: for the value every LLM stage uses, so they all move together; referenced as
+#: the :class:`LLMSettings` ``max_tokens`` default and re-exported as
+#: ``arandu.shared.judge.criterion.DEFAULT_MAX_TOKENS``.
+REASONING_MODEL_MAX_TOKENS = 8192
+
 
 class LLMSettings(BaseSettings):
     """Canonical LLM connection + sampling settings for any pipeline stage.
@@ -44,12 +53,10 @@ class LLMSettings(BaseSettings):
     api_key_env: str = Field(default="OPENAI_API_KEY")
     base_url: str | None = Field(default=None)
     temperature: float = Field(default=0.2, ge=0.0, le=2.0)
-    # 8192: sized for reasoning models (qwen3:14b default, gemini-2.5-flash)
-    # whose internal thinking tokens count against this budget. A tighter cap
-    # is exhausted mid-reasoning and truncates the (often JSON) response, which
-    # surfaces downstream as a parse failure and a dropped result. Stages that
-    # emit short free-text (e.g. the answerer) pin a smaller value themselves.
-    max_tokens: int = Field(default=8192, gt=0)
+    # See REASONING_MODEL_MAX_TOKENS. Every stage inherits this headroom; even
+    # short-answer stages (e.g. the answerer) need it because the response is
+    # structured and reasoning models burn thinking tokens against the budget.
+    max_tokens: int = Field(default=REASONING_MODEL_MAX_TOKENS, gt=0)
     language: Literal["pt", "en"] = Field(default="pt")
 
     model_config = SettingsConfigDict(env_prefix="ARANDU_LLM_", extra="ignore")

--- a/src/arandu/shared/rag/answer/settings.py
+++ b/src/arandu/shared/rag/answer/settings.py
@@ -18,21 +18,35 @@ class AnswererSettings(LLMSettings):
     (spec §5.1).
 
     Attributes:
-        max_tokens: Max tokens in the answerer's response. Overrides the
-            base default down to 1024 (answers are short).
+        max_tokens: Max tokens in the answerer's response. Defaults to 8192:
+            although the free-text answer is short, the answerer emits
+            *structured* output, and reasoning models (gemini-2.5-flash,
+            qwen3:14b) spend thinking tokens against this budget. A small
+            ceiling (the old 1024) truncated the JSON mid-string, so the
+            answerer fell back to ``abstained`` and polluted the answerable
+            arms with spurious abstentions (dry-run 2026-06-08). Matches the
+            judge/CEP reasoning-model headroom (see
+            :data:`arandu.shared.judge.criterion.DEFAULT_MAX_TOKENS`).
         top_k: Maximum passages to consider per question. Defaults to 10;
             the actual count may be smaller after token-budget packing.
-        max_context_tokens: Total context window for the answerer. Default
-            8192. Used by :func:`pack_passages` to compute the passage budget.
+        max_context_tokens: Total token budget (passages + prompt + answer)
+            the answerer packs into one call. Default 16384.
+            :func:`pack_passages` derives the passage budget as
+            ``max_context_tokens - prompt_overhead_tokens - max_tokens``, so it
+            must exceed the reasoning-model ``max_tokens`` (8192) with room left
+            for passages — an 8192 ceiling here leaves a negative budget. This
+            is an artificial benchmark cap held constant across arms, not the
+            model's real context window (gemini-2.5-flash / qwen3:14b are far
+            larger).
         prompt_overhead_tokens: Reserved budget for the rendered prompt
             template (everything except the passage list). The spec's default
             of 350 is an empirical estimate; tune downward if larger questions
             blow the budget.
     """
 
-    max_tokens: int = Field(default=1024, gt=0)
+    max_tokens: int = Field(default=8192, gt=0)
     top_k: int = Field(default=10, ge=1)
-    max_context_tokens: int = Field(default=8192, gt=0)
+    max_context_tokens: int = Field(default=16384, gt=0)
     prompt_overhead_tokens: int = Field(default=350, ge=0)
 
     model_config = SettingsConfigDict(env_prefix="ARANDU_ANSWERER_")

--- a/src/arandu/shared/rag/answer/settings.py
+++ b/src/arandu/shared/rag/answer/settings.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from pydantic import Field
+from typing import Self
+
+from pydantic import Field, model_validator
 from pydantic_settings import SettingsConfigDict
 
 from arandu.shared.llm_settings import LLMSettings
@@ -17,16 +19,15 @@ class AnswererSettings(LLMSettings):
     retrieval-quality from generation-quality in the cross-arm comparison
     (spec §5.1).
 
+    ``max_tokens`` is inherited unchanged from :class:`LLMSettings` (the shared
+    :data:`~arandu.shared.llm_settings.REASONING_MODEL_MAX_TOKENS` headroom):
+    although the answer is short, it is emitted as *structured* output and
+    reasoning models spend thinking tokens against the budget, so a tight cap
+    truncates the JSON and the answerer falls back to ``abstained`` (dry-run
+    2026-06-08). The packing budget invariant tying it to ``max_context_tokens``
+    is enforced by :meth:`_check_packing_budget`.
+
     Attributes:
-        max_tokens: Max tokens in the answerer's response. Defaults to 8192:
-            although the free-text answer is short, the answerer emits
-            *structured* output, and reasoning models (gemini-2.5-flash,
-            qwen3:14b) spend thinking tokens against this budget. A small
-            ceiling (the old 1024) truncated the JSON mid-string, so the
-            answerer fell back to ``abstained`` and polluted the answerable
-            arms with spurious abstentions (dry-run 2026-06-08). Matches the
-            judge/CEP reasoning-model headroom (see
-            :data:`arandu.shared.judge.criterion.DEFAULT_MAX_TOKENS`).
         top_k: Maximum passages to consider per question. Defaults to 10;
             the actual count may be smaller after token-budget packing.
         max_context_tokens: Total token budget (passages + prompt + answer)
@@ -44,9 +45,30 @@ class AnswererSettings(LLMSettings):
             blow the budget.
     """
 
-    max_tokens: int = Field(default=8192, gt=0)
     top_k: int = Field(default=10, ge=1)
     max_context_tokens: int = Field(default=16384, gt=0)
     prompt_overhead_tokens: int = Field(default=350, ge=0)
 
     model_config = SettingsConfigDict(env_prefix="ARANDU_ANSWERER_")
+
+    @model_validator(mode="after")
+    def _check_packing_budget(self) -> Self:
+        """Fail fast if no token budget is left for passages.
+
+        :func:`~arandu.shared.rag.answer.packer.pack_passages` derives the
+        passage budget as ``max_context_tokens - prompt_overhead_tokens -
+        max_tokens`` and raises if it is non-positive. Because all three fields
+        are independently overridable (``ARANDU_ANSWERER_*``), a bad combination
+        would otherwise only surface mid-run on the first question; catch it at
+        construction instead.
+        """
+        budget = self.max_context_tokens - self.prompt_overhead_tokens - self.max_tokens
+        if budget <= 0:
+            raise ValueError(
+                f"Answerer packing budget is non-positive: max_context_tokens "
+                f"({self.max_context_tokens}) - prompt_overhead_tokens "
+                f"({self.prompt_overhead_tokens}) - max_tokens ({self.max_tokens}) "
+                f"= {budget}. Raise max_context_tokens or lower max_tokens / "
+                f"prompt_overhead_tokens so pack_passages has room for passages."
+            )
+        return self

--- a/src/arandu/shared/rag/retrieve/factory.py
+++ b/src/arandu/shared/rag/retrieve/factory.py
@@ -217,8 +217,12 @@ def _build_chunk_resolver(*, pipeline_id: str, base_dir: Path) -> ChunkResolver:
     """Construct a :class:`ChunkResolver` reading source text from this run.
 
     Source text lives at ``<base_dir>/<pipeline_id>/transcription/outputs/
-    <file_id>.json`` as an :class:`EnrichedRecord`. The loader reads it
-    lazily; ``ChunkResolver`` caches loaded texts in its LRU.
+    <file_id>_transcription.json`` as an :class:`EnrichedRecord`. The
+    transcription stage writes the ``_transcription`` suffix
+    (:func:`arandu.transcription.batch.run_batch_transcription`); older or
+    future runs may use the bare ``<file_id>.json``, so both are tried —
+    mirrors :func:`arandu.kg.passage_offsets._load_source_text`. The loader
+    reads lazily; ``ChunkResolver`` caches loaded texts in its LRU.
     """
     transcription_dir = base_dir / pipeline_id / "transcription" / "outputs"
     if not transcription_dir.exists():
@@ -228,11 +232,17 @@ def _build_chunk_resolver(*, pipeline_id: str, base_dir: Path) -> ChunkResolver:
         )
 
     def _load_text(file_id: str) -> str:
-        path = transcription_dir / f"{file_id}.json"
-        if not path.exists():
-            raise FileNotFoundError(f"Transcription not found for file_id {file_id!r}: {path}")
-        record = EnrichedRecord.model_validate_json(path.read_text(encoding="utf-8"))
-        return record.transcription_text
+        for candidate in (
+            transcription_dir / f"{file_id}_transcription.json",
+            transcription_dir / f"{file_id}.json",
+        ):
+            if candidate.exists():
+                record = EnrichedRecord.model_validate_json(candidate.read_text(encoding="utf-8"))
+                return record.transcription_text
+        raise FileNotFoundError(
+            f"Transcription not found for file_id {file_id!r} in {transcription_dir} "
+            f"(tried {file_id}_transcription.json and {file_id}.json)."
+        )
 
     return ChunkResolver(text_loader=_load_text)
 

--- a/src/arandu/shared/rag/retrieve/factory.py
+++ b/src/arandu/shared/rag/retrieve/factory.py
@@ -18,6 +18,7 @@ from arandu.shared.chunking.resolver import ChunkResolver
 from arandu.shared.chunking.schemas import Chunk, ChunkSet
 from arandu.shared.config import ResultsConfig
 from arandu.shared.embeddings import EmbedderSettings, build_embedder
+from arandu.shared.io import resolve_transcription_path
 from arandu.shared.llm_client import LLMClient, LLMProvider, parse_provider
 from arandu.shared.rag.retrieve.settings import (
     AtlasRagRetrieveSettings,
@@ -216,13 +217,12 @@ def _load_chunks(chunk_dir: Path, chunker_id: str) -> list[Chunk]:
 def _build_chunk_resolver(*, pipeline_id: str, base_dir: Path) -> ChunkResolver:
     """Construct a :class:`ChunkResolver` reading source text from this run.
 
-    Source text lives at ``<base_dir>/<pipeline_id>/transcription/outputs/
-    <file_id>_transcription.json`` as an :class:`EnrichedRecord`. The
-    transcription stage writes the ``_transcription`` suffix
-    (:func:`arandu.transcription.batch.run_batch_transcription`); older or
-    future runs may use the bare ``<file_id>.json``, so both are tried —
-    mirrors :func:`arandu.kg.passage_offsets._load_source_text`. The loader
-    reads lazily; ``ChunkResolver`` caches loaded texts in its LRU.
+    Source text lives at ``<base_dir>/<pipeline_id>/transcription/outputs/`` as
+    an :class:`EnrichedRecord`. The filename (``_transcription`` suffix, bare
+    fallback) is resolved by
+    :func:`arandu.shared.io.resolve_transcription_path` — the single source of
+    the read-side convention. The loader reads lazily; ``ChunkResolver`` caches
+    loaded texts in its LRU.
     """
     transcription_dir = base_dir / pipeline_id / "transcription" / "outputs"
     if not transcription_dir.exists():
@@ -232,17 +232,14 @@ def _build_chunk_resolver(*, pipeline_id: str, base_dir: Path) -> ChunkResolver:
         )
 
     def _load_text(file_id: str) -> str:
-        for candidate in (
-            transcription_dir / f"{file_id}_transcription.json",
-            transcription_dir / f"{file_id}.json",
-        ):
-            if candidate.exists():
-                record = EnrichedRecord.model_validate_json(candidate.read_text(encoding="utf-8"))
-                return record.transcription_text
-        raise FileNotFoundError(
-            f"Transcription not found for file_id {file_id!r} in {transcription_dir} "
-            f"(tried {file_id}_transcription.json and {file_id}.json)."
-        )
+        path = resolve_transcription_path(transcription_dir, file_id)
+        if path is None:
+            raise FileNotFoundError(
+                f"Transcription not found for file_id {file_id!r} in {transcription_dir} "
+                f"(tried {file_id}_transcription.json and {file_id}.json)."
+            )
+        record = EnrichedRecord.model_validate_json(path.read_text(encoding="utf-8"))
+        return record.transcription_text
 
     return ChunkResolver(text_loader=_load_text)
 

--- a/src/arandu/shared/rag/retrievers/atlas_rag.py
+++ b/src/arandu/shared/rag/retrievers/atlas_rag.py
@@ -250,6 +250,19 @@ class AtlasRagRetriever:
             relname: hashlib.sha256(path.read_bytes()).hexdigest()
             for relname, path in artifact_paths.items()
         }
+        # Record the edge faiss index sha alongside the pickles so _load_data_dict
+        # can integrity-check it on load. Stored under EDGE_FAISS_SHA_KEY (not a
+        # pickle, so it is verified + loaded separately, not via the pickle loop).
+        edge_index_path = cls._edge_faiss_index_path(
+            precompute_dir=precompute_dir,
+            keyword=keyword,
+            sentence_encoder_model=sentence_encoder_model,
+            include_events=include_events,
+            include_concept=include_concept,
+        )
+        artifact_sha256[cls.EDGE_FAISS_SHA_KEY] = hashlib.sha256(
+            edge_index_path.read_bytes()
+        ).hexdigest()
 
         manifest = {
             "kg_outputs_dir": str(kg_outputs_dir),
@@ -264,7 +277,23 @@ class AtlasRagRetriever:
         (precompute_dir / MANIFEST_FILENAME).write_text(json.dumps(manifest, indent=2))
 
     @staticmethod
+    def _encoder_short_and_flags(
+        sentence_encoder_model: str, include_events: bool, include_concept: bool
+    ) -> tuple[str, str]:
+        """Derive the ``(encoder_short, flags)`` filename parts atlas-rag uses.
+
+        Both shared by :meth:`_artifact_paths` and :meth:`_edge_faiss_index_path`
+        so the upstream filename scheme (encoder basename + event/concept flags)
+        lives in one place; mirrors
+        ``atlas_rag.vectorstore.create_graph_index.create_embeddings_and_index``.
+        """
+        encoder_short = sentence_encoder_model.split("/")[-1]
+        flags = f"event{include_events}_concept{include_concept}"
+        return encoder_short, flags
+
+    @classmethod
     def _artifact_paths(
+        cls,
         *,
         precompute_dir: Path,
         keyword: str,
@@ -279,8 +308,9 @@ class AtlasRagRetriever:
         ``manifest["artifact_sha256"]`` so `_load_data_dict` can verify
         integrity without re-deriving filenames from arguments.
         """
-        encoder_short = sentence_encoder_model.split("/")[-1]
-        flags = f"event{include_events}_concept{include_concept}"
+        encoder_short, flags = cls._encoder_short_and_flags(
+            sentence_encoder_model, include_events, include_concept
+        )
         return {
             "node_embeddings": precompute_dir
             / f"{keyword}_{flags}_{encoder_short}_node_embeddings.pkl",
@@ -292,8 +322,14 @@ class AtlasRagRetriever:
             "text_dict": precompute_dir / f"{keyword}_original_text_dict_with_node_id.pkl",
         }
 
-    @staticmethod
+    #: Manifest key under which the edge faiss index sha256 is recorded.
+    #: Verified *if present* (see :meth:`_load_data_dict`): precomputes built
+    #: before this key existed still load, newer ones get integrity-checked.
+    EDGE_FAISS_SHA_KEY = "edge_faiss_index"
+
+    @classmethod
     def _edge_faiss_index_path(
+        cls,
         *,
         precompute_dir: Path,
         keyword: str,
@@ -306,12 +342,14 @@ class AtlasRagRetriever:
         Filename mirrors ``atlas_rag.vectorstore.create_graph_index.
         create_embeddings_and_index`` (``..._edge_faiss.index``), which
         :meth:`build_index` already writes. Kept out of :meth:`_artifact_paths`
-        because that map feeds the ``pickle.load`` + sha-verify loop, while the
-        faiss index is read with ``faiss.read_index`` (not a pickle, so the
-        pickle-tamper threat model that drives sha verification does not apply).
+        because that map feeds the ``pickle.load`` loop; the faiss index is read
+        with ``faiss.read_index`` (not a pickle), so it is loaded separately and
+        its sha is recorded under :attr:`EDGE_FAISS_SHA_KEY` rather than mixed
+        into the pickle artifact-sha map.
         """
-        encoder_short = sentence_encoder_model.split("/")[-1]
-        flags = f"event{include_events}_concept{include_concept}"
+        encoder_short, flags = cls._encoder_short_and_flags(
+            sentence_encoder_model, include_events, include_concept
+        )
         return precompute_dir / f"{keyword}_{flags}_{encoder_short}_edge_faiss.index"
 
     @staticmethod
@@ -424,7 +462,20 @@ class AtlasRagRetriever:
 
         # atlas-rag's prebuilt edge faiss index — see _build_inner_retriever
         # for why this is injected onto the retriever rather than read from
-        # `data` by its __init__.
+        # `data` by its __init__. Integrity-checked against the manifest if the
+        # sha was recorded (verify-if-present: precomputes built before
+        # EDGE_FAISS_SHA_KEY existed still load). faiss.read_index is not a
+        # pickle, so this is bytes-equality, not an arbitrary-code-exec gate.
+        recorded_edge_sha = artifact_sha256.get(cls.EDGE_FAISS_SHA_KEY)
+        if recorded_edge_sha is not None:
+            actual_edge_sha = hashlib.sha256(edge_index_path.read_bytes()).hexdigest()
+            if actual_edge_sha != recorded_edge_sha:
+                raise ValueError(
+                    f"sha256 mismatch on {edge_index_path}: manifest records "
+                    f"{recorded_edge_sha[:12]}…, computed {actual_edge_sha[:12]}… — "
+                    f"artifact may be corrupted or tampered. Rebuild the index."
+                )
+
         import faiss
 
         edge_faiss_index = faiss.read_index(str(edge_index_path))

--- a/src/arandu/shared/rag/retrievers/atlas_rag.py
+++ b/src/arandu/shared/rag/retrievers/atlas_rag.py
@@ -293,6 +293,28 @@ class AtlasRagRetriever:
         }
 
     @staticmethod
+    def _edge_faiss_index_path(
+        *,
+        precompute_dir: Path,
+        keyword: str,
+        sentence_encoder_model: str,
+        include_events: bool,
+        include_concept: bool,
+    ) -> Path:
+        """Path to atlas-rag's prebuilt edge faiss index for this KG.
+
+        Filename mirrors ``atlas_rag.vectorstore.create_graph_index.
+        create_embeddings_and_index`` (``..._edge_faiss.index``), which
+        :meth:`build_index` already writes. Kept out of :meth:`_artifact_paths`
+        because that map feeds the ``pickle.load`` + sha-verify loop, while the
+        faiss index is read with ``faiss.read_index`` (not a pickle, so the
+        pickle-tamper threat model that drives sha verification does not apply).
+        """
+        encoder_short = sentence_encoder_model.split("/")[-1]
+        flags = f"event{include_events}_concept{include_concept}"
+        return precompute_dir / f"{keyword}_{flags}_{encoder_short}_edge_faiss.index"
+
+    @staticmethod
     def _validate_manifest(
         manifest: dict[str, Any],
         *,
@@ -362,8 +384,15 @@ class AtlasRagRetriever:
             include_events=include_events,
             include_concept=include_concept,
         )
+        edge_index_path = cls._edge_faiss_index_path(
+            precompute_dir=precompute_dir,
+            keyword=keyword,
+            sentence_encoder_model=sentence_encoder_model,
+            include_events=include_events,
+            include_concept=include_concept,
+        )
 
-        for path in (*artifacts.values(), graphml_path):
+        for path in (*artifacts.values(), edge_index_path, graphml_path):
             if not path.exists():
                 raise FileNotFoundError(
                     f"atlas-rag retriever artifact missing: {path}. "
@@ -393,6 +422,13 @@ class AtlasRagRetriever:
             kg = nx.read_graphml(f)
         cls._patch_orphan_file_ids(kg)
 
+        # atlas-rag's prebuilt edge faiss index — see _build_inner_retriever
+        # for why this is injected onto the retriever rather than read from
+        # `data` by its __init__.
+        import faiss
+
+        edge_faiss_index = faiss.read_index(str(edge_index_path))
+
         return {
             "node_embeddings": loaded["node_embeddings"],
             "edge_embeddings": loaded["edge_embeddings"],
@@ -400,6 +436,7 @@ class AtlasRagRetriever:
             "edge_list": loaded["edge_list"],
             "text_embeddings": loaded["text_embeddings"],
             "text_dict": loaded["text_dict"],
+            "edge_faiss_index": edge_faiss_index,
             "KG": kg,
         }
 
@@ -449,11 +486,21 @@ class AtlasRagRetriever:
             client=llm_client,
             model_name=llm_model_id,
         )
-        return HippoRAGRetriever(
+        retriever = HippoRAGRetriever(
             llm_generator=llm_generator,
             sentence_encoder=sentence_encoder,
             data=data,
         )
+        # Shim: this atlas-rag version's HippoRAGRetriever.__init__ sets
+        # self.edge_embeddings but NOT self.edge_faiss_index, yet query2edge()
+        # under the default inference config (is_filter_edges=True,
+        # hipporag_mode="query2edge") searches self.edge_faiss_index and
+        # crashes with AttributeError (dry-run 2026-06-08). Sibling retrievers
+        # (HippoRAG2, SimpleGraphRetriever) read data["edge_faiss_index"];
+        # hipporag.py omits it. Inject the prebuilt index we already write at
+        # build_index time so the LLM-filtered edge path works.
+        retriever.edge_faiss_index = data["edge_faiss_index"]
+        return retriever
 
     def retrieve(self, question: str, top_k: int) -> list[RetrievedPassage]:
         """Run HippoRAG retrieval and return ranked passages.

--- a/tests/kg/test_atlas_backend.py
+++ b/tests/kg/test_atlas_backend.py
@@ -127,8 +127,8 @@ class TestAtlasRagConstructorInit:
 
         assert constructor._opts["chunk_size"] == 4096
         assert constructor._opts["batch_size_triple"] == 5
-        # Non-overridden defaults stay
-        assert constructor._opts["max_new_tokens"] == 2048
+        # Non-overridden defaults stay (8192 headroom for reasoning models)
+        assert constructor._opts["max_new_tokens"] == 8192
 
 
 class TestPrepareInputData:

--- a/tests/shared/rag/answer/test_batch.py
+++ b/tests/shared/rag/answer/test_batch.py
@@ -92,8 +92,8 @@ class TestRunAnswerBatch:
         # even if run-level metadata is later moved or split.
         assert rec.answerer_meta["provider"] == "ollama"
         assert rec.answerer_meta["top_k"] == 10
-        assert rec.answerer_meta["max_tokens"] == 1024
-        assert rec.answerer_meta["max_context_tokens"] == 8192
+        assert rec.answerer_meta["max_tokens"] == 8192
+        assert rec.answerer_meta["max_context_tokens"] == 16384
         assert rec.answerer_meta["prompt_overhead_tokens"] == 350
         assert rec.answerer_model == "qwen3:14b"
 

--- a/tests/shared/rag/answer/test_settings.py
+++ b/tests/shared/rag/answer/test_settings.py
@@ -15,10 +15,15 @@ class TestAnswererSettings:
         assert s.provider == "ollama"
         assert s.model_id == "qwen3:14b"
         assert s.temperature == 0.2
-        assert s.max_tokens == 1024
+        # 8192 headroom: the answerer emits structured output and reasoning
+        # models burn thinking tokens against this budget; 1024 truncated the
+        # JSON -> spurious abstention (dry-run 2026-06-08).
+        assert s.max_tokens == 8192
         assert s.language == "pt"
         assert s.top_k == 10
-        assert s.max_context_tokens == 8192
+        # 16384 (not 8192): the packer reserves max_tokens (8192) from this
+        # budget, so it must leave room for passages (dry-run bug #7 follow-on).
+        assert s.max_context_tokens == 16384
         assert s.prompt_overhead_tokens == 350
 
     def test_provider_lowercased(self, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/shared/rag/answer/test_settings.py
+++ b/tests/shared/rag/answer/test_settings.py
@@ -45,3 +45,15 @@ class TestAnswererSettings:
             AnswererSettings(temperature=-0.1)
         with pytest.raises(ValueError):
             AnswererSettings(temperature=2.5)
+
+    def test_rejects_nonpositive_packing_budget(self) -> None:
+        # max_context_tokens must leave room after reserving max_tokens +
+        # prompt_overhead; otherwise pack_passages would crash mid-run. The
+        # model_validator fails fast at construction. 8192 - 350 - 8192 < 0.
+        with pytest.raises(ValueError, match="packing budget is non-positive"):
+            AnswererSettings(_env_file=None, max_context_tokens=8192)
+
+    def test_accepts_budget_with_room_for_passages(self) -> None:
+        # Just enough headroom: 8543 - 350 - 8192 = 1 > 0.
+        s = AnswererSettings(_env_file=None, max_context_tokens=8543)
+        assert s.max_context_tokens == 8543

--- a/tests/shared/rag/retrieve/test_factory.py
+++ b/tests/shared/rag/retrieve/test_factory.py
@@ -15,7 +15,7 @@ import networkx as nx
 import pytest
 
 from arandu.shared.embeddings import EmbedderSettings
-from arandu.shared.rag.retrieve.factory import build_retriever
+from arandu.shared.rag.retrieve.factory import _build_chunk_resolver, build_retriever
 from arandu.shared.rag.retrieve.settings import (
     AtlasRagRetrieveSettings,
     Bm25RetrieveSettings,
@@ -24,9 +24,35 @@ from arandu.shared.rag.retrieve.settings import (
 from arandu.shared.rag.retrievers.khop_subgraph import KHopSubgraphRetriever
 from arandu.shared.rag.retrievers.khop_triple import KHopTripleRetriever
 from arandu.shared.rag.retrievers.null import NullRetriever
+from arandu.shared.schemas import EnrichedRecord
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+
+def _write_transcription(outputs_dir: Path, file_id: str, *, suffix: str, text: str) -> None:
+    """Write a minimal valid ``EnrichedRecord`` under ``outputs_dir``.
+
+    ``suffix`` is the on-disk filename stem suffix: ``"_transcription"`` for the
+    real convention the transcription stage emits, or ``""`` for the legacy
+    bare ``<file_id>.json`` form.
+    """
+    outputs_dir.mkdir(parents=True, exist_ok=True)
+    record = EnrichedRecord(
+        file_id=file_id,
+        name=f"{file_id}.m4a",
+        mimeType="audio/mpeg",
+        parents=["root"],
+        web_content_link="https://drive.google.com/x",
+        transcription_text=text,
+        detected_language="pt",
+        language_probability=0.9,
+        model_id="openai/whisper-large-v3",
+        compute_device="cuda",
+        processing_duration_sec=1.0,
+        transcription_status="completed",
+    )
+    (outputs_dir / f"{file_id}{suffix}.json").write_text(record.model_dump_json(), encoding="utf-8")
 
 
 class TestNullArm:
@@ -184,3 +210,33 @@ class TestBm25Arm:
                 settings=Bm25RetrieveSettings(chunker_id="cep_4k"),
                 base_dir=tmp_path,
             )
+
+
+class TestChunkResolverFilename:
+    """`_build_chunk_resolver` resolves the transcription stage's filename (bug #5).
+
+    The transcription stage writes ``<file_id>_transcription.json``; the bm25
+    arm's chunk text loader built ``<file_id>.json`` and 404'd on every chunk
+    in the first real end-to-end run (dry-run 2026-06-08). It now tries the
+    suffixed form first, with the bare form as a legacy fallback.
+    """
+
+    def test_loads_transcription_suffixed_file(self, tmp_path: Path) -> None:
+        outputs = tmp_path / "run_x" / "transcription" / "outputs"
+        _write_transcription(outputs, "src_a", suffix="_transcription", text="texto êmico")
+        resolver = _build_chunk_resolver(pipeline_id="run_x", base_dir=tmp_path)
+        assert resolver._loader("src_a") == "texto êmico"
+
+    def test_loads_legacy_bare_file(self, tmp_path: Path) -> None:
+        outputs = tmp_path / "run_x" / "transcription" / "outputs"
+        _write_transcription(outputs, "src_a", suffix="", text="legado")
+        resolver = _build_chunk_resolver(pipeline_id="run_x", base_dir=tmp_path)
+        assert resolver._loader("src_a") == "legado"
+
+    def test_missing_file_error_names_both_candidates(self, tmp_path: Path) -> None:
+        outputs = tmp_path / "run_x" / "transcription" / "outputs"
+        # Dir exists (so the resolver builds) but the file_id is absent.
+        _write_transcription(outputs, "other", suffix="_transcription", text="x")
+        resolver = _build_chunk_resolver(pipeline_id="run_x", base_dir=tmp_path)
+        with pytest.raises(FileNotFoundError, match=r"_transcription\.json and src_a\.json"):
+            resolver._loader("src_a")

--- a/tests/shared/rag/retrievers/test_atlas_rag.py
+++ b/tests/shared/rag/retrievers/test_atlas_rag.py
@@ -311,6 +311,10 @@ def _write_minimal_precompute(
     placeholder = b"placeholder-pickle-bytes"
     for path in artifacts.values():
         path.write_bytes(placeholder)
+    # The edge faiss index must exist for `_load_data_dict`'s presence check;
+    # it is not sha-verified (not a pickle) and these integrity tests fail at
+    # the pickle sha/load step before `faiss.read_index` is ever reached.
+    (precompute / f"{keyword}_{flags}_{encoder_short}_edge_faiss.index").write_bytes(placeholder)
 
     manifest: dict[str, object] = {
         "kg_outputs_dir": str(kg_outputs_dir),
@@ -480,3 +484,73 @@ class TestAtlasRagManifestIntegrity:
                 sentence_encoder=MagicMock(),
                 sentence_encoder_model="m",
             )
+
+
+# -- edge faiss index shim (dry-run bug #6, 2026-06-08) ------------------
+
+
+class TestEdgeFaissIndexPath:
+    """The prebuilt edge-faiss-index filename must mirror upstream exactly."""
+
+    def test_mirrors_upstream_create_graph_index_filename(self, tmp_path: Path) -> None:
+        # Must match atlas_rag.vectorstore.create_graph_index's
+        # `..._edge_faiss.index` so we read the index build_index wrote.
+        # encoder_short strips any namespace prefix (org/model -> model).
+        path = AtlasRagRetriever._edge_faiss_index_path(
+            precompute_dir=tmp_path,
+            keyword="transcriptions.json",
+            sentence_encoder_model="org/gemini-embedding-001",
+            include_events=True,
+            include_concept=True,
+        )
+        assert path == (
+            tmp_path
+            / "transcriptions.json_eventTrue_conceptTrue_gemini-embedding-001_edge_faiss.index"
+        )
+
+
+class TestBuildInnerRetrieverEdgeFaissShim:
+    """`_build_inner_retriever` injects edge_faiss_index onto the retriever.
+
+    Our pinned atlas-rag's ``HippoRAGRetriever.__init__`` sets
+    ``edge_embeddings`` but not ``edge_faiss_index``, yet ``query2edge`` under
+    the default config searches the latter and crashes (dry-run bug #6). The
+    wrapper patches it post-construction. This runs without the ``kg`` extra
+    by faking the atlas_rag import targets.
+    """
+
+    def test_injects_prebuilt_edge_faiss_index(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import sys
+        import types
+
+        captured: dict[str, object] = {}
+
+        class _FakeHippoRAGRetriever:
+            def __init__(self, **kwargs: object) -> None:
+                captured.update(kwargs)
+                # Mimic the upstream bug: edge_faiss_index is NOT set here.
+
+        fake_retriever_mod = types.ModuleType("atlas_rag.retriever")
+        fake_retriever_mod.HippoRAGRetriever = _FakeHippoRAGRetriever  # type: ignore[attr-defined]
+        fake_llm_mod = types.ModuleType("atlas_rag.llm_generator")
+        fake_llm_mod.LLMGenerator = lambda **kw: MagicMock()  # type: ignore[attr-defined]
+        fake_pkg = types.ModuleType("atlas_rag")
+        monkeypatch.setitem(sys.modules, "atlas_rag", fake_pkg)
+        monkeypatch.setitem(sys.modules, "atlas_rag.retriever", fake_retriever_mod)
+        monkeypatch.setitem(sys.modules, "atlas_rag.llm_generator", fake_llm_mod)
+
+        sentinel_index = object()
+        data = {"edge_faiss_index": sentinel_index, "text_dict": {}}
+
+        retriever = AtlasRagRetriever._build_inner_retriever(
+            llm_client=MagicMock(),
+            llm_model_id="m",
+            sentence_encoder=MagicMock(),
+            data=data,
+        )
+
+        # Upstream __init__ left it unset; the wrapper injected the prebuilt one.
+        assert retriever.edge_faiss_index is sentinel_index
+        # The faiss index is injected, NOT smuggled through the data dict the
+        # upstream constructor reads (it ignores the key in this version).
+        assert "edge_faiss_index" in captured["data"]  # type: ignore[operator]


### PR DESCRIPTION
## Context

The 2026-06-08 local mini-dry-run ran the full Phase C chain end-to-end for the first time and surfaced 7 integration bugs. Bugs #1-3 were fixed earlier (`4aa5bb1`, `76b11f3`, `671e8be`/`6d24a85`); this PR closes the remaining 4 that an end-to-end run exposed but unit fixtures had masked.

## Fixes

- **#5 bm25 arm dead (`shared/rag/retrieve/factory.py`).** The chunk text loader built `<file_id>.json`, but the transcription stage writes `<file_id>_transcription.json`, so every resolution 404'd and the core baseline arm produced 0 records. Now tries the suffixed form first with the bare form as a legacy fallback, mirroring `kg.passage_offsets._load_source_text`.

- **#6 atlas_rag `edge_faiss_index` AttributeError (`shared/rag/retrievers/atlas_rag.py`).** Our pinned atlas-rag's `HippoRAGRetriever.__init__` sets `edge_embeddings` but not `edge_faiss_index`, yet `query2edge` under the default config (`is_filter_edges=True`) searches the latter (sibling retrievers read `data["edge_faiss_index"]`; `hipporag.py` omits it). Load the prebuilt index `build_index` already writes and inject it post-construction, mirroring the existing `_patch_orphan_file_ids` shim. The `.index` is read with `faiss.read_index` (not a pickle), so it sits outside the pickle-tamper sha-verification model.

- **#7 answerer 93% spurious abstention (`shared/rag/answer/settings.py`).** The answerer emits structured output and reasoning models spend thinking tokens against `max_tokens`; the 1024 ceiling truncated the JSON, so it fell back to `abstained`. Raise `max_tokens` 1024 -> 8192. Because `pack_passages` derives the passage budget as `max_context_tokens - prompt_overhead_tokens - max_tokens`, an 8192 reservation against an 8192 budget goes negative, so also raise `max_context_tokens` 8192 -> 16384 (an artificial benchmark cap held constant across arms, not the model's real window).

- **#4 atlas KG `max_new_tokens` (`kg/atlas_backend.py`).** Triple/concept extraction runs through reasoning models; atlas-rag's own 2048 default truncated the JSON. The dry-run worked around it with `--backend-option max_new_tokens=8192`; make 8192 the default.

## Notes for the re-run

- The #6 fix exercises the HippoRAG LLM edge-filter path (`filter_triples_with_entity_event`) for the first time, since it crashed before ever reaching it. Worth watching when re-running `retrieve`.
- The #6 fix works with the existing mini-dry-run precompute (the `.index` files are already on disk; no rebuild needed).

## Testing

Each fix carries a regression test. Full suite: 1401 passed. The one remaining failure (`test_report_command_deprecation_warning`) is pre-existing and unrelated (missing `plotly` optional dep in this environment), confirmed by stashing the changes.