### PR TITLE
feat(rag): carry khop_passage source text inline via payload

### DIFF
--- a/src/arandu/kg/passage_offsets.py
+++ b/src/arandu/kg/passage_offsets.py
@@ -119,11 +119,13 @@ def _iter_atlas_passages(kg_extraction_dir: Path) -> Iterator[_AtlasPassage]:
                 )
 
 
-def _strip_atlas_header(text: str) -> str:
+def strip_atlas_header(text: str) -> str:
     """Strip the atlas-rag-injected ``[Contexto…][Transcrição]\\n`` header.
 
     If the marker is absent (passage was indexed without a header), return
-    the text unchanged.
+    the text unchanged. Public so retrievers that surface atlas passage text
+    inline (``KHopSubgraphRetriever`` payload) strip the same header the
+    offset-resolution path strips, keeping arms comparable on identical text.
     """
     idx = text.find(_HEADER_END_MARKER)
     if idx == -1:
@@ -310,7 +312,7 @@ def link_passages(
             unmatched.append(passage.passage_id)
             continue
 
-        needle = _strip_atlas_header(passage.text)
+        needle = strip_atlas_header(passage.text)
         # If the atlas record carried only the injected header (degenerate
         # chunk), `needle` is empty / whitespace. `str.find("")` returns 0,
         # which would yield `end_char=0` and fail `PassageOffset.end_char (gt=0)`

--- a/src/arandu/shared/rag/judge_answers/batch.py
+++ b/src/arandu/shared/rag/judge_answers/batch.py
@@ -261,7 +261,7 @@ def _judge_one(
       ``question`` / ``gold_answer`` / ``system_answer`` / ``passages_text``;
     - ``source_recovery`` (heuristic): ``retrieved_text`` (raw joined
       passage text, no ``[Passage N]`` markers) / ``context`` /
-      ``passages_are_payload``.
+      ``passages_are_non_prose``.
 
     ``gold`` is ``None`` for non-answerable items (no CEP pair); the
     answerability gate rejects those before the gold criteria run, so the
@@ -275,11 +275,16 @@ def _judge_one(
         system_answer=answer.answer_text or "",
         rationale=answer.rationale,
         passages_text=_format_passages(resolved_passages),
-        # Raw joined passage text + payload flag for the deterministic
+        # Raw joined passage text + non-prose flag for the deterministic
         # source_recovery criterion (separate from the LLM-facing
-        # passages_text, which carries "[Passage N]" markers).
+        # passages_text, which carries "[Passage N]" markers). Non-prose =
+        # payload that isn't verbatim source text (triples), where token
+        # containment is meaningless; inline-prose payloads (khop_passage,
+        # payload_is_prose=True) and offset-resolved passages still score.
         retrieved_text="\n".join(resolved_passages),
-        passages_are_payload=any(p.payload is not None for p in answer.passages),
+        passages_are_non_prose=any(
+            p.payload is not None and not p.payload_is_prose for p in answer.passages
+        ),
         question=gold.question if gold is not None else answer.question,
         gold_answer=gold.gold_answer if gold is not None else "",
         context=gold.context if gold is not None else "",

--- a/src/arandu/shared/rag/judge_answers/heuristic.py
+++ b/src/arandu/shared/rag/judge_answers/heuristic.py
@@ -120,10 +120,13 @@ class SourceRecoveryCriterion(HeuristicCriterion):
     undefined or would bias the cross-arm comparison, so the analysis mean
     excludes them:
 
-    - **payload arms** (e.g. ``KHopTripleRetriever``): linearized triples
-      are not source prose, so token overlap is structurally near-zero
-      regardless of relevance — the same bias that kept the deterministic
-      ``offset_coverage`` variant out of the pipeline.
+    - **non-prose payload arms** (e.g. ``KHopTripleRetriever``): linearized
+      triples are not source prose, so token overlap is structurally
+      near-zero regardless of relevance — the same bias that kept the
+      deterministic ``offset_coverage`` variant out of the pipeline.
+      Inline-*prose* payloads (``KHopSubgraphRetriever``, which carries the
+      source passage in ``payload`` with ``payload_is_prose=True``) are NOT
+      skipped — they are source prose and score normally.
     - **no retrieved passages** (e.g. ``NullRetriever``): empty denominator.
     - **no source context**: empty denominator on the gold side.
 
@@ -156,19 +159,19 @@ class SourceRecoveryCriterion(HeuristicCriterion):
         """Compute containment, or ``score=None`` for the undefined cases.
 
         Args:
-            **kwargs: Reads ``passages_are_payload`` (bool),
+            **kwargs: Reads ``passages_are_non_prose`` (bool),
                 ``retrieved_text`` (raw joined passage text), and
                 ``context`` (gold source span).
 
         Returns:
             CriterionScore with the containment fraction, or ``score=None``
-            for payload arms / empty passages / empty context.
+            for non-prose payload arms / empty passages / empty context.
         """
-        if bool(kwargs.get("passages_are_payload", False)):
+        if bool(kwargs.get("passages_are_non_prose", False)):
             return CriterionScore(
                 score=None,
                 threshold=self.threshold,
-                rationale="payload arm (non-prose passages); source-recovery N/A",
+                rationale="non-prose payload arm (e.g. triples); source-recovery N/A",
             )
         retrieved_tokens = set(self._tokenize(str(kwargs.get("retrieved_text", ""))))
         context_tokens = set(self._tokenize(str(kwargs.get("context", ""))))

--- a/src/arandu/shared/rag/retrievers/khop_subgraph.py
+++ b/src/arandu/shared/rag/retrievers/khop_subgraph.py
@@ -43,7 +43,10 @@ from typing import TYPE_CHECKING
 
 import networkx as nx
 
-from arandu.kg.passage_offsets import build_passage_text_to_atlas_passage_id
+from arandu.kg.passage_offsets import (
+    build_passage_text_to_atlas_passage_id,
+    strip_atlas_header,
+)
 from arandu.shared.rag.retrievers._khop_common import (
     _DEFAULT_MAX_POSTINGS,
     _LINKABLE_TYPES,
@@ -235,16 +238,22 @@ class KHopSubgraphRetriever:
         max_count = ranked[0][1]
         # Carry the passage text inline in `payload` (marked prose) so the
         # Answerer doesn't re-resolve `chunk_id` through `passage_offsets.json`
-        # at answer time — the retriever already holds the exact text. The
-        # `chunk_id` stays the sidecar-joinable `<file_id>:<chunk_index>` for
-        # joins/dedup, and `payload_is_prose=True` keeps source_recovery's
-        # token-containment lens applicable (unlike triple payloads).
+        # at answer time — the retriever already holds the exact text.
+        # `strip_atlas_header` mirrors the offset-resolution path (which strips
+        # the same `[Contexto…][Transcrição]` header before slicing), so the
+        # payload matches the header-free text every other arm feeds — keeping
+        # the answerer prompt and source_recovery comparable across arms. The
+        # `chunk_id` stays the stable sidecar-joinable `<file_id>:<chunk_index>`,
+        # and `payload_is_prose=True` keeps source_recovery's token-containment
+        # lens applicable (unlike triple payloads). NB: the header-bearing raw
+        # `text` is still the lookup key for `_text_to_passage_id` above; only
+        # the surfaced payload is stripped.
         return [
             RetrievedPassage(
                 chunk_id=atlas_passage_id,
                 rank=rank,
                 score=count / max_count,
-                payload=text,
+                payload=strip_atlas_header(text),
                 payload_is_prose=True,
                 retriever_meta={
                     "score_method": "node_freq_khop",

--- a/src/arandu/shared/rag/retrievers/khop_subgraph.py
+++ b/src/arandu/shared/rag/retrievers/khop_subgraph.py
@@ -214,7 +214,7 @@ class KHopSubgraphRetriever:
         # downstream identity, and surfacing them in `RetrievedPassage`
         # would carry an opaque hash that can't be joined with the offset
         # sidecar the judges consult.
-        ranked: list[tuple[str, int]] = []
+        ranked: list[tuple[str, int, str]] = []
         for passage_node_id, count in passage_counts.most_common():
             text = self._passage_text[passage_node_id]
             atlas_passage_id = self._text_to_passage_id.get(text)
@@ -225,7 +225,7 @@ class KHopSubgraphRetriever:
                     passage_node_id,
                 )
                 continue
-            ranked.append((atlas_passage_id, count))
+            ranked.append((atlas_passage_id, count, text))
             if len(ranked) >= top_k:
                 break
 
@@ -233,18 +233,26 @@ class KHopSubgraphRetriever:
             return []
 
         max_count = ranked[0][1]
+        # Carry the passage text inline in `payload` (marked prose) so the
+        # Answerer doesn't re-resolve `chunk_id` through `passage_offsets.json`
+        # at answer time — the retriever already holds the exact text. The
+        # `chunk_id` stays the sidecar-joinable `<file_id>:<chunk_index>` for
+        # joins/dedup, and `payload_is_prose=True` keeps source_recovery's
+        # token-containment lens applicable (unlike triple payloads).
         return [
             RetrievedPassage(
                 chunk_id=atlas_passage_id,
                 rank=rank,
                 score=count / max_count,
+                payload=text,
+                payload_is_prose=True,
                 retriever_meta={
                     "score_method": "node_freq_khop",
                     "k_hop": self._k_hop,
                     "max_postings": self._max_postings,
                 },
             )
-            for rank, (atlas_passage_id, count) in enumerate(ranked)
+            for rank, (atlas_passage_id, count, text) in enumerate(ranked)
         ]
 
     def _entity_link(self, question: str) -> Iterable[str]:

--- a/src/arandu/shared/rag/schemas.py
+++ b/src/arandu/shared/rag/schemas.py
@@ -47,11 +47,18 @@ class RetrievedPassage(BaseModel):
             offset / ChunkSet lookup. When set, the Answerer uses
             ``payload`` verbatim as the prompt context for this record,
             bypassing offset resolution. Use cases: KG-triple
-            linearization (``KHopTripleRetriever``), LLM-summarized
-            chunks, or any retriever whose output isn't a sliceable span
-            of source text. Downstream judging that operates on offsets
-            (``passage_coverage`` offset variant) skips records where
-            ``payload`` is set, since they have no source-text grounding.
+            linearization (``KHopTripleRetriever``), passages carried
+            inline to decouple from offset resolution
+            (``KHopSubgraphRetriever``), LLM-summarized chunks, or any
+            retriever whose output isn't a sliceable span of source text.
+        payload_is_prose: Whether a set ``payload`` is verbatim source-text
+            prose (``True``; e.g. ``KHopSubgraphRetriever``) versus synthetic
+            non-prose content (``False`` default; e.g. linearized triples).
+            Lets prose-grounded deterministic judging (``source_recovery``
+            token containment) still apply to inline-prose payloads while
+            skipping non-prose ones, where token overlap with the source
+            would be structurally near-zero regardless of relevance. Ignored
+            when ``payload`` is ``None`` (offset-resolved passages are prose).
     """
 
     chunk_id: str = Field(..., min_length=1)
@@ -62,7 +69,16 @@ class RetrievedPassage(BaseModel):
         default=None,
         description=(
             "Optional raw content overriding offset-based resolution. "
-            "Set by retrievers emitting non-chunk content (e.g. triples)."
+            "Set by retrievers emitting non-chunk content (e.g. triples) or "
+            "carrying source prose inline (e.g. khop_passage)."
+        ),
+    )
+    payload_is_prose: bool = Field(
+        default=False,
+        description=(
+            "Whether a set payload is verbatim source prose (True) vs "
+            "synthetic non-prose content like triples (False). Gates "
+            "prose-grounded judging; ignored when payload is None."
         ),
     )
 

--- a/tests/shared/rag/judge_answers/test_batch.py
+++ b/tests/shared/rag/judge_answers/test_batch.py
@@ -18,9 +18,9 @@ from arandu.shared.judge.schemas import (
     JudgePipelineResult,
     JudgeStepResult,
 )
-from arandu.shared.rag.judge_answers.batch import run_judge_answers_batch
+from arandu.shared.rag.judge_answers.batch import _judge_one, run_judge_answers_batch
 from arandu.shared.rag.judge_answers.settings import JudgeAnswersSettings
-from arandu.shared.rag.schemas import AnswerRecord
+from arandu.shared.rag.schemas import AnswerRecord, RetrievedPassage
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -388,3 +388,57 @@ class TestBuildLlmClientFailures:
         settings = JudgeAnswersSettings(provider="custom", base_url=None)
         with pytest.raises(ValueError, match="provider='custom' requires a base URL"):
             run_judge_answers_batch(pipeline_id="run_x", settings=settings, base_dir=tmp_path)
+
+
+class TestPassagesAreNonProseFlag:
+    """`_judge_one` flags source_recovery N/A only for *non-prose* payloads.
+
+    khop_passage carries source prose inline (payload + payload_is_prose=True),
+    so it must NOT be treated as non-prose (source_recovery should still score
+    it); only synthetic payloads like triples are non-prose.
+    """
+
+    def _captured_flag(self, passages: list[RetrievedPassage]) -> bool:
+        judge = MagicMock()
+        answer = AnswerRecord(
+            qa_pair_id="src_a:chk_aa:0",
+            question="Onde Maria mora?",
+            retriever_id="khop_passage",
+            chunker_id="cep_4k",
+            top_k=5,
+            passages=passages,
+            elapsed_ms=1.0,
+            is_answerable=True,
+            answer_text="Itaqui.",
+            abstained=False,
+            rationale="From passages.",
+            answerer_model="qwen3:14b",
+            answerer_temperature=0.2,
+        )
+        _judge_one(judge=judge, answer=answer, gold=None, passage_text={})
+        return judge.evaluate.call_args.kwargs["passages_are_non_prose"]
+
+    def test_prose_payload_is_not_flagged_non_prose(self) -> None:
+        passage = RetrievedPassage(
+            chunk_id="src_a:0",
+            rank=0,
+            score=1.0,
+            payload="Maria mora em Itaqui.",
+            payload_is_prose=True,
+        )
+        assert self._captured_flag([passage]) is False
+
+    def test_triple_payload_is_flagged_non_prose(self) -> None:
+        passage = RetrievedPassage(
+            chunk_id="triple:abc123",
+            rank=0,
+            score=1.0,
+            payload="[pessoa] Maria --[mora_em]--> [lugar] Itaqui",
+            payload_is_prose=False,
+        )
+        assert self._captured_flag([passage]) is True
+
+    def test_offset_resolved_passage_is_not_flagged_non_prose(self) -> None:
+        # No payload -> offset-resolved source prose -> scores normally.
+        passage = RetrievedPassage(chunk_id="src_a:0", rank=0, score=1.0)
+        assert self._captured_flag([passage]) is False

--- a/tests/shared/rag/judge_answers/test_heuristic.py
+++ b/tests/shared/rag/judge_answers/test_heuristic.py
@@ -63,7 +63,7 @@ class TestSourceRecoveryCriterion:
         score = SourceRecoveryCriterion().evaluate(
             retrieved_text="Maria mora em Itaqui",
             context="Maria mora em Itaqui na beira do rio",
-            passages_are_payload=False,
+            passages_are_non_prose=False,
         )
         assert score.score == 1.0
 
@@ -73,7 +73,7 @@ class TestSourceRecoveryCriterion:
         score = SourceRecoveryCriterion(language="en").evaluate(
             retrieved_text="Maria lives in Itaqui",
             context="Maria lives in Itaqui by the river",
-            passages_are_payload=False,
+            passages_are_non_prose=False,
         )
         assert score.score == 1.0
 
@@ -83,28 +83,41 @@ class TestSourceRecoveryCriterion:
         score = SourceRecoveryCriterion().evaluate(
             retrieved_text="Maria mora em Brasilia",
             context="Maria mora em Itaqui",
-            passages_are_payload=False,
+            passages_are_non_prose=False,
         )
         assert score.score is not None
         assert 0.0 < score.score < 1.0
 
-    def test_payload_arm_scores_none(self) -> None:
+    def test_non_prose_payload_arm_scores_none(self) -> None:
+        # Triples (non-prose payload) -> N/A: token overlap is structurally
+        # near-zero regardless of relevance, so it would bias the cross-arm mean.
         score = SourceRecoveryCriterion().evaluate(
             retrieved_text="(Maria, mora_em, Itaqui)",
             context="Maria mora em Itaqui",
-            passages_are_payload=True,
+            passages_are_non_prose=True,
         )
         assert score.score is None
         assert score.error is None
 
+    def test_prose_payload_arm_still_scores(self) -> None:
+        # Inline-prose payload (khop_passage, payload_is_prose=True) sets
+        # passages_are_non_prose=False, so containment scores normally — the
+        # payload IS source prose, unlike triples.
+        score = SourceRecoveryCriterion().evaluate(
+            retrieved_text="Maria mora em Itaqui",
+            context="Maria mora em Itaqui na beira do rio",
+            passages_are_non_prose=False,
+        )
+        assert score.score == 1.0
+
     def test_empty_passages_scores_none(self) -> None:
         score = SourceRecoveryCriterion().evaluate(
-            retrieved_text="", context="Maria mora em Itaqui", passages_are_payload=False
+            retrieved_text="", context="Maria mora em Itaqui", passages_are_non_prose=False
         )
         assert score.score is None
 
     def test_empty_context_scores_none(self) -> None:
         score = SourceRecoveryCriterion().evaluate(
-            retrieved_text="Maria mora em Itaqui", context="", passages_are_payload=False
+            retrieved_text="Maria mora em Itaqui", context="", passages_are_non_prose=False
         )
         assert score.score is None

--- a/tests/shared/rag/judge_answers/test_judge.py
+++ b/tests/shared/rag/judge_answers/test_judge.py
@@ -32,7 +32,7 @@ def _kwargs(*, is_answerable: bool, abstained: str) -> dict[str, object]:
         "rationale": "r",
         "passages_text": "p",
         "retrieved_text": "Maria mora em Itaqui",
-        "passages_are_payload": False,
+        "passages_are_non_prose": False,
         "question": "Onde Maria mora?",
         "gold_answer": "Em Itaqui.",
         "context": "Maria mora em Itaqui na beira do rio",

--- a/tests/shared/rag/retrievers/test_khop_subgraph.py
+++ b/tests/shared/rag/retrievers/test_khop_subgraph.py
@@ -221,6 +221,29 @@ class TestKHopSubgraphRetrieverRetrieve:
             assert r.payload != r.chunk_id, "payload must be the text, not the id"
             assert r.payload_is_prose is True
 
+    def test_payload_strips_atlas_header(self, tmp_path: Path) -> None:
+        # atlas KG passage labels carry a `[Contexto…][Transcrição]\n` header
+        # that the offset-resolution path strips before slicing. The inline
+        # payload must strip the SAME header so khop_passage feeds the answerer
+        # and source_recovery the header-free text every other arm sees;
+        # otherwise the header tokens confound the cross-arm comparison.
+        body = "A enchente do rio Uruguai em 2024."
+        label = f"[Contexto da Entrevista] entrevista de teste [Transcrição]\n{body}"
+        kg = nx.DiGraph()
+        kg.add_node("p_h", type="passage", id=label, file_id="p_h")
+        kg.add_node("e_rio", type="entity", id="rio Uruguai", file_id="p_h")
+        kg.add_edge("e_rio", "p_h", relation="mentions")
+        path = _write_kg_layout(kg, tmp_path)
+
+        retriever = KHopSubgraphRetriever(kg_outputs_dir=path, k_hop=2)
+        results = retriever.retrieve("rio Uruguai enchente", top_k=5)
+
+        assert results, "expected the header-bearing passage to be retrieved"
+        for r in results:
+            assert "[Transcrição]" not in r.payload
+            assert "[Contexto" not in r.payload
+            assert r.payload == body
+
     def test_passage_with_no_kg_extraction_record_dropped(self, tmp_path: Path) -> None:
         # If a KG passage node has no matching kg_extraction record (corpus
         # drift between KG build and JSONL on disk), the retriever drops it

--- a/tests/shared/rag/retrievers/test_khop_subgraph.py
+++ b/tests/shared/rag/retrievers/test_khop_subgraph.py
@@ -206,6 +206,21 @@ class TestKHopSubgraphRetrieverRetrieve:
             assert "[Contexto" not in r.chunk_id
             assert "A enchente" not in r.chunk_id
 
+    def test_payload_carries_source_prose(self, tmp_path: Path) -> None:
+        # khop_passage carries the source passage inline in `payload` so the
+        # Answerer doesn't re-resolve `chunk_id` through passage_offsets.json at
+        # answer time. `chunk_id` stays the joinable id; `payload_is_prose=True`
+        # keeps source_recovery (prose token-containment) applicable, unlike the
+        # triple arm's non-prose payload.
+        path = _write_kg_layout(_build_minimal_kg(), tmp_path)
+        retriever = KHopSubgraphRetriever(kg_outputs_dir=path, k_hop=2)
+        results = retriever.retrieve("rio Uruguai enchente", top_k=5)
+        assert results, "expected non-empty results for in-KG question"
+        for r in results:
+            assert r.payload, "expected source prose carried in payload"
+            assert r.payload != r.chunk_id, "payload must be the text, not the id"
+            assert r.payload_is_prose is True
+
     def test_passage_with_no_kg_extraction_record_dropped(self, tmp_path: Path) -> None:
         # If a KG passage node has no matching kg_extraction record (corpus
         # drift between KG build and JSONL on disk), the retriever drops it


### PR DESCRIPTION
## What

`khop_passage` now carries each retrieved passage's text inline in `RetrievedPassage.payload` instead of emitting only a `chunk_id` the Answerer re-resolves at answer time.

## Why

The retriever already holds the exact passage text at retrieval (`khop_subgraph.py` looked it up to map the KG node → atlas passage_id, then discarded it). Emitting only `chunk_id` forced the Answerer to re-resolve text through `passage_offsets.json` + the transcription — the same multi-step resolution that produced **0 records for bm25** when a filename drifted (the dry-run bug). Carrying the text inline removes that answer-time dependency.

## The source_recovery interaction

Naively setting `payload` would have made `source_recovery` (deterministic token-containment) go N/A for khop_passage, because the judge skipped *any* payload-bearing record. But that flag conflated two different things:

- **synthetic non-prose payload** (khop_triple's linearized triples) — token overlap with the source is structurally near-zero regardless of relevance → legitimately N/A.
- **verbatim prose payload** (khop_passage) — real source text → `source_recovery` is meaningful and should run.

So this PR adds `RetrievedPassage.payload_is_prose` and switches the judge's skip predicate from `any(payload is not None)` to `any(payload is not None and not payload_is_prose)`. khop_passage sets `payload_is_prose=True`; only triples stay N/A.

## Effect on judging

- `passage_coverage` (LLM, the active retrieval criterion): **unaffected** — it sees the same passage text either way.
- `source_recovery` (heuristic): **still scores khop_passage**; N/A only for triples (unchanged) and empty/no-context cases.
- The byte-offset `offset_coverage` variant remains unwired (no change).

## Note for the re-run

This changes the *source* of khop_passage's answerer text (inline KG-node text vs offset-resolved text). Content should be identical; if there was any whitespace drift between the two, khop_passage's `passage_coverage`/`source_recovery` numbers may shift slightly — the inline version is the more faithful one.

## Tests

1408 pass (+5: prose-payload retriever assertion, prose-vs-non-prose source_recovery, and the `passages_are_non_prose` flag computation for prose-payload / triple / offset-resolved shapes). Ruff check + format clean.