### PR TITLE
fix(rag): de-stricten + unify k-hop retrieval (lemmatized IDF top-K seeds, seed-proximity scoring)

### DIFF
--- a/scripts/slurm/AGENTS.md
+++ b/scripts/slurm/AGENTS.md
@@ -36,6 +36,21 @@ PIPELINE_ID=<run-id> [overrides] sbatch [--exclude=<nodes>] scripts/slurm/<step>
 | `MIN_DISK_GB` | 15 | Disk-floor preflight on the Docker root partition |
 | `USE_GPU_OLLAMA` | set by partition script | Selects `kg-gpu` vs `kg` compose profile |
 
+## Partitions: access + GPU (confirmed 2026-06-15 — do NOT re-test)
+
+- **tupi** — the ONLY GPU partition we can use. Every GPU/ollama stage
+  (build-kg, cep, judge-qa, answer, judge-answers, atlas_rag retrieve) runs
+  here. Frequently saturated by other users; when it is, **wait** — there is
+  no faster GPU alternative for this account.
+- **draco** — **CPU-only, no GPU.** Idle and fast to schedule; use it for
+  CPU-only work (root-container result prep, the khop retrieve, rag-analysis,
+  chunk, kg-link-passages). NEVER submit a GPU/ollama stage here.
+- **grace** — NO ACCESS (uid not in the allowed group); jobs PEND forever
+  with `uid_..._not_in_group_permitted_to_use_this_partition`. Do not submit.
+
+Never reroute a stuck GPU job to grace or draco to "beat the queue" — grace is
+denied and draco has no GPU. The lever is: wait, or ask the user.
+
 ## Node selection (tupi partition)
 
 Prefer `--exclude=<broken-nodes>` over pinning a node with `--nodelist`: a pin

--- a/src/arandu/cli/retrieve.py
+++ b/src/arandu/cli/retrieve.py
@@ -103,7 +103,7 @@ def retrieve(
     if "bm25" in selected_arms:
         print_info(f"BM25 chunker: {bm25_settings.chunker_id}")
     if any(a.startswith("khop_") for a in selected_arms):
-        print_info(f"K-hop: k_hop={khop_settings.k_hop}, max_postings={khop_settings.max_postings}")
+        print_info(f"K-hop: k_hop={khop_settings.k_hop}, top_k_seeds={khop_settings.top_k_seeds}")
     if atlas_rag_settings is not None:
         print_info(
             f"atlas_rag LLM: provider={atlas_rag_settings.provider}, "

--- a/src/arandu/shared/rag/retrieve/batch.py
+++ b/src/arandu/shared/rag/retrieve/batch.py
@@ -107,7 +107,7 @@ def run_retrieve_batch(
             benchmark is almost certainly a misconfiguration.
         bm25_settings: BM25 arm settings (chunker view). Defaults
             instantiated from env when omitted.
-        khop_settings: K-hop arm settings (k_hop, max_postings, keyword).
+        khop_settings: K-hop arm settings (k_hop, top_k_seeds, keyword).
             Defaults instantiated from env when omitted.
         atlas_rag_settings: atlas-rag arm settings (LLM provider/model/
             api_key/base_url + keyword/include_events/include_concept).

--- a/src/arandu/shared/rag/retrieve/factory.py
+++ b/src/arandu/shared/rag/retrieve/factory.py
@@ -129,7 +129,7 @@ def build_retriever(
             kg_outputs_dir=kg_outputs_dir,
             keyword=khop_settings.keyword,
             k_hop=khop_settings.k_hop,
-            max_postings=khop_settings.max_postings,
+            top_k_seeds=khop_settings.top_k_seeds,
         )
 
     if arm == "atlas_rag":

--- a/src/arandu/shared/rag/retrieve/settings.py
+++ b/src/arandu/shared/rag/retrieve/settings.py
@@ -175,11 +175,9 @@ class KHopRetrieveSettings(BaseSettings):
             more recall, slower, more dilution. The 2026-05-23 calibration
             against ``test-kg-04`` runs at ``k_hop=2`` for seconds-per-query
             wall time.
-        max_postings: IDF-style cap on per-token entity-link expansion.
-            Tokens whose inverted-index posting list exceeds this size
-            are dropped from the entity link (e.g. ``"enchente"`` in a
-            flood-themed corpus would otherwise link to thousands of
-            entities and dominate the ego graph).
+        top_k_seeds: Max entity-link seeds kept per question, ranked by
+            summed smoothed-IDF weight. Bounds ego-graph size; replaces
+            the previous per-token hard cap on inverted-index expansion.
         keyword: atlas-rag's filename pattern for the graphml. Defaults
             to project convention ``"transcriptions.json"`` (see
             :mod:`arandu.kg.atlas_backend`).
@@ -191,10 +189,14 @@ class KHopRetrieveSettings(BaseSettings):
         ge=1,
         description="Ego-graph radius around entity-linked seeds.",
     )
-    max_postings: int = Field(
-        default=200,
+    top_k_seeds: int = Field(
+        default=50,
         ge=1,
-        description="IDF-style cap on per-token entity-link expansion.",
+        description=(
+            "Max entity-link seeds kept per question, ranked by summed "
+            "smoothed-IDF weight. Bounds ego-graph size (replaces the old "
+            "previous per-token posting hard cap)."
+        ),
     )
     keyword: str = Field(
         default="transcriptions.json",

--- a/src/arandu/shared/rag/retrievers/_khop_common.py
+++ b/src/arandu/shared/rag/retrievers/_khop_common.py
@@ -23,7 +23,7 @@ from functools import lru_cache
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Iterable
 
     import networkx as nx
 
@@ -231,3 +231,41 @@ def link_entities(
         return []
     ranked = sorted(weights.items(), key=lambda kv: kv[1], reverse=True)
     return [node for node, _ in ranked[:top_k_seeds]]
+
+
+def subgraph_node_distances(kg: nx.DiGraph, seeds: Iterable[str], k_hop: int) -> dict[str, int]:
+    """Min undirected hop-distance from any seed to each node within ``k_hop``.
+
+    Unions the ``k_hop`` ego graph of each seed, induces that node set, and runs
+    single-source shortest paths (undirected, cutoff ``k_hop``) from every seed,
+    keeping the minimum distance per reached node. Seeds map to 0. The returned
+    dict's keys are exactly the in-``k_hop`` subgraph node set, so callers that
+    also need that subgraph can use ``kg.subgraph(dist.keys())`` without a second
+    ego-graph pass.
+
+    Args:
+        kg: The knowledge graph.
+        seeds: Entity-linked seed node IDs.
+        k_hop: Ego-graph radius / shortest-path cutoff.
+
+    Returns:
+        ``{node_id: min_distance}`` for every node within ``k_hop`` of a seed;
+        empty when ``seeds`` is empty.
+    """
+    import networkx as nx
+
+    seeds = list(seeds)
+    if not seeds:
+        return {}
+    subgraph_nodes: set[str] = set()
+    for seed in seeds:
+        subgraph_nodes.update(nx.ego_graph(kg, seed, radius=k_hop, undirected=True).nodes)
+    induced_undir = kg.subgraph(subgraph_nodes).to_undirected(as_view=True)
+    dist: dict[str, int] = {}
+    for seed in seeds:
+        for node, d in nx.single_source_shortest_path_length(
+            induced_undir, seed, cutoff=k_hop
+        ).items():
+            if node not in dist or d < dist[node]:
+                dist[node] = d
+    return dist

--- a/src/arandu/shared/rag/retrievers/_khop_common.py
+++ b/src/arandu/shared/rag/retrievers/_khop_common.py
@@ -16,7 +16,13 @@ variant ever appears, it imports from here too.
 from __future__ import annotations
 
 import re
+import threading
 import unicodedata
+from functools import lru_cache
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 _TOKEN_RE = re.compile(r"\w+", flags=re.UNICODE)
 _MIN_TOKEN_LEN = 3
@@ -65,19 +71,68 @@ _STOPWORDS: frozenset[str] = frozenset(
 )  # fmt: skip
 
 
-def _tokenize(text: str, *, filter_stopwords: bool = False) -> list[str]:
-    """Whitespace + punctuation split, lowercased + NFKC-normalised.
+@lru_cache(maxsize=1)
+def _lemmatizer() -> Callable[[str], list[str]] | None:
+    """Lazy spaCy lemmatizer (pt_core_news_sm); None when unavailable.
 
-    When ``filter_stopwords`` is true, tokens in :data:`_STOPWORDS` and
-    tokens shorter than :data:`_MIN_TOKEN_LEN` are dropped. We do NOT
-    filter at index-build time (node labels keep all tokens so multi-word
-    names like "rio Uruguai" remain linkable when the question mentions
-    only the rare half); only the QUERY tokens are filtered, so a question
-    composed only of stopwords degenerates to an empty entity link and
-    the graph-floor guarantee fires (returns ``[]``).
+    Returns:
+        A callable that accepts a string and returns a list of casefolded lemmas,
+        or ``None`` if spaCy or its Portuguese model is not installed.
     """
-    normalised = unicodedata.normalize("NFKC", text).casefold()
-    tokens = _TOKEN_RE.findall(normalised)
+    try:
+        import spacy
+    except ImportError:
+        return None
+    try:
+        nlp = spacy.load("pt_core_news_sm", disable=["ner", "parser"])
+    except OSError:
+        return None
+
+    # spaCy does not formally guarantee thread safety for a shared Language
+    # object (Vocab/StringStore mutate during calls). Mirror the lock pattern
+    # from _bm25_tokenize._spacy_tokenizer to serialize access across workers.
+    lock = threading.Lock()
+
+    def lemmatize(text: str) -> list[str]:
+        with lock:
+            return [tok.lemma_.casefold() for tok in nlp(text) if not tok.is_space]
+
+    return lemmatize
+
+
+def _tokenize(text: str, *, filter_stopwords: bool = False) -> list[str]:
+    """Tokenize ``text`` with spaCy lemmatization when available, else whitespace split.
+
+    Uses ``pt_core_news_sm`` lemmatization to collapse inflectional variants so
+    that query tokens match node labels regardless of number or conjugation (e.g.
+    "enchentes" -> "enchente", "pescavam" -> "pescar"). Derivational variants
+    (e.g. "pescador" vs "pesca") remain distinct — accepted limitation of
+    lexical-only matching.
+
+    When spaCy or ``pt_core_news_sm`` is unavailable, falls back to NFKC
+    normalisation + ``\\w+`` regex split (the original whitespace path).
+
+    When ``filter_stopwords`` is true, tokens in :data:`_STOPWORDS` and tokens
+    shorter than :data:`_MIN_TOKEN_LEN` are dropped. We do NOT filter at
+    index-build time (node labels keep all tokens so multi-word names like
+    "rio Uruguai" remain linkable when the question mentions only the rare
+    half); only the QUERY tokens are filtered, so a question composed only of
+    stopwords degenerates to an empty entity link and the graph-floor guarantee
+    fires (returns ``[]``).
+
+    Args:
+        text: Raw text to tokenize.
+        filter_stopwords: When ``True``, drop stopwords and short tokens.
+
+    Returns:
+        List of casefolded token strings (lemmatized when spaCy is available).
+    """
+    lemmatize = _lemmatizer()
+    if lemmatize is not None:
+        tokens = lemmatize(text)
+    else:
+        normalised = unicodedata.normalize("NFKC", text).casefold()
+        tokens = _TOKEN_RE.findall(normalised)
     if filter_stopwords:
         tokens = [t for t in tokens if t not in _STOPWORDS and len(t) >= _MIN_TOKEN_LEN]
     return tokens

--- a/src/arandu/shared/rag/retrievers/_khop_common.py
+++ b/src/arandu/shared/rag/retrievers/_khop_common.py
@@ -15,6 +15,7 @@ variant ever appears, it imports from here too.
 
 from __future__ import annotations
 
+import math
 import re
 import threading
 import unicodedata
@@ -24,9 +25,14 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    import networkx as nx
+
 _TOKEN_RE = re.compile(r"\w+", flags=re.UNICODE)
 _MIN_TOKEN_LEN = 3
+# Kept for backward compat — khop_subgraph and khop_triple still import this
+# until Tasks 3 and 4 migrate them to link_entities.
 _DEFAULT_MAX_POSTINGS = 200
+_DEFAULT_TOP_K_SEEDS = 50
 
 # Linkable node types (used by both arms during entity-linking). Concept
 # nodes ARE linkable — a question may name a concept directly — but the
@@ -136,3 +142,95 @@ def _tokenize(text: str, *, filter_stopwords: bool = False) -> list[str]:
     if filter_stopwords:
         tokens = [t for t in tokens if t not in _STOPWORDS and len(t) >= _MIN_TOKEN_LEN]
     return tokens
+
+
+def build_label_index(kg: nx.DiGraph) -> tuple[dict[str, set[str]], int]:
+    """Build the token->nodes inverted index over linkable node labels.
+
+    Returns ``(token_to_nodes, n_linkable)`` where ``n_linkable`` is the
+    number of linkable nodes (the IDF document count — the universe the
+    labels are drawn from). Labels are NOT stopword-filtered (index-build
+    path) so multi-word names stay linkable on their rare half.
+
+    Args:
+        kg: A NetworkX directed graph with node attributes ``id`` (label text)
+            and ``type`` (used to decide linkability via ``_LINKABLE_TYPES``).
+
+    Returns:
+        A tuple of (token_to_nodes, n_linkable) where token_to_nodes maps each
+        token to the set of node IDs whose label contains it, and n_linkable is
+        the count of linkable nodes.
+    """
+    from collections import defaultdict
+
+    token_to_nodes: dict[str, set[str]] = defaultdict(set)
+    n_linkable = 0
+    for node_id, attrs in kg.nodes(data=True):
+        if attrs.get("type") in _LINKABLE_TYPES:
+            n_linkable += 1
+            for token in _tokenize(attrs.get("id", "")):
+                token_to_nodes[token].add(node_id)
+    return token_to_nodes, n_linkable
+
+
+def score_seeds(
+    question: str, token_to_nodes: dict[str, set[str]], n_linkable: int
+) -> dict[str, float]:
+    """Map candidate seed node -> summed smoothed-IDF weight of its linking tokens.
+
+    Smoothed IDF ``log((N+1)/(df+1))`` stays strictly non-negative (a token in
+    every node still contributes a weight of 0.0, so the rarest available token
+    can always seed). A node matched by several query tokens accumulates their
+    weights.
+
+    Args:
+        question: Raw question text; query tokens are stopword-filtered.
+        token_to_nodes: Inverted index from :func:`build_label_index`.
+        n_linkable: Total linkable node count from :func:`build_label_index`.
+
+    Returns:
+        Dict mapping node IDs to their accumulated IDF-weight score.
+    """
+    from collections import defaultdict
+
+    weights: dict[str, float] = defaultdict(float)
+    for token in set(_tokenize(question, filter_stopwords=True)):
+        postings = token_to_nodes.get(token)
+        if not postings:
+            continue
+        idf = math.log((n_linkable + 1) / (len(postings) + 1))
+        for node in postings:
+            weights[node] += idf
+    return weights
+
+
+def link_entities(
+    question: str,
+    token_to_nodes: dict[str, set[str]],
+    n_linkable: int,
+    *,
+    top_k_seeds: int = _DEFAULT_TOP_K_SEEDS,
+) -> list[str]:
+    """Entity-link a question to the top-K KG seed nodes by IDF weight.
+
+    Keeps every matched token (no hard drop); weights candidate seeds by
+    summed smoothed IDF; returns the top-K by weight. Empty only when no
+    query token matches any label (true graph-floor). The top-K budget
+    bounds downstream ego-graph size (the role the old ``max_postings``
+    cap played).
+
+    Args:
+        question: Raw question text used to identify seed nodes.
+        token_to_nodes: Inverted index from :func:`build_label_index`.
+        n_linkable: Total linkable node count from :func:`build_label_index`.
+        top_k_seeds: Maximum number of seed nodes to return.
+
+    Returns:
+        List of node IDs (strings), ranked by descending IDF weight, capped
+        at ``top_k_seeds``. Returns ``[]`` when no query token matches any label.
+    """
+    weights = score_seeds(question, token_to_nodes, n_linkable)
+    if not weights:
+        return []
+    ranked = sorted(weights.items(), key=lambda kv: kv[1], reverse=True)
+    return [node for node, _ in ranked[:top_k_seeds]]

--- a/src/arandu/shared/rag/retrievers/_khop_common.py
+++ b/src/arandu/shared/rag/retrievers/_khop_common.py
@@ -213,8 +213,8 @@ def link_entities(
     Keeps every matched token (no hard drop); weights candidate seeds by
     summed smoothed IDF; returns the top-K by weight. Empty only when no
     query token matches any label (true graph-floor). The top-K budget
-    bounds downstream ego-graph size (the role the old ``max_postings``
-    cap played).
+    bounds downstream ego-graph size (the role previously played by the
+    per-token posting cap).
 
     Args:
         question: Raw question text used to identify seed nodes.

--- a/src/arandu/shared/rag/retrievers/_khop_common.py
+++ b/src/arandu/shared/rag/retrievers/_khop_common.py
@@ -29,9 +29,6 @@ if TYPE_CHECKING:
 
 _TOKEN_RE = re.compile(r"\w+", flags=re.UNICODE)
 _MIN_TOKEN_LEN = 3
-# Kept for backward compat — khop_subgraph and khop_triple still import this
-# until Tasks 3 and 4 migrate them to link_entities.
-_DEFAULT_MAX_POSTINGS = 200
 _DEFAULT_TOP_K_SEEDS = 50
 
 # Linkable node types (used by both arms during entity-linking). Concept

--- a/src/arandu/shared/rag/retrievers/khop_subgraph.py
+++ b/src/arandu/shared/rag/retrievers/khop_subgraph.py
@@ -37,7 +37,7 @@ Implementation notes:
 from __future__ import annotations
 
 import logging
-from collections import Counter, defaultdict
+from collections import Counter
 from pathlib import Path  # noqa: TC003
 from typing import TYPE_CHECKING
 
@@ -48,9 +48,9 @@ from arandu.kg.passage_offsets import (
     strip_atlas_header,
 )
 from arandu.shared.rag.retrievers._khop_common import (
-    _DEFAULT_MAX_POSTINGS,
-    _LINKABLE_TYPES,
-    _tokenize,
+    _DEFAULT_TOP_K_SEEDS,
+    build_label_index,
+    link_entities,
 )
 from arandu.shared.rag.schemas import RetrievedPassage
 
@@ -77,7 +77,7 @@ class KHopSubgraphRetriever:
         kg_outputs_dir: Path,
         keyword: str = "transcriptions.json",
         k_hop: int = 2,
-        max_postings: int = _DEFAULT_MAX_POSTINGS,
+        top_k_seeds: int = _DEFAULT_TOP_K_SEEDS,
         retriever_id: str | None = None,
     ) -> None:
         """Load the KG, the ``passage_text → passage_id`` map, and the entity-label index.
@@ -92,27 +92,21 @@ class KHopSubgraphRetriever:
                 convention ``"transcriptions.json"`` (cf.
                 :mod:`arandu.kg.atlas_backend`).
             k_hop: Ego-graph radius used at retrieval time. Must be ``>= 1``.
-            max_postings: A poor-person's IDF threshold. Tokens whose
-                inverted-index posting list exceeds this size are treated
-                as too common and dropped from the entity link. Bounds the
-                worst-case subgraph size: with ``max_postings=200`` and
-                ``k_hop=2`` the per-query work stays in the seconds-range
-                on a 14k-node KG. Without it, common-but-topical tokens
-                like "enchente" (which name-matches thousands of entities
-                in a flood-themed corpus) blow the ego-graph up to most of
-                the giant component, producing identical results across
-                very different questions in minutes-per-query.
+            top_k_seeds: Max entity-link seeds kept per question (ranked by
+                summed smoothed-IDF weight); bounds ego-graph size. A smaller
+                value prunes low-weight seeds that would otherwise expand the
+                subgraph with loosely related nodes.
             retriever_id: Optional override of :attr:`DEFAULT_RETRIEVER_ID`.
 
         Raises:
             FileNotFoundError: If the graphml or the ``kg_extraction/``
                 directory is missing under ``kg_outputs_dir``.
-            ValueError: If ``k_hop < 1`` or ``max_postings < 1``.
+            ValueError: If ``k_hop < 1`` or ``top_k_seeds < 1``.
         """
         if k_hop < 1:
             raise ValueError(f"k_hop must be >= 1, got {k_hop}")
-        if max_postings < 1:
-            raise ValueError(f"max_postings must be >= 1, got {max_postings}")
+        if top_k_seeds < 1:
+            raise ValueError(f"top_k_seeds must be >= 1, got {top_k_seeds}")
 
         graphml_path = kg_outputs_dir / "kg_graphml" / f"{keyword}_graph.graphml"
         if not graphml_path.exists():
@@ -127,7 +121,7 @@ class KHopSubgraphRetriever:
 
         self.retriever_id = retriever_id or self.DEFAULT_RETRIEVER_ID
         self._k_hop = k_hop
-        self._max_postings = max_postings
+        self._top_k_seeds = top_k_seeds
         self._kg: nx.DiGraph = nx.read_graphml(str(graphml_path))
 
         # passage_text → "<source_file_id>:<chunk_index>" — built from the
@@ -140,20 +134,14 @@ class KHopSubgraphRetriever:
             kg_extraction_dir
         )
 
-        # Token-level inverted index: token → set of linkable node_ids whose
-        # label tokenizes to include that token. Lets entity-link be O(Q)
-        # where Q is the question's distinct token count, instead of
-        # O(N * Q) over every node every query.
-        self._token_to_nodes: dict[str, set[str]] = defaultdict(set)
-        self._passage_text: dict[str, str] = {}
-        for node_id, attrs in self._kg.nodes(data=True):
-            node_type = attrs.get("type")
-            label = attrs.get("id", "")
-            if node_type in _LINKABLE_TYPES:
-                for token in _tokenize(label):
-                    self._token_to_nodes[token].add(node_id)
-            elif node_type == "passage":
-                self._passage_text[node_id] = label
+        # Shared IDF-weighted inverted index (build_label_index covers
+        # linkable nodes only) + passage-text map (iterated once here).
+        self._token_to_nodes, self._n_linkable = build_label_index(self._kg)
+        self._passage_text: dict[str, str] = {
+            node_id: attrs.get("id", "")
+            for node_id, attrs in self._kg.nodes(data=True)
+            if attrs.get("type") == "passage"
+        }
 
     def retrieve(self, question: str, top_k: int) -> list[RetrievedPassage]:
         """Run the entity-link + k-hop + frequency-scoring pipeline.
@@ -258,35 +246,14 @@ class KHopSubgraphRetriever:
                 retriever_meta={
                     "score_method": "node_freq_khop",
                     "k_hop": self._k_hop,
-                    "max_postings": self._max_postings,
+                    "top_k_seeds": self._top_k_seeds,
                 },
             )
             for rank, (atlas_passage_id, count, text) in enumerate(ranked)
         ]
 
     def _entity_link(self, question: str) -> Iterable[str]:
-        """Find seed nodes whose label tokens overlap the question's tokens.
-
-        Token-level intersection — a question token "Uruguai" hits any
-        linkable node whose label tokenizes to include "uruguai" (case-
-        folded). Returns deduplicated node IDs. Empty when no token matches
-        (graph-floor guarantee fires upstream).
-
-        Query tokens are filtered via :func:`_tokenize`'s stopword mode so
-        common particles like "que" / "a" / "de" don't link to thousands of
-        unrelated entities. Node-label tokens at index-build time are NOT
-        stopword-filtered so multi-word names like "rio Uruguai" remain
-        linkable when the question mentions only the rare half ("Uruguai").
-        """
-        question_tokens = set(_tokenize(question, filter_stopwords=True))
-        if not question_tokens:
-            return []
-        seeds: set[str] = set()
-        for token in question_tokens:
-            postings = self._token_to_nodes.get(token, ())
-            if len(postings) > self._max_postings:
-                # Token is too common in the KG — likely a topical word that
-                # would explode the seed set. Skip it (IDF-style threshold).
-                continue
-            seeds.update(postings)
-        return seeds
+        """IDF-weighted top-K lexical entity link (see _khop_common.link_entities)."""
+        return link_entities(
+            question, self._token_to_nodes, self._n_linkable, top_k_seeds=self._top_k_seeds
+        )

--- a/src/arandu/shared/rag/retrievers/khop_subgraph.py
+++ b/src/arandu/shared/rag/retrievers/khop_subgraph.py
@@ -37,7 +37,6 @@ Implementation notes:
 from __future__ import annotations
 
 import logging
-from collections import Counter
 from pathlib import Path  # noqa: TC003
 from typing import TYPE_CHECKING
 
@@ -51,6 +50,7 @@ from arandu.shared.rag.retrievers._khop_common import (
     _DEFAULT_TOP_K_SEEDS,
     build_label_index,
     link_entities,
+    subgraph_node_distances,
 )
 from arandu.shared.rag.schemas import RetrievedPassage
 
@@ -164,40 +164,32 @@ class KHopSubgraphRetriever:
         if not seeds:
             return []
 
-        # Union the k-hop ego graph of each seed. NetworkX's `ego_graph`
-        # returns a copy already; we union node IDs only.
-        subgraph_nodes: set[str] = set()
-        for seed in seeds:
-            ego = nx.ego_graph(self._kg, seed, radius=self._k_hop, undirected=True)
-            subgraph_nodes.update(ego.nodes)
-
-        # Passage scoring: a passage counts only if its NODE is in the
-        # subgraph (i.e. reachable from a seed within k_hop edges). The
-        # score is how many other subgraph nodes reference it via
-        # `file_id` (atlas-rag's mention-attribution convention; cf.
-        # `kg/atlas_backend.py`). Limiting "candidate passages" to those
-        # actually in the subgraph is what makes the `k_hop` knob
-        # meaningful — without it, any seed entity would surface its own
-        # passage regardless of edge connectivity, defeating the
-        # "graph-quality vs retrieval-tool" decomposition this baseline
-        # exists to test.
-        candidate_passages = {n for n in subgraph_nodes if n in self._passage_text}
-        passage_counts: Counter[str] = Counter()
-        for node_id in subgraph_nodes:
-            if node_id in candidate_passages:
-                # Don't count a passage's own self-mention.
-                continue
-            file_id_attr = self._kg.nodes[node_id].get("file_id", "")
-            if not file_id_attr:
-                continue
-            for pid in (p.strip() for p in file_id_attr.split(",")):
-                if pid and pid in candidate_passages:
-                    passage_counts[pid] += 1
-
-        if not passage_counts:
+        node_dist = subgraph_node_distances(self._kg, seeds, self._k_hop)
+        if not node_dist:
             return []
 
-        # Convert KG passage-node hashes to atlas-rag synthesized passage_ids
+        # Project proximal entity/event nodes onto their source passages via
+        # file_id (atlas-rag mention attribution). Each passage scores by its
+        # CLOSEST node's proximity (1/(1+dist)); passages absent from
+        # _passage_text (concept_file sentinel / corpus drift) are dropped.
+        passage_score: dict[str, float] = {}
+        for node, dist in node_dist.items():
+            file_id_attr = self._kg.nodes[node].get("file_id", "")
+            if not file_id_attr:
+                continue
+            prox = 1.0 / (1.0 + dist)
+            for passage_node in (p.strip() for p in file_id_attr.split(",")):
+                if (
+                    passage_node
+                    and passage_node in self._passage_text
+                    and prox > passage_score.get(passage_node, 0.0)
+                ):
+                    passage_score[passage_node] = prox
+
+        if not passage_score:
+            return []
+
+        # Convert KG passage-node keys to atlas-rag synthesized passage_ids
         # (``<source_file_id>:<chunk_index>`` — same namespace as
         # `passage_offsets.json` from PR #100). KG passage nodes that have no
         # matching `kg_extraction` JSONL record are dropped — they're either
@@ -205,25 +197,31 @@ class KHopSubgraphRetriever:
         # downstream identity, and surfacing them in `RetrievedPassage`
         # would carry an opaque hash that can't be joined with the offset
         # sidecar the judges consult.
-        ranked: list[tuple[str, int, str]] = []
-        for passage_node_id, count in passage_counts.most_common():
-            text = self._passage_text[passage_node_id]
+        ranked: list[tuple[str, float, str]] = []
+        seen_atlas: set[str] = set()
+        for passage_node, score in sorted(
+            passage_score.items(), key=lambda kv: kv[1], reverse=True
+        ):
+            text = self._passage_text[passage_node]
             atlas_passage_id = self._text_to_passage_id.get(text)
             if atlas_passage_id is None:
                 logger.debug(
                     "Skipping KG passage node %s — no matching kg_extraction "
                     "record (text-equality miss).",
-                    passage_node_id,
+                    passage_node,
                 )
                 continue
-            ranked.append((atlas_passage_id, count, text))
+            if atlas_passage_id in seen_atlas:
+                continue
+            seen_atlas.add(atlas_passage_id)
+            ranked.append((atlas_passage_id, score, text))
             if len(ranked) >= top_k:
                 break
 
         if not ranked:
             return []
 
-        max_count = ranked[0][1]
+        max_score = ranked[0][1]
         # Carry the passage text inline in `payload` (marked prose) so the
         # Answerer doesn't re-resolve `chunk_id` through `passage_offsets.json`
         # at answer time — the retriever already holds the exact text.
@@ -240,16 +238,16 @@ class KHopSubgraphRetriever:
             RetrievedPassage(
                 chunk_id=atlas_passage_id,
                 rank=rank,
-                score=count / max_count,
+                score=score / max_score,
                 payload=strip_atlas_header(text),
                 payload_is_prose=True,
                 retriever_meta={
-                    "score_method": "node_freq_khop",
+                    "score_method": "seed_proximity",
                     "k_hop": self._k_hop,
                     "top_k_seeds": self._top_k_seeds,
                 },
             )
-            for rank, (atlas_passage_id, count, text) in enumerate(ranked)
+            for rank, (atlas_passage_id, score, text) in enumerate(ranked)
         ]
 
     def _entity_link(self, question: str) -> Iterable[str]:

--- a/src/arandu/shared/rag/retrievers/khop_triple.py
+++ b/src/arandu/shared/rag/retrievers/khop_triple.py
@@ -27,16 +27,15 @@ offset-based source-text resolution.
 from __future__ import annotations
 
 import hashlib
-from collections import defaultdict
 from pathlib import Path  # noqa: TC003
 from typing import TYPE_CHECKING
 
 import networkx as nx
 
 from arandu.shared.rag.retrievers._khop_common import (
-    _DEFAULT_MAX_POSTINGS,
-    _LINKABLE_TYPES,
-    _tokenize,
+    _DEFAULT_TOP_K_SEEDS,
+    build_label_index,
+    link_entities,
 )
 from arandu.shared.rag.schemas import RetrievedPassage
 
@@ -105,7 +104,7 @@ class KHopTripleRetriever:
         kg_outputs_dir: Path,
         keyword: str = "transcriptions.json",
         k_hop: int = 2,
-        max_postings: int = _DEFAULT_MAX_POSTINGS,
+        top_k_seeds: int = _DEFAULT_TOP_K_SEEDS,
         retriever_id: str | None = None,
     ) -> None:
         """Load the KG and pre-build the entity-label index.
@@ -118,20 +117,18 @@ class KHopTripleRetriever:
                 needed — this retriever operates purely on the graphml.
             keyword: atlas-rag's filename pattern.
             k_hop: Ego-graph radius. Must be ``>= 1``.
-            max_postings: IDF-style threshold for the entity link
-                (drops question tokens that hit more than this many
-                linkable nodes). See :class:`KHopSubgraphRetriever` for the
-                calibration rationale.
+            top_k_seeds: Max entity-link seeds kept per question, ranked by
+                summed smoothed-IDF weight; bounds ego-graph size.
             retriever_id: Optional override of :attr:`DEFAULT_RETRIEVER_ID`.
 
         Raises:
             FileNotFoundError: If the graphml is missing.
-            ValueError: If ``k_hop < 1`` or ``max_postings < 1``.
+            ValueError: If ``k_hop < 1`` or ``top_k_seeds < 1``.
         """
         if k_hop < 1:
             raise ValueError(f"k_hop must be >= 1, got {k_hop}")
-        if max_postings < 1:
-            raise ValueError(f"max_postings must be >= 1, got {max_postings}")
+        if top_k_seeds < 1:
+            raise ValueError(f"top_k_seeds must be >= 1, got {top_k_seeds}")
 
         graphml_path = kg_outputs_dir / "kg_graphml" / f"{keyword}_graph.graphml"
         if not graphml_path.exists():
@@ -139,15 +136,10 @@ class KHopTripleRetriever:
 
         self.retriever_id = retriever_id or self.DEFAULT_RETRIEVER_ID
         self._k_hop = k_hop
-        self._max_postings = max_postings
+        self._top_k_seeds = top_k_seeds
         self._kg: nx.DiGraph = nx.read_graphml(str(graphml_path))
 
-        # Token-level inverted index over linkable node labels.
-        self._token_to_nodes: dict[str, set[str]] = defaultdict(set)
-        for node_id, attrs in self._kg.nodes(data=True):
-            if attrs.get("type") in _LINKABLE_TYPES:
-                for token in _tokenize(attrs.get("id", "")):
-                    self._token_to_nodes[token].add(node_id)
+        self._token_to_nodes, self._n_linkable = build_label_index(self._kg)
 
     def retrieve(self, question: str, top_k: int) -> list[RetrievedPassage]:
         """Run entity-link + k-hop subgraph + triple linearization.
@@ -246,14 +238,7 @@ class KHopTripleRetriever:
         ]
 
     def _entity_link(self, question: str) -> Iterable[str]:
-        """Identical contract to :meth:`KHopSubgraphRetriever._entity_link`."""
-        question_tokens = set(_tokenize(question, filter_stopwords=True))
-        if not question_tokens:
-            return []
-        seeds: set[str] = set()
-        for token in question_tokens:
-            postings = self._token_to_nodes.get(token, ())
-            if len(postings) > self._max_postings:
-                continue
-            seeds.update(postings)
-        return seeds
+        """IDF-weighted top-K lexical entity link (see _khop_common.link_entities)."""
+        return link_entities(
+            question, self._token_to_nodes, self._n_linkable, top_k_seeds=self._top_k_seeds
+        )

--- a/src/arandu/shared/rag/retrievers/khop_triple.py
+++ b/src/arandu/shared/rag/retrievers/khop_triple.py
@@ -36,6 +36,7 @@ from arandu.shared.rag.retrievers._khop_common import (
     _DEFAULT_TOP_K_SEEDS,
     build_label_index,
     link_entities,
+    subgraph_node_distances,
 )
 from arandu.shared.rag.schemas import RetrievedPassage
 
@@ -158,27 +159,10 @@ class KHopTripleRetriever:
         if not seeds:
             return []
 
-        subgraph_nodes: set[str] = set()
-        for seed in seeds:
-            ego = nx.ego_graph(self._kg, seed, radius=self._k_hop, undirected=True)
-            subgraph_nodes.update(ego.nodes)
-
-        # Induced subgraph + undirected shortest-path distances from any
-        # seed. **Scoring is seed-proximity**, not endpoint-degree.
-        # Rationale: degree-based scoring rewards graph hubs (`Dona Gilda`,
-        # generic locations) regardless of question relevance — the first
-        # post-concept-filter smoke on `test-kg-04` returned identical
-        # hub-entity triples across very different questions. Proximity
-        # to the question's anchored seeds is the signal we actually want.
-        induced = self._kg.subgraph(subgraph_nodes)
-        induced_undir = induced.to_undirected(as_view=True)
-        node_dist: dict[str, int] = {}
-        for seed in seeds:
-            for n, d in nx.single_source_shortest_path_length(
-                induced_undir, seed, cutoff=self._k_hop
-            ).items():
-                if d < node_dist.get(n, _INFINITY):
-                    node_dist[n] = d
+        node_dist = subgraph_node_distances(self._kg, seeds, self._k_hop)
+        if not node_dist:
+            return []
+        induced = self._kg.subgraph(node_dist.keys())
 
         # Collect entity-entity / event-entity / event-event triples — skip:
         # - any edge touching a non-{entity,event} node (passages have 2 KB

--- a/tests/shared/rag/retrieve/test_settings.py
+++ b/tests/shared/rag/retrieve/test_settings.py
@@ -36,15 +36,15 @@ class TestKHopSettings:
     def test_defaults(self) -> None:
         s = KHopRetrieveSettings(_env_file=None)
         assert s.k_hop == 2
-        assert s.max_postings == 200
+        assert s.top_k_seeds == 50
         assert s.keyword == "transcriptions.json"
 
     def test_env_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("ARANDU_KHOP_K_HOP", "3")
-        monkeypatch.setenv("ARANDU_KHOP_MAX_POSTINGS", "50")
+        monkeypatch.setenv("ARANDU_KHOP_TOP_K_SEEDS", "75")
         s = KHopRetrieveSettings()
         assert s.k_hop == 3
-        assert s.max_postings == 50
+        assert s.top_k_seeds == 75
 
     def test_invalid_k_hop_rejected(self) -> None:
         # k_hop=0 doesn't match any real retrieval pattern; reject at
@@ -108,3 +108,12 @@ class TestAtlasRagSettings:
         monkeypatch.setenv("ARANDU_ATLAS_RAG_BASE_URL", "https://custom.example/v1/")
         s = AtlasRagRetrieveSettings()
         assert s.base_url == "https://custom.example/v1/"
+
+
+def test_khop_top_k_seeds_default_and_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    from arandu.shared.rag.retrieve.settings import KHopRetrieveSettings
+
+    assert KHopRetrieveSettings().top_k_seeds == 50
+    monkeypatch.setenv("ARANDU_KHOP_TOP_K_SEEDS", "25")
+    assert KHopRetrieveSettings().top_k_seeds == 25
+    assert not hasattr(KHopRetrieveSettings(), "max_postings")

--- a/tests/shared/rag/retrievers/test_khop_common.py
+++ b/tests/shared/rag/retrievers/test_khop_common.py
@@ -61,3 +61,41 @@ class TestLinkEntities:
         g = _kg({"n1": "barra", "n2": "uruguai"})
         idx, n = kc.build_label_index(g)
         assert kc.link_entities("inexistente", idx, n, top_k_seeds=50) == []
+
+
+class TestSubgraphNodeDistances:
+    def test_seed_is_distance_zero_neighbor_one(self) -> None:
+        g = nx.DiGraph()
+        g.add_node("s", id="seed", type="entity")
+        g.add_node("a", id="a", type="entity")
+        g.add_edge("s", "a", relation="r")
+        dist = kc.subgraph_node_distances(g, ["s"], k_hop=2)
+        assert dist["s"] == 0
+        assert dist["a"] == 1
+
+    def test_beyond_k_hop_excluded(self) -> None:
+        g = nx.DiGraph()
+        for n in ("s", "a", "b", "c"):
+            g.add_node(n, id=n, type="entity")
+        g.add_edge("s", "a", relation="r")
+        g.add_edge("a", "b", relation="r")
+        g.add_edge("b", "c", relation="r")
+        dist = kc.subgraph_node_distances(g, ["s"], k_hop=2)
+        assert "b" in dist and dist["b"] == 2
+        assert "c" not in dist
+
+    def test_min_distance_over_multiple_seeds(self) -> None:
+        g = nx.DiGraph()
+        for n in ("s1", "s2", "a", "x"):
+            g.add_node(n, id=n, type="entity")
+        g.add_edge("s1", "a", relation="r")
+        g.add_edge("a", "s2", relation="r")
+        g.add_edge("s1", "x", relation="r")
+        dist = kc.subgraph_node_distances(g, ["s1", "s2"], k_hop=2)
+        assert dist["a"] == 1
+        assert dist["s1"] == 0 and dist["s2"] == 0
+
+    def test_empty_seeds_returns_empty(self) -> None:
+        g = nx.DiGraph()
+        g.add_node("s", id="seed", type="entity")
+        assert kc.subgraph_node_distances(g, [], k_hop=2) == {}

--- a/tests/shared/rag/retrievers/test_khop_common.py
+++ b/tests/shared/rag/retrievers/test_khop_common.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import pytest
+
+from arandu.shared.rag.retrievers import _khop_common as kc
+
+
+class TestTokenize:
+    def test_lemmatizes_inflectional_variants(self) -> None:
+        pytest.importorskip("spacy")
+        toks = kc._tokenize("enchentes pescavam", filter_stopwords=True)
+        assert "enchente" in toks
+        assert any(t.startswith("pesc") for t in toks)
+
+    def test_filter_stopwords_drops_particles_and_short(self) -> None:
+        toks = kc._tokenize("a de Barra", filter_stopwords=True)
+        assert "a" not in toks and "de" not in toks
+        assert "barra" in toks
+
+    def test_no_filter_keeps_all_label_tokens(self) -> None:
+        toks = kc._tokenize("rio Uruguai", filter_stopwords=False)
+        assert "rio" in toks and "uruguai" in toks

--- a/tests/shared/rag/retrievers/test_khop_common.py
+++ b/tests/shared/rag/retrievers/test_khop_common.py
@@ -1,8 +1,17 @@
 from __future__ import annotations
 
+import networkx as nx
 import pytest
 
 from arandu.shared.rag.retrievers import _khop_common as kc
+
+
+def _kg(labels: dict[str, str]) -> nx.DiGraph:
+    """Build a tiny KG; labels maps node_id -> label, all type 'entity'."""
+    g = nx.DiGraph()
+    for node_id, label in labels.items():
+        g.add_node(node_id, id=label, type="entity")
+    return g
 
 
 class TestTokenize:
@@ -20,3 +29,35 @@ class TestTokenize:
     def test_no_filter_keeps_all_label_tokens(self) -> None:
         toks = kc._tokenize("rio Uruguai", filter_stopwords=False)
         assert "rio" in toks and "uruguai" in toks
+
+
+class TestLinkEntities:
+    def test_rare_token_seed_outranks_common_token_seed(self) -> None:
+        g = _kg(
+            {
+                "n1": "comum coisa",
+                "n2": "comum outra",
+                "n3": "comum mais",
+                "n4": "valverde",
+            }
+        )
+        idx, n = kc.build_label_index(g)
+        seeds = kc.link_entities("valverde comum", idx, n, top_k_seeds=2)
+        assert "n4" in seeds
+
+    def test_top_k_budget_caps_seed_count(self) -> None:
+        g = _kg({f"n{i}": "comum" for i in range(10)})
+        idx, n = kc.build_label_index(g)
+        seeds = kc.link_entities("comum", idx, n, top_k_seeds=3)
+        assert len(seeds) == 3
+
+    def test_common_only_query_still_seeds(self) -> None:
+        g = _kg({f"n{i}": "pesca" for i in range(500)})
+        idx, n = kc.build_label_index(g)
+        seeds = kc.link_entities("pesca", idx, n, top_k_seeds=50)
+        assert len(seeds) == 50
+
+    def test_no_match_returns_empty(self) -> None:
+        g = _kg({"n1": "barra", "n2": "uruguai"})
+        idx, n = kc.build_label_index(g)
+        assert kc.link_entities("inexistente", idx, n, top_k_seeds=50) == []

--- a/tests/shared/rag/retrievers/test_khop_subgraph.py
+++ b/tests/shared/rag/retrievers/test_khop_subgraph.py
@@ -270,12 +270,12 @@ class TestKHopSubgraphRetrieverRetrieve:
 
     def test_retriever_meta_records_score_method(self, tmp_path: Path) -> None:
         path = _write_kg_layout(_build_minimal_kg(), tmp_path)
-        retriever = KHopSubgraphRetriever(kg_outputs_dir=path, k_hop=2, max_postings=50)
+        retriever = KHopSubgraphRetriever(kg_outputs_dir=path, k_hop=2, top_k_seeds=50)
         results = retriever.retrieve("enchente", top_k=1)
         assert results[0].retriever_meta == {
             "score_method": "node_freq_khop",
             "k_hop": 2,
-            "max_postings": 50,
+            "top_k_seeds": 50,
         }
 
     def test_empty_entity_link_returns_empty(self, tmp_path: Path) -> None:
@@ -297,30 +297,32 @@ class TestKHopSubgraphRetrieverRetrieve:
         results = retriever.retrieve("Uruguai", top_k=3)
         assert any(r.chunk_id == "p_a:0" for r in results)
 
-    def test_too_common_tokens_dropped_via_postings_cap(self, tmp_path: Path) -> None:
-        # If a question token name-matches more than `max_postings` linkable
-        # nodes, drop it (IDF-style threshold). Without this, topical words
-        # in narrow-domain KGs (e.g. "enchente" in a flood corpus) link to
-        # thousands of entities and blow up the ego graph.
+    def test_rare_seeds_ranked_above_common_via_idf(self, tmp_path: Path) -> None:
+        # The shared IDF linker ranks seeds by summed smoothed-IDF weight.
+        # A token that appears in many nodes (high df) scores lower than a
+        # token that appears in only one node (rare). With top_k_seeds=1 only
+        # the highest-IDF seed survives, demonstrating that common tokens are
+        # down-ranked and rare tokens rise to the top.
         kg = nx.DiGraph()
-        # 5 entities all containing the word "common" → 5 postings for "common".
+        # 5 entities all containing the word "common" → high df, low IDF weight.
         for i in range(5):
             kg.add_node(f"e_{i}", type="entity", id=f"common label {i}", file_id="p_x")
-        # Plus a rare token only on one entity.
+        # One entity with a rare token → low df, high IDF weight.
         kg.add_node("e_rare", type="entity", id="raretoken specifictoken", file_id="p_x")
         kg.add_node("p_x", type="passage", id="Target passage.", file_id="p_x")
         for n in [f"e_{i}" for i in range(5)] + ["e_rare"]:
             kg.add_edge(n, "p_x")
         path = _write_kg_layout(kg, tmp_path)
 
-        # max_postings=4 < 5 → "common" gets dropped; "raretoken" survives.
-        retriever = KHopSubgraphRetriever(kg_outputs_dir=path, k_hop=1, max_postings=4)
-        results = retriever.retrieve("common common raretoken", top_k=5)
-        # "raretoken" still links e_rare → passage scored via the surviving seed.
+        # top_k_seeds=1 → only the top-ranked (highest-IDF) seed survives.
+        # "raretoken" has a much higher IDF than "common" (df=1 vs df=5),
+        # so e_rare is the seed; p_x is reachable via e_rare → p_x.
+        retriever = KHopSubgraphRetriever(kg_outputs_dir=path, k_hop=1, top_k_seeds=1)
+        results = retriever.retrieve("common raretoken", top_k=5)
         assert any(r.chunk_id == "p_x:0" for r in results)
 
-        # With ONLY common tokens (all over the cap), the link is empty.
-        empty = retriever.retrieve("common only words", top_k=5)
+        # A question with no matching tokens still returns empty (graph-floor).
+        empty = retriever.retrieve("totallyunrelated xyzzy", top_k=5)
         assert empty == []
 
     def test_stopword_only_query_returns_empty(self, tmp_path: Path) -> None:
@@ -362,3 +364,16 @@ class TestKHopContainment:
         retriever3 = KHopSubgraphRetriever(kg_outputs_dir=path, k_hop=3)
         results3 = retriever3.retrieve("mid_token", top_k=5)
         assert any(r.chunk_id == "p_far:0" for r in results3)
+
+
+# -- signature contract --------------------------------------------------
+
+
+def test_top_k_seeds_param_and_no_max_postings() -> None:
+    import inspect
+
+    from arandu.shared.rag.retrievers.khop_subgraph import KHopSubgraphRetriever
+
+    sig = inspect.signature(KHopSubgraphRetriever.__init__)
+    assert "top_k_seeds" in sig.parameters
+    assert "max_postings" not in sig.parameters

--- a/tests/shared/rag/retrievers/test_khop_subgraph.py
+++ b/tests/shared/rag/retrievers/test_khop_subgraph.py
@@ -273,7 +273,7 @@ class TestKHopSubgraphRetrieverRetrieve:
         retriever = KHopSubgraphRetriever(kg_outputs_dir=path, k_hop=2, top_k_seeds=50)
         results = retriever.retrieve("enchente", top_k=1)
         assert results[0].retriever_meta == {
-            "score_method": "node_freq_khop",
+            "score_method": "seed_proximity",
             "k_hop": 2,
             "top_k_seeds": 50,
         }
@@ -345,25 +345,37 @@ class TestKHopSubgraphRetrieverRetrieve:
 class TestKHopContainment:
     """k_hop bounds how far the subgraph walk reaches."""
 
-    def test_distant_entity_excluded_at_k_hop_1(self, tmp_path: Path) -> None:
-        # Build a chain: q_token → mid → far → p_far. With k_hop=1 only
-        # `mid` is in the subgraph (so p_far is NOT reached); with k_hop=2
-        # `far` joins, but p_far still isn't reached (3 hops away); with
-        # k_hop=3 p_far is reached.
+    def test_distant_entity_excluded_when_beyond_k_hop(self, tmp_path: Path) -> None:
+        # Build a chain: seed (hop1) → mid → projector, where only
+        # `projector` has a file_id pointing to p_far. With k_hop=1 only
+        # `mid` is reachable from `hop1`; `projector` is 2 hops away and
+        # is excluded — so p_far (attributed only via `projector`'s file_id)
+        # must NOT appear in results. With k_hop=2 `projector` enters the
+        # subgraph and p_far IS surfaced.
+        #
+        # Under the seed-proximity model, passages qualify via entity file_id
+        # projection. k_hop therefore bounds which entity nodes can project
+        # their passages — an entity outside k_hop cannot project.
         kg = nx.DiGraph()
         kg.add_node("p_far", type="passage", id="Far passage.", file_id="p_far")
-        kg.add_node("mid", type="entity", id="mid_token", file_id="p_far")
-        kg.add_node("far", type="entity", id="far_token", file_id="p_far")
-        kg.add_edge("mid", "far")
-        kg.add_edge("far", "p_far")
+        # mid: no file_id -> cannot project itself
+        kg.add_node("mid", type="entity", id="mid_token", file_id="")
+        # projector is 2 hops from hop1 (seed); only it has file_id="p_far"
+        kg.add_node("projector", type="entity", id="projector_token", file_id="p_far")
+        kg.add_node("hop1", type="entity", id="hop1_token", file_id="")
+        kg.add_edge("hop1", "mid")
+        kg.add_edge("mid", "projector")
+        kg.add_edge("projector", "p_far")
         path = _write_kg_layout(kg, tmp_path)
 
+        # k_hop=1: only mid is reachable; projector (dist=2) is excluded
         retriever = KHopSubgraphRetriever(kg_outputs_dir=path, k_hop=1)
-        assert retriever.retrieve("mid_token", top_k=5) == []
+        assert retriever.retrieve("hop1_token", top_k=5) == []
 
-        retriever3 = KHopSubgraphRetriever(kg_outputs_dir=path, k_hop=3)
-        results3 = retriever3.retrieve("mid_token", top_k=5)
-        assert any(r.chunk_id == "p_far:0" for r in results3)
+        # k_hop=2: projector enters the subgraph and projects p_far
+        retriever2 = KHopSubgraphRetriever(kg_outputs_dir=path, k_hop=2)
+        results2 = retriever2.retrieve("hop1_token", top_k=5)
+        assert any(r.chunk_id == "p_far:0" for r in results2)
 
 
 # -- signature contract --------------------------------------------------
@@ -377,3 +389,92 @@ def test_top_k_seeds_param_and_no_max_postings() -> None:
     sig = inspect.signature(KHopSubgraphRetriever.__init__)
     assert "top_k_seeds" in sig.parameters
     assert "max_postings" not in sig.parameters
+
+
+# -- seed-proximity projection scoring (v2) ---------------------------------
+
+
+def _passage_kg() -> nx.DiGraph:
+    import networkx as nx
+
+    g = nx.DiGraph()
+    g.add_node("seed", id="seed", type="entity", file_id="")
+    g.add_node("near", id="near", type="entity", file_id="P1")
+    g.add_node("far", id="far", type="entity", file_id="P2")
+    g.add_edge("seed", "near", relation="r")  # near: 1 hop
+    g.add_edge("near", "far", relation="r")  # far: 2 hops
+    return g
+
+
+def test_passage_near_entity_outranks_far() -> None:
+    from arandu.shared.rag.retrievers.khop_subgraph import KHopSubgraphRetriever
+
+    r = KHopSubgraphRetriever.__new__(KHopSubgraphRetriever)
+    r.retriever_id = "khop_test"
+    r._kg = _passage_kg()
+    r._k_hop = 3
+    r._top_k_seeds = 50
+    r._passage_text = {"P1": "passage one text", "P2": "passage two text"}
+    r._text_to_passage_id = {"passage one text": "src:0", "passage two text": "src:1"}
+    r._entity_link = lambda _q: ["seed"]  # type: ignore[method-assign]
+
+    results = r.retrieve("q", top_k=10)
+    ids = [p.chunk_id for p in results]
+    assert ids[0] == "src:0"
+    assert results[0].score == pytest.approx(1.0)
+    assert all(p.retriever_meta["score_method"] == "seed_proximity" for p in results)
+
+
+def test_passage_scored_by_closest_node() -> None:
+    from arandu.shared.rag.retrievers.khop_subgraph import KHopSubgraphRetriever
+
+    g = _passage_kg()
+    g.add_node("alsonear", id="alsonear", type="entity", file_id="P2")
+    g.add_edge("seed", "alsonear", relation="r")  # P2 now also reachable at 1 hop
+    r = KHopSubgraphRetriever.__new__(KHopSubgraphRetriever)
+    r.retriever_id = "khop_test"
+    r._kg = g
+    r._k_hop = 3
+    r._top_k_seeds = 50
+    r._passage_text = {"P1": "p1", "P2": "p2"}
+    r._text_to_passage_id = {"p1": "src:0", "p2": "src:1"}
+    r._entity_link = lambda _q: ["seed"]  # type: ignore[method-assign]
+
+    results = r.retrieve("q", top_k=10)
+    scores = {p.chunk_id: p.score for p in results}
+    assert scores["src:0"] == pytest.approx(1.0)
+    assert scores["src:1"] == pytest.approx(1.0)
+
+
+def test_dedup_and_unresolvable_dropped() -> None:
+    from arandu.shared.rag.retrievers.khop_subgraph import KHopSubgraphRetriever
+
+    g = _passage_kg()
+    g.nodes["near"]["file_id"] = "P1,PX"  # PX has no text -> dropped
+    r = KHopSubgraphRetriever.__new__(KHopSubgraphRetriever)
+    r.retriever_id = "khop_test"
+    r._kg = g
+    r._k_hop = 3
+    r._top_k_seeds = 50
+    r._passage_text = {"P1": "p1", "P2": "p2"}
+    r._text_to_passage_id = {"p1": "src:0", "p2": "src:1"}
+    r._entity_link = lambda _q: ["seed"]  # type: ignore[method-assign]
+
+    results = r.retrieve("q", top_k=10)
+    ids = [p.chunk_id for p in results]
+    assert ids.count("src:0") == 1
+    assert "PX" not in ids
+
+
+def test_empty_seeds_returns_empty() -> None:
+    from arandu.shared.rag.retrievers.khop_subgraph import KHopSubgraphRetriever
+
+    r = KHopSubgraphRetriever.__new__(KHopSubgraphRetriever)
+    r.retriever_id = "khop_test"
+    r._kg = _passage_kg()
+    r._k_hop = 3
+    r._top_k_seeds = 50
+    r._passage_text = {"P1": "p1"}
+    r._text_to_passage_id = {"p1": "src:0"}
+    r._entity_link = lambda _q: []  # type: ignore[method-assign]
+    assert r.retrieve("q", top_k=10) == []

--- a/tests/shared/rag/retrievers/test_khop_triple.py
+++ b/tests/shared/rag/retrievers/test_khop_triple.py
@@ -108,10 +108,10 @@ class TestKHopTripleConstructorValidation:
         with pytest.raises(ValueError, match="k_hop"):
             KHopTripleRetriever(kg_outputs_dir=path, k_hop=0)
 
-    def test_invalid_max_postings_raises(self, tmp_path: Path) -> None:
+    def test_invalid_top_k_seeds_raises(self, tmp_path: Path) -> None:
         path = _write_kg_layout(_build_triple_kg(), tmp_path)
-        with pytest.raises(ValueError, match="max_postings"):
-            KHopTripleRetriever(kg_outputs_dir=path, max_postings=0)
+        with pytest.raises(ValueError, match="top_k_seeds"):
+            KHopTripleRetriever(kg_outputs_dir=path, top_k_seeds=0)
 
 
 # -- retrieve() behaviour ------------------------------------------------
@@ -309,3 +309,13 @@ class TestKHopTripleRetrieve:
         results = retriever.retrieve("Alpha", top_k=5)
         assert results
         assert any("related_to" in r.payload for r in results)
+
+
+def test_top_k_seeds_param_and_no_max_postings() -> None:
+    import inspect
+
+    from arandu.shared.rag.retrievers.khop_triple import KHopTripleRetriever
+
+    sig = inspect.signature(KHopTripleRetriever.__init__)
+    assert "top_k_seeds" in sig.parameters
+    assert "max_postings" not in sig.parameters


### PR DESCRIPTION
## Summary

Makes the two k-hop arms (`khop_passage`, `khop_triple`) fair lexical baselines. The dry run showed them degenerate (khop_passage KC 0.500 / over-caution 0.957; khop_triple 0.438 / 0.913); a local distance analysis on test-kg-04 + mini-dry-run-qwen showed the cause was **not** empty seeds (the original empty-seed hypothesis was disproven - both KGs over-seeded, median 116-221) but **seed sprawl + hub-frequency passage scoring**. Two coordinated fixes, both strictly lexical (no embeddings/PPR - the arm's distinction from atlas_rag is preserved):

**v1 - linking (`docs/superpowers/specs/2026-06-15-khop-lexical-seeding-fix-design.md`):**
- Lemmatized tokenizer for the k-hop entity link (spaCy `pt_core_news_sm`, thread-safe), fixing inflectional misses (`enchentes`/`enchente`).
- Replaced the hard `max_postings=200` cap (which *dropped* corpus-central tokens) with **IDF-weighted seeds + a top-K=50 budget** in the shared `_khop_common`: keep every matched token, weight candidate seeds by smoothed IDF, keep the top-K. Bounds ego-graph size without discarding the rarest/most-informative tokens. `KHopSettings.max_postings` → `top_k_seeds`.

**v2 - scoring (`docs/superpowers/specs/2026-06-15-khop-unified-seed-proximity-scoring-design.md`):**
- Extracted the seed-proximity distance computation into shared `subgraph_node_distances`; khop_triple refactored onto it (behavior unchanged, regression-guarded by its existing tests).
- Replaced khop_passage's hub-frequency scoring with a **closest-node `file_id` node→passage projection** (the standard GraphRAG passage step, lexical here): each passage scores by its nearest question-anchored entity's proximity, deduped, normalized to the top; `score_method` `node_freq_khop` → `seed_proximity`. Both arms now score on one principle, so the passage-vs-triple comparison is a clean delivery-format A/B.

Also: `scripts/slurm/AGENTS.md` records the partition access + GPU facts (tupi = only accessible GPU; draco = CPU-only; grace = no access).

## Test plan

- [x] `subgraph_node_distances`, IDF top-K linker, lemmatized tokenizer: unit tests (TDD)
- [x] khop_passage proximity projection: near>far, closest-node-wins, dedup, unresolvable dropped, empty seeds, normalized-to-top
- [x] khop_triple refactor: existing tests pass unchanged (regression guard)
- [x] `uv run pytest`: 1492 passed (only the pre-existing `test_app.py::TestReportCommandDeprecation` plotly failure), ruff clean
- [x] Local distance analysis on test-kg-04 + mini-dry-run-qwen confirms seeds focus from sprawling (median 116-221) to top-50
- [x] khop v2 dry-run on `mini-dry-run-qwen` COMPLETE (795477 answer + 795478 judge, tupi-GPU; local rag-analysis): **khop_passage KC 0.500→0.623, over-caution 0.957→0.717**; khop_triple KC 0.438→0.417 (flat), over-caution 0.913→0.870; controls pinned (atlas_rag KC 0.702, bm25 0.687; null over-caution 1.000). Seed-proximity scoring raised khop_passage KC and cut its over-caution; change isolated to the khop arms. **v2 validated.**