### PR TITLE
docs: resync user/dev docs to merged code (CLI, config, schemas, CEP)

### DIFF
--- a/docs/development/schemas.md
+++ b/docs/development/schemas.md
@@ -17,7 +17,7 @@ This document provides complete specifications for all data schemas used in the 
 
 ### EnrichedRecord
 
-Represents a transcription record with enrichment metadata. Extends `InputRecord` with transcription results and quality checks.
+Represents a transcription record with enrichment metadata. Extends `InputRecord` (transcription results) and `JudgeResultMixin` (judge verdict fields).
 
 **Fields** (inherits all fields from InputRecord):
 
@@ -38,8 +38,10 @@ Represents a transcription record with enrichment metadata. Extends `InputRecord
 | `transcription_status` | `str` | Yes | Status of transcription process |
 | `created_at_enrichment` | `datetime` | Yes | Timestamp of enrichment |
 | `segments` | `list[TranscriptionSegment] \| None` | No | Detailed timestamp segments |
-| `transcription_quality` | `TranscriptionQualityScore \| None` | No | Transcription quality check results |
-| `is_valid` | `bool \| None` | No | Whether transcription passes quality check (None = not yet checked) |
+| `validation` | `JudgePipelineResult \| None` | No | Full judge pipeline result (from `JudgeResultMixin`). None = not yet judged |
+| `is_valid` | `bool \| None` | Computed | Derived from `validation.passed` (None when not yet judged). See `JudgeResultMixin` |
+
+> **Note**: A `@model_validator` migrates records that still carry the retired `transcription_quality` key: an interim `JudgePipelineResult` payload is renamed to `validation`; the very old weighted-score struct is dropped (the record becomes re-judgeable).
 
 **Language Routing Note**:
 
@@ -69,14 +71,27 @@ The `detected_language` field provides the language code directly. There is **no
       "end": 5.2
     }
   ],
-  "transcription_quality": {
-    "script_match_score": 0.95,
-    "repetition_score": 0.92,
-    "segment_quality_score": 0.88,
-    "content_density_score": 0.90,
-    "overall_score": 0.91,
-    "issues_detected": [],
-    "quality_rationale": "High-quality transcription with natural pacing"
+  "validation": {
+    "stage_results": {
+      "heuristic": {
+        "criterion_scores": {
+          "content_length": {
+            "score": 1.0,
+            "scale": "continuous",
+            "threshold": 1.0,
+            "rationale": "Transcription length above the minimum floor"
+          },
+          "script_match": {
+            "score": 0.95,
+            "scale": "continuous",
+            "threshold": 0.9,
+            "rationale": "Text uses the expected Latin script"
+          }
+        }
+      }
+    },
+    "passed": true,
+    "rejected_at": null
   },
   "is_valid": true
 }
@@ -87,14 +102,20 @@ The `detected_language` field provides the language code directly. There is **no
 from datetime import datetime
 from pydantic import BaseModel, Field
 
+from arandu.shared.judge.schemas import JudgeResultMixin
+
 class TranscriptionSegment(BaseModel):
     """Schema for a transcription segment with timestamp information."""
     text: str = Field(..., description="Transcribed text for this segment")
     start: float = Field(..., description="Start time in seconds")
     end: float = Field(..., description="End time in seconds")
 
-class EnrichedRecord(InputRecord):
-    """Schema for output records containing transcription results and metadata."""
+class EnrichedRecord(InputRecord, JudgeResultMixin):
+    """Schema for output records containing transcription results and metadata.
+
+    The ``validation`` field and the computed ``is_valid`` property come from
+    ``JudgeResultMixin``; they are not declared here.
+    """
     transcription_text: str = Field(..., description="Full transcription text")
     detected_language: str = Field(..., description="Detected language code")
     language_probability: float = Field(..., description="Confidence score for detected language")
@@ -108,17 +129,10 @@ class EnrichedRecord(InputRecord):
     segments: list[TranscriptionSegment] | None = Field(
         None, description="Detailed timestamp segments"
     )
-    transcription_quality: TranscriptionQualityScore | None = Field(
-        None, description="Transcription quality check results"
-    )
-    is_valid: bool | None = Field(
-        default=None,
-        description="Whether transcription passes quality check (None = not yet checked)",
-    )
 
     def ensure_language_metadata(self) -> None:
         """Ensure metadata compatibility for AutoSchemaKG language routing.
-        
+
         Note: The detected_language field already provides the language code.
         """
         pass
@@ -126,58 +140,93 @@ class EnrichedRecord(InputRecord):
 
 ---
 
-## Transcription Quality Schemas
+## Judge Result Schemas
 
-### TranscriptionQualityScore
+Transcription quality is no longer a single weighted score. It is the verdict of a multi-stage **filter pipeline** (pure-Python heuristics, plus an optional LLM stage), and the same domain-agnostic result types are reused for QA-pair judging. A record passes only when it clears every criterion in each non-skipped stage; there is no aggregate `overall_score`. See the [Transcription Validation guide](../user-guide/transcription-validation.md) for the full model.
 
-Quality scores for transcription validation using heuristics. Distinct from `ValidationScore` (LLM-as-a-Judge for QA pairs). This evaluates Whisper transcription output quality.
+### JudgeResultMixin
+
+Mixin that adds the canonical judge verdict fields to any record schema (e.g. `EnrichedRecord`). Stores the full pipeline result under `validation` and derives `is_valid` from it so the two cannot drift.
+
+**Fields / computed properties**:
+
+| Member | Type | Kind | Description |
+|--------|------|------|-------------|
+| `validation` | `JudgePipelineResult \| None` | Field | Full judge pipeline result. None when the record has not been judged yet |
+| `is_valid` | `bool \| None` | Computed | `validation.passed` when judged, else None |
+
+**Python Implementation**:
+```python
+from pydantic import BaseModel, Field, computed_field
+
+class JudgeResultMixin(BaseModel):
+    """Adds judge verdict fields to a record schema."""
+    validation: "JudgePipelineResult | None" = Field(
+        default=None,
+        description="Full judge pipeline result. None when not yet judged.",
+    )
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def is_valid(self) -> bool | None:
+        """Pass/fail verdict derived from ``validation.passed`` (None if unjudged)."""
+        return self.validation.passed if self.validation is not None else None
+```
+
+### JudgePipelineResult
+
+Result of running the full multi-stage judge pipeline.
 
 **Fields**:
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `script_match_score` | `float` | Yes | Text uses expected character set (0.0-1.0, Latin for pt/en) |
-| `repetition_score` | `float` | Yes | Text is free from excessive repetition (0.0-1.0) |
-| `segment_quality_score` | `float` | Yes | Segment timestamps are natural, not suspicious (0.0-1.0) |
-| `content_density_score` | `float` | Yes | Words per minute within reasonable range (0.0-1.0) |
-| `overall_score` | `float` | Yes | Weighted average of all scores (0.0-1.0) |
-| `issues_detected` | `list[str]` | Yes | List of quality issues (default: empty list) |
-| `quality_rationale` | `str \| None` | No | Explanation of quality assessment |
+| `stage_results` | `dict[str, JudgeStepResult]` | Yes | Per-stage results, keyed by stage name (e.g. `"heuristic"`, `"llm"`) |
+| `passed` | `bool` | Yes | Whether the record cleared every non-skipped stage |
+| `rejected_at` | `str \| None` | No | Name of the stage that rejected the record, if any |
 
-**Example**:
+### JudgeStepResult
+
+Result of running all criteria in a single stage. Its `passed` property is True only when every criterion met its threshold.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `criterion_scores` | `dict[str, CriterionScore]` | Yes | Per-criterion results, keyed by criterion name |
+
+### CriterionScore
+
+Result of a single criterion evaluation. Carries either a continuous `score` or an `ordinal_score`, selected by `scale`.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `score` | `float \| None` | No | Continuous score in [0, 1] (default scale) |
+| `ordinal_score` | `int \| None` | No | Integer label for ordinal criteria (e.g. emic validity {1..5}) |
+| `scale` | `Literal["continuous", "ordinal"]` | No | Which scale this criterion uses (default `"continuous"`) |
+| `threshold` | `float` | Yes | Pass threshold for continuous criteria |
+| `rationale` | `str` | Yes | Explanation of the verdict |
+| `thinking` | `str \| None` | No | Optional reasoning trace from the LLM |
+| `error` | `str \| None` | No | Error message; `passed` is always False when set |
+
+A continuous criterion's `passed` is `score >= threshold`; an ordinal criterion runs in score mode (any downstream filter threshold is applied separately).
+
+**Example** (`validation` payload on a judged record):
 ```json
 {
-  "script_match_score": 0.95,
-  "repetition_score": 0.88,
-  "segment_quality_score": 0.92,
-  "content_density_score": 0.85,
-  "overall_score": 0.90,
-  "issues_detected": ["Minor repetition in segment 3-5"],
-  "quality_rationale": "Good quality transcription with minor repetition issues"
+  "stage_results": {
+    "heuristic": {
+      "criterion_scores": {
+        "script_match": {
+          "score": 0.95,
+          "scale": "continuous",
+          "threshold": 0.9,
+          "rationale": "Text uses the expected Latin script"
+        }
+      }
+    }
+  },
+  "passed": true,
+  "rejected_at": null
 }
-```
-
-**Python Implementation**:
-```python
-from pydantic import BaseModel, Field
-
-class TranscriptionQualityScore(BaseModel):
-    """Quality scores for transcription validation."""
-    script_match_score: float = Field(
-        ..., ge=0.0, le=1.0, description="Text uses expected character set (Latin for pt/en)"
-    )
-    repetition_score: float = Field(
-        ..., ge=0.0, le=1.0, description="Text is free from excessive repetition"
-    )
-    segment_quality_score: float = Field(
-        ..., ge=0.0, le=1.0, description="Segment timestamps are natural, not suspicious"
-    )
-    content_density_score: float = Field(
-        ..., ge=0.0, le=1.0, description="Words per minute within reasonable range"
-    )
-    overall_score: float = Field(..., ge=0.0, le=1.0, description="Weighted average of all scores")
-    issues_detected: list[str] = Field(default_factory=list, description="List of quality issues")
-    quality_rationale: str | None = Field(None, description="Explanation of quality assessment")
 ```
 
 ---

--- a/docs/user-guide/cep-qa-generation.md
+++ b/docs/user-guide/cep-qa-generation.md
@@ -1,14 +1,14 @@
 # CEP QA Generation Guide
 
-Generate cognitively-calibrated question-answer pairs using the **Cognitive Elicitation Pipeline (CEP)** with Bloom's Taxonomy scaffolding and LLM-as-a-Judge validation.
+Generate cognitively-calibrated question-answer pairs using the **Cognitive Elicitation Pipeline (CEP)** with Bloom's Taxonomy scaffolding. Validation is a separate step: `generate-cep-qa` generates pairs, and the [`judge-qa`](cli-reference.md#judge-qa) command validates them with LLM-as-a-Judge.
 
 ## Overview
 
-The CEP pipeline extends the standard QA generation with three specialized modules:
+The CEP pipeline generates QA pairs through two specialized modules, then validation runs as a separate command:
 
 1. **Module I: Bloom Scaffolding** - Generates questions distributed across Bloom's taxonomy levels
 2. **Module II: Reasoning & Grounding** - Enriches higher-level questions with reasoning traces
-3. **Module III: LLM-as-a-Judge** - Validates QA pairs for faithfulness, Bloom calibration, and informativeness
+3. **LLM-as-a-Judge (separate `judge-qa` step)** - Validates QA pairs for faithfulness, Bloom calibration, informativeness, and self-containedness
 
 ### Key Features
 
@@ -17,7 +17,7 @@ The CEP pipeline extends the standard QA generation with three specialized modul
 - **Reasoning Traces**: Explicit logical connections for complex questions
 - **Multi-hop Detection**: Identifies questions requiring distant information connection
 - **Tacit Knowledge Extraction**: Surfaces implicit domain knowledge
-- **Quality Validation**: LLM-based scoring for faithfulness and informativeness
+- **Quality Validation** (via `judge-qa`): LLM-based scoring for faithfulness, Bloom calibration, informativeness, and self-containedness
 
 ## Prerequisites
 
@@ -50,11 +50,11 @@ sbatch scripts/slurm/cep/sirius.slurm
 ### Using CLI
 
 ```bash
-# Basic usage (validation enabled by default)
+# Generate CEP QA pairs
 arandu generate-cep-qa results/ --output-dir cep_dataset/
 
-# Disable validation for faster processing
-arandu generate-cep-qa results/ --no-validate --output-dir cep_dataset/
+# Validate the generated pairs with LLM-as-a-Judge (separate step)
+arandu judge-qa cep_dataset/ --model qwen3:14b
 
 # Export to JSONL format
 arandu generate-cep-qa results/ --jsonl --output-dir cep_dataset/
@@ -79,12 +79,20 @@ arandu generate-cep-qa results/ --id etno-project-001
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `ARANDU_CEP_ENABLE_VALIDATION` | `true` | Enable LLM-as-a-Judge validation |
-| `ARANDU_CEP_VALIDATOR_PROVIDER` | `ollama` | Validator LLM provider |
-| `ARANDU_CEP_VALIDATOR_MODEL_ID` | `qwen3:14b` | Validator model |
 | `ARANDU_CEP_LANGUAGE` | `pt` | Prompt language (`pt` or `en`) |
 | `ARANDU_CEP_ENABLE_SCAFFOLDING_CONTEXT` | `true` | Pass prior QA pairs to higher Bloom levels |
 | `ARANDU_CEP_MAX_SCAFFOLDING_PAIRS` | `10` | Max prior QA pairs to include as context |
+| `ARANDU_CEP_VALIDATION_THRESHOLD` | `0.6` | Min overall judge score for a pair to pass (used by `judge-qa`) |
+
+### Judge Variables (used by `judge-qa`)
+
+Validation is a separate command; its validator client is configured with the `ARANDU_JUDGE_` prefix (shared with `judge-transcription`). There is no `ARANDU_CEP_ENABLE_VALIDATION` switch.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ARANDU_JUDGE_VALIDATOR_MODEL` | (none) | Judge model. Required via this var or `judge-qa --model` |
+| `ARANDU_JUDGE_VALIDATOR_PROVIDER` | inferred | `openai`, `ollama`, or `custom` |
+| `ARANDU_JUDGE_VALIDATOR_BASE_URL` | inferred | Validator base URL (falls back to `ARANDU_LLM_BASE_URL`) |
 
 ### Bloom Distribution
 
@@ -112,15 +120,18 @@ ARANDU_QA_PROVIDER=ollama
 ARANDU_QA_MODEL_ID=qwen3:14b
 ARANDU_QA_TEMPERATURE=0.7
 ARANDU_QA_WORKERS=4
+ARANDU_QA_OUTPUT_DIR=cep_dataset
 
 # CEP-Specific Settings
-ARANDU_CEP_ENABLE_VALIDATION=true
-ARANDU_CEP_VALIDATOR_MODEL_ID=qwen3:14b
 ARANDU_CEP_LANGUAGE=pt
+ARANDU_CEP_VALIDATION_THRESHOLD=0.6
+
+# Judge Settings (used by judge-qa)
+ARANDU_JUDGE_VALIDATOR_MODEL=qwen3:14b
+ARANDU_JUDGE_VALIDATOR_PROVIDER=ollama
 
 # Directories
 ARANDU_RESULTS_DIR=./results
-ARANDU_CEP_DIR=./cep_dataset
 ```
 
 ## Usage Examples
@@ -128,15 +139,18 @@ ARANDU_CEP_DIR=./cep_dataset
 ### Basic CEP Generation
 
 ```bash
-# Default configuration (Portuguese prompts, validation enabled)
+# Default configuration (Portuguese prompts); validate separately with judge-qa
 docker compose --profile cep up
 ```
 
-### Without LLM-as-a-Judge Validation
+### Validating Generated Pairs
 
 ```bash
-# Disable validation for faster processing
-ARANDU_CEP_ENABLE_VALIDATION=false docker compose --profile cep up
+# Generation does not validate. Run judge-qa afterwards:
+arandu judge-qa cep_dataset/ --model qwen3:14b
+
+# Sample a subset while iterating
+arandu judge-qa cep_dataset/ --files 2 --pairs 3
 ```
 
 ### GPU-Accelerated Ollama
@@ -272,9 +286,9 @@ Each line contains one QA pair:
 
 ## Validation Criteria
 
-When validation is enabled, each QA pair is scored on three criteria:
+Validation runs via the separate [`judge-qa`](cli-reference.md#judge-qa) command. Each sampled QA pair is scored on four criteria, and the weighted overall score gates the pair against `validation_threshold`. The weights live in `CEPConfig` and must sum to 1.0.
 
-### Faithfulness (40% weight)
+### Faithfulness (30% weight)
 Is the answer grounded in the provided context?
 
 | Score | Description |
@@ -286,7 +300,7 @@ Is the answer grounded in the provided context?
 | 0.2 | Answer weakly grounded |
 | 0.0 | Answer not grounded, hallucinated, or contradictory |
 
-### Bloom Calibration (30% weight)
+### Bloom Calibration (25% weight)
 Does the question match the proposed cognitive level?
 
 | Score | Description |
@@ -297,7 +311,7 @@ Does the question match the proposed cognitive level?
 | 0.4 | Undercalibrated - requires lower cognitive level |
 | 0.0 | Completely miscalibrated |
 
-### Informativeness (30% weight)
+### Informativeness (25% weight)
 Does the answer reveal non-obvious or tacit knowledge?
 
 | Score | Description |
@@ -308,13 +322,22 @@ Does the answer reveal non-obvious or tacit knowledge?
 | 0.4 | Common but well-articulated information |
 | 0.0 | Trivial or obvious information |
 
-The overall score is a weighted average. QA pairs below the threshold (default 0.6) are marked as invalid.
+### Self-Containedness (20% weight)
+Can the question be understood and answered without external context beyond the provided text?
+
+| Score | Description |
+|-------|-------------|
+| 1.0 | Fully self-contained; no outside context needed |
+| 0.6 | Mostly self-contained with minor ambiguity |
+| 0.0 | Depends on context not present in the question/answer |
+
+The overall score is the weighted average of these four criteria. QA pairs below `validation_threshold` (default 0.6) are marked invalid (`is_valid = false`).
 
 ## Programmatic Usage
 
 ```python
-from arandu.schemas import QARecordCEP, QAPairCEP
-from arandu.config import CEPConfig, QAConfig, get_cep_config
+from arandu.qa.schemas import QARecordCEP, QAPairCEP
+from arandu.qa.config import CEPConfig, QAConfig, get_cep_config
 
 # Load existing CEP record
 record = QARecordCEP.load("cep_dataset/1abc123xyz_cep_qa.json")
@@ -340,10 +363,15 @@ jsonl_content = record.to_jsonl()
 # Export to JSONL file
 record.to_jsonl("output.jsonl")
 
+# Inspect per-pair judge verdicts (populated by judge-qa)
+for qa in record.qa_pairs:
+    print(f"{qa.bloom_level}: is_valid={qa.is_valid}")
+
 # Get CEP configuration
 cep_config = get_cep_config()
-print(f"Validation enabled: {cep_config.enable_validation}")
-print(f"Bloom levels: {cep_config.bloom_levels}")
+print(f"Bloom distribution: {cep_config.bloom_distribution}")
+print(f"Pairs per chunk: {cep_config.pairs_per_chunk}")
+print(f"Validation threshold: {cep_config.validation_threshold}")
 ```
 
 ## Monitoring Progress
@@ -390,9 +418,10 @@ The checkpoint file (`cep_dataset/cep_checkpoint.json`) tracks:
 - **llama3.3:70b**: Highest quality for final production runs (48GB+ GPU)
 
 ### Validation Strategy
-1. Keep validation enabled (default) for quality assurance
-2. Disable validation (`--no-validate`) for faster iteration during development
-3. Use validation threshold of 0.6-0.7 to balance coverage and quality
+1. Generate first, then validate with `judge-qa` as a separate step
+2. During development, sample with `judge-qa --files N --pairs M` for faster iteration
+3. Use `ARANDU_CEP_VALIDATION_THRESHOLD` of 0.6-0.7 to balance coverage and quality
+4. Re-run with `judge-qa --rejudge` after changing the validator model
 
 ### Bloom Distribution
 - Start with default distribution

--- a/docs/user-guide/cli-reference.md
+++ b/docs/user-guide/cli-reference.md
@@ -7,9 +7,11 @@ Complete reference for all command-line interface commands in Arandu.
 1. [Command Overview](#command-overview)
 2. [Transcription Commands](#transcription-commands)
 3. [QA Generation Commands](#qa-generation-commands)
-4. [Utilities Commands](#utilities-commands)
-5. [Usage Examples](#usage-examples)
-6. [Common Patterns](#common-patterns)
+4. [Judging Commands](#judging-commands)
+5. [Knowledge Graph & RAG Commands (Phase C)](#knowledge-graph--rag-commands-phase-c)
+6. [Utilities Commands](#utilities-commands)
+7. [Usage Examples](#usage-examples)
+8. [Common Patterns](#common-patterns)
 
 ---
 
@@ -21,8 +23,10 @@ The Arandu CLI is built with [Typer](https://typer.tiangolo.com/) and provides r
 
 **Command Categories**:
 - **Transcription**: `transcribe`, `drive-transcribe`, `batch-transcribe`
-- **QA Generation**: `generate-cep-qa`
-- **Utilities**: `refresh-auth`, `info`, `list-runs`, `run-info`, `judge-transcription`, `rebuild-index`
+- **QA Generation**: `generate-cep-qa`, `generate-non-answerable`
+- **Judging**: `judge-transcription`, `judge-qa`, `judge-answers`
+- **Knowledge Graph & RAG (Phase C)**: `chunk`, `build-kg`, `kg-link-passages`, `kg-build-retriever-index`, `retrieve`, `answer`, `emic-prepass`, `build-human-eval-sample`, `rag-analysis`
+- **Utilities**: `refresh-auth`, `enrich-metadata`, `replicate`, `info`, `list-runs`, `run-info`, `rebuild-index`, `report`, `serve-report`
 
 **Global Options**:
 - `--help` - Show command help
@@ -174,7 +178,7 @@ arandu batch-transcribe input/catalog.csv --id my-project-001
 
 ### `generate-cep-qa`
 
-Generate CEP (Cognitive Elicitation Pipeline) QA pairs from transcriptions with Bloom-level scaffolding and LLM-as-a-Judge validation.
+Generate CEP (Cognitive Elicitation Pipeline) QA pairs from transcriptions with Bloom-level scaffolding. Generation and validation are now separate steps: this command only generates pairs. Run [`judge-qa`](#judge-qa) afterwards to evaluate them with LLM-as-a-Judge.
 
 **Usage**:
 ```bash
@@ -196,8 +200,6 @@ arandu generate-cep-qa INPUT_DIR [OPTIONS]
 | `--ollama-url` | | str | `http://localhost:11434/v1` | Ollama API base URL |
 | `--base-url` | | str | `None` | Custom base URL for OpenAI-compatible endpoints |
 | `--language` | `-l` | str | `pt` | Language for prompts: 'pt' or 'en' |
-| `--validate/--no-validate` | | flag | `True` | Enable LLM-as-a-Judge validation |
-| `--validator-model` | | str | `qwen3:14b` | Model ID for validation |
 | `--bloom-dist` | | str | `None` | Bloom level pair counts (e.g., 'remember:3,understand:1,analyze:1,evaluate:1') |
 | `--jsonl/--no-jsonl` | | flag | `False` | Export QA pairs to JSONL format for training |
 | `--id` | | str | Auto-resolved | Pipeline ID (auto-resolves transcription outputs) |
@@ -217,14 +219,9 @@ arandu generate-cep-qa results/ \
     --model-id gpt-4o-mini \
     --workers 2
 
-# Without validation (faster)
-arandu generate-cep-qa results/ \
-    --no-validate \
-    --workers 4
-
-# With custom validator model
-arandu generate-cep-qa results/ \
-    --validator-model qwen3:14b
+# Generate, then validate as a separate step
+arandu generate-cep-qa results/ -o qa_dataset/ --workers 4
+arandu judge-qa qa_dataset/ --model qwen3:14b
 
 # Export to JSONL for KGQA training
 arandu generate-cep-qa results/ \
@@ -241,9 +238,159 @@ arandu generate-cep-qa results/ --id my-project-001
 **Output Structure**:
 ```
 qa_dataset/
-├── cep_qa_1abc123xyz.json
-├── cep_qa_2def456uvw.json
+├── 1abc123xyz_cep_qa.json
+├── 2def456uvw_cep_qa.json
 └── cep_qa_checkpoint.json
+```
+
+---
+
+### `generate-non-answerable`
+
+Generate a non-answerable benchmark from validated CEP pairs and the knowledge graph. Used to measure whether the RAG arms correctly abstain on questions the corpus cannot answer.
+
+**Usage**:
+```bash
+arandu generate-non-answerable INPUT_DIR [OPTIONS]
+```
+
+Run `arandu generate-non-answerable --help` for the full option list.
+
+---
+
+## Judging Commands
+
+The judging commands share the `ARANDU_JUDGE_VALIDATOR_*` environment fallbacks (model, provider, base URL) and the `--rejudge/--resume` resume semantics.
+
+### `judge-transcription`
+
+Judge transcription quality with a two-stage filter pipeline: pure-Python heuristics (always) plus optional LLM criteria. A record passes only when it clears every criterion in each filter stage; there is no aggregate score. See the [Transcription Validation guide](transcription-validation.md) for the full model.
+
+**Usage**:
+```bash
+arandu judge-transcription INPUT_DIR [OPTIONS]
+```
+
+**Arguments**:
+- `INPUT_DIR` - Directory containing `*_transcription.json` files to judge
+
+**Options**:
+
+| Option | Short | Type | Default | Description |
+|--------|-------|------|---------|-------------|
+| `--language` | `-l` | str | `pt` | Expected language code (e.g., 'pt', 'en') |
+| `--validator-model` | | str | (none) | Model ID enabling the LLM filter stage. Falls back to `ARANDU_JUDGE_VALIDATOR_MODEL` |
+| `--validator-provider` | | str | inferred | `openai`, `ollama`, or `custom`. Falls back to `ARANDU_JUDGE_VALIDATOR_PROVIDER` |
+| `--validator-base-url` | | str | inferred | Validator base URL. Falls back to `ARANDU_JUDGE_VALIDATOR_BASE_URL`, then `ARANDU_LLM_BASE_URL` |
+| `--validator-temperature` | | float | `0.3` | Sampling temperature for LLM criteria. Falls back to `ARANDU_JUDGE_TEMPERATURE` |
+| `--validator-max-tokens` | | int | `2048` | Max tokens for LLM criterion responses. Falls back to `ARANDU_JUDGE_MAX_TOKENS` |
+| `--rejudge` / `--resume` | | flag | `--resume` | `--rejudge` re-evaluates every record; `--resume` skips already-judged records |
+
+**Examples**:
+```bash
+# Heuristics only, update in-place
+arandu judge-transcription results/
+
+# Enable the LLM filter stage (language_drift + hallucination_loop)
+arandu judge-transcription results/ --validator-model qwen3:14b
+
+# Judge English transcriptions
+arandu judge-transcription results/ --language en
+
+# Force a fresh pass over every record
+arandu judge-transcription results/ --validator-model qwen3:14b --rejudge
+```
+
+**Stages**:
+- Heuristic filter (always): content length floor, script match, repetition, content density, segment quality
+- LLM filter (optional): `language_drift`, `hallucination_loop`
+
+---
+
+### `judge-qa`
+
+Judge CEP QA pairs with LLM-as-a-Judge across four criteria (faithfulness, Bloom calibration, informativeness, self-containedness). Each judged pair is persisted back into its `*_cep_qa.json` file via the pair's `validation` field; `is_valid` is derived from `validation.passed`. There is no aggregate side-file. This is the validation step that used to be folded into `generate-cep-qa`.
+
+**Usage**:
+```bash
+arandu judge-qa INPUT_DIR [OPTIONS]
+```
+
+**Arguments**:
+- `INPUT_DIR` - Directory containing `*_cep_qa.json` files to judge
+
+**Options**:
+
+| Option | Short | Type | Default | Description |
+|--------|-------|------|---------|-------------|
+| `--model` | `-m` | str | (none) | Judge model ID. Required via flag or `ARANDU_JUDGE_VALIDATOR_MODEL` |
+| `--provider` | | str | inferred | `openai`, `ollama`, or `custom`. Falls back to `ARANDU_JUDGE_VALIDATOR_PROVIDER` |
+| `--base-url` | | str | inferred | Custom/OpenAI-compatible URL. Falls back to `ARANDU_JUDGE_VALIDATOR_BASE_URL`, then `ARANDU_LLM_BASE_URL` |
+| `--language` | `-l` | str | `pt` | Language for judge prompts: 'pt' or 'en' |
+| `--files` | | int | All | Maximum number of QA files to sample |
+| `--pairs` | | int | All | Maximum QA pairs to judge per file |
+| `--rejudge` / `--resume` | | flag | `--resume` | `--rejudge` re-evaluates every sampled pair; `--resume` skips pairs already carrying a `validation` payload |
+
+**Examples**:
+```bash
+# Defaults from ARANDU_JUDGE_* env vars
+arandu judge-qa qa_dataset/
+
+# Explicit Ollama model
+arandu judge-qa qa_dataset/ --provider ollama --model qwen3:14b
+
+# OpenAI-compatible custom endpoint
+arandu judge-qa qa_dataset/ --provider custom --model gemini-2.5-flash \
+    --base-url https://generativelanguage.googleapis.com/v1beta/openai/
+
+# Sample a subset, then force a fresh pass
+arandu judge-qa qa_dataset/ --files 2 --pairs 3
+arandu judge-qa qa_dataset/ --rejudge
+```
+
+---
+
+### `judge-answers`
+
+Run the gated answer judge over every `AnswerRecord` in a populated Phase C run, scoring generated RAG answers. See the [RAG evaluation docs](rag-analysis.md) for the scoring model.
+
+**Usage**:
+```bash
+arandu judge-answers RUN_ID [OPTIONS]
+```
+
+Run `arandu judge-answers --help` for the full option list.
+
+---
+
+## Knowledge Graph & RAG Commands (Phase C)
+
+These commands implement the Phase C retrieval-augmented-generation evaluation chain: build a knowledge graph from transcriptions, link passages, build retriever indices, retrieve, answer, and analyze. They operate on a populated run identified by a pipeline/run ID. Each command exposes its full option set via `--help`; the summaries below cover the common workflow.
+
+| Command | Description |
+|---------|-------------|
+| `chunk` | Build `ChunkSets` across one or more chunker views |
+| `build-kg` | Build a knowledge graph from transcription records |
+| `kg-link-passages` | Map atlas-rag passages back to char offsets in source `EnrichedRecord` space |
+| `kg-build-retriever-index` | Build the atlas-rag retriever's precomputed index for a run |
+| `retrieve` | Run Phase C retrievers over a populated run |
+| `answer` | Run the Answerer LLM over every `RetrievalRecord` in a populated run |
+| `emic-prepass` | Score canonical-approved CEP pairs for emic validity (ordinal 1-5) |
+| `build-human-eval-sample` | Build the stratified human-comparison sample (80 pairs) for a run |
+| `rag-analysis` | Aggregate judged answers and emit `report.json` + `tables.md` |
+
+**Typical Phase C chain**:
+```bash
+# Build the KG and retriever index for a run
+arandu build-kg results/ --id project-001
+arandu kg-link-passages project-001
+arandu kg-build-retriever-index project-001
+
+# Retrieve, answer, judge, analyze
+arandu retrieve project-001
+arandu answer project-001
+arandu judge-answers project-001
+arandu rag-analysis project-001
 ```
 
 ---
@@ -359,51 +506,6 @@ arandu run-info latest --pipeline cep
 
 ---
 
-### `judge-transcription`
-
-Judge transcription quality with a two-stage filter pipeline: pure-Python heuristics (always) plus optional LLM criteria. A record passes only when it clears every criterion in each filter stage; there is no aggregate score. See the [Transcription Validation guide](transcription-validation.md) for the full model.
-
-**Usage**:
-```bash
-arandu judge-transcription INPUT_DIR [OPTIONS]
-```
-
-**Arguments**:
-- `INPUT_DIR` - Directory containing `*_transcription.json` files to judge
-
-**Options**:
-
-| Option | Short | Type | Default | Description |
-|--------|-------|------|---------|-------------|
-| `--language` | `-l` | str | `pt` | Expected language code (e.g., 'pt', 'en') |
-| `--validator-model` | | str | (none) | Model ID enabling the LLM filter stage. Falls back to `ARANDU_JUDGE_VALIDATOR_MODEL` |
-| `--validator-provider` | | str | inferred | `openai`, `ollama`, or `custom`. Falls back to `ARANDU_JUDGE_VALIDATOR_PROVIDER` |
-| `--validator-base-url` | | str | inferred | Validator base URL. Falls back to `ARANDU_JUDGE_VALIDATOR_BASE_URL`, then `ARANDU_LLM_BASE_URL` |
-| `--validator-temperature` | | float | `0.3` | Sampling temperature for LLM criteria. Falls back to `ARANDU_JUDGE_TEMPERATURE` |
-| `--validator-max-tokens` | | int | `2048` | Max tokens for LLM criterion responses. Falls back to `ARANDU_JUDGE_MAX_TOKENS` |
-| `--rejudge` / `--resume` | | flag | `--resume` | `--rejudge` re-evaluates every record; `--resume` skips already-judged records |
-
-**Examples**:
-```bash
-# Heuristics only, update in-place
-arandu judge-transcription results/
-
-# Enable the LLM filter stage (language_drift + hallucination_loop)
-arandu judge-transcription results/ --validator-model qwen3:14b
-
-# Judge English transcriptions
-arandu judge-transcription results/ --language en
-
-# Force a fresh pass over every record
-arandu judge-transcription results/ --validator-model qwen3:14b --rejudge
-```
-
-**Stages**:
-- Heuristic filter (always): content length floor, script match, repetition, content density, segment quality
-- LLM filter (optional): `language_drift`, `hallucination_loop`
-
----
-
 ### `rebuild-index`
 
 Rebuild index.json from existing run directories by scanning all pipeline ID directories for run_metadata.json files.
@@ -423,6 +525,19 @@ arandu rebuild-index [OPTIONS]
 ```bash
 arandu rebuild-index --results-dir /path/to/results
 ```
+
+---
+
+### Other utilities
+
+Concise reference for the remaining run-management and reporting commands. Run `arandu <command> --help` for the full option list.
+
+| Command | Description |
+|---------|-------------|
+| `replicate SOURCE_PIPELINE_ID` | Replicate (clone) an existing pipeline run to a new ID |
+| `enrich-metadata INPUT_DIR OUTPUT_DIR` | Enrich existing transcription JSONs with source metadata |
+| `report` | Generate interactive HTML dashboard and PNG charts for pipeline results |
+| `serve-report RESULTS_DIR` | Launch interactive dashboard for pipeline results exploration |
 
 ---
 
@@ -449,10 +564,13 @@ arandu generate-cep-qa results/ \
     --language pt \
     --id etno-001
 
-# Step 4: List all runs
+# Step 4: Judge the generated QA pairs
+arandu judge-qa qa_dataset/ --model qwen3:14b
+
+# Step 5: List all runs
 arandu list-runs
 
-# Step 5: View run details
+# Step 6: View run details
 arandu run-info latest --pipeline cep
 ```
 
@@ -525,9 +643,9 @@ export ARANDU_QUANTIZE=true
 export ARANDU_QA_PROVIDER=ollama
 export ARANDU_QA_MODEL_ID=qwen3:14b
 
-# CEP settings
-export ARANDU_CEP_ENABLE_VALIDATION=true
-export ARANDU_CEP_VALIDATOR_MODEL_ID=qwen3:14b
+# Judge settings (used by judge-qa and judge-transcription)
+export ARANDU_JUDGE_VALIDATOR_MODEL=qwen3:14b
+export ARANDU_JUDGE_VALIDATOR_PROVIDER=ollama
 
 # Now run with defaults
 arandu batch-transcribe input/catalog.csv
@@ -650,6 +768,6 @@ arandu generate-cep-qa results/ --workers 4
 
 ---
 
-**Document Version**: 2.0  
-**Last Updated**: 2026-02-11  
+**Document Version**: 2.1  
+**Last Updated**: 2026-06-16  
 **Status**: Aligned with codebase v0.1.0

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -8,11 +8,11 @@ Complete reference for all configuration settings in the Arandu pipeline.
 2. [TranscriberConfig](#transcriberconfig)
 3. [QAConfig](#qaconfig)
 4. [CEPConfig](#cepconfig)
-5. [KGConfig](#kgconfig)
-6. [EvaluationConfig](#evaluationconfig)
-7. [LLMConfig](#llmconfig)
-8. [ResultsConfig](#resultsconfig)
-9. [TranscriptionQualityConfig](#transcriptionqualityconfig)
+5. [JudgeConfig](#judgeconfig)
+6. [KGConfig](#kgconfig)
+7. [EvaluationConfig](#evaluationconfig)
+8. [LLMConfig](#llmconfig)
+9. [ResultsConfig](#resultsconfig)
 10. [Environment Variables](#environment-variables)
 11. [Configuration Examples](#configuration-examples)
 
@@ -25,23 +25,25 @@ The Arandu project uses **Pydantic Settings** for configuration management with 
 1. **Command-line arguments** (highest priority)
 2. **Environment variables** with config-specific prefixes
 3. **`.env` file** in project root
-4. **Default values** in `config.py` (lowest priority)
+4. **Default values** in each config class (lowest priority)
 
-**Configuration File**: `src/arandu/config.py`
+**Configuration modules**: there is no flat `config.py`. Each config class lives next to the domain it configures:
 
-**Architecture**: The system uses **8 separate configuration classes**, each with its own environment variable prefix:
-- `TranscriberConfig` - Prefix: `ARANDU_`
-- `QAConfig` - Prefix: `ARANDU_QA_`
-- `CEPConfig` - Prefix: `ARANDU_CEP_`
-- `KGConfig` - Prefix: `ARANDU_KG_`
-- `EvaluationConfig` - Prefix: `ARANDU_EVAL_`
-- `LLMConfig` - No prefix (uses aliases like `OPENAI_API_KEY`)
-- `ResultsConfig` - Prefix: `ARANDU_RESULTS_`
-- `TranscriptionQualityConfig` - Prefix: `ARANDU_QUALITY_`
+| Config Class | Module | Prefix |
+|--------------|--------|--------|
+| `TranscriberConfig` | `arandu.transcription.config` | `ARANDU_` |
+| `QAConfig` | `arandu.qa.config` | `ARANDU_QA_` |
+| `CEPConfig` | `arandu.qa.config` | `ARANDU_CEP_` |
+| `JudgeConfig` | `arandu.qa.config` | `ARANDU_JUDGE_` |
+| `KGConfig` | `arandu.kg.config` | `ARANDU_KG_` |
+| `EvaluationConfig` | `arandu.shared.config` | `ARANDU_EVAL_` |
+| `LLMConfig` | `arandu.shared.config` | (no prefix; uses aliases like `OPENAI_API_KEY`) |
+| `ResultsConfig` | `arandu.shared.config` | `ARANDU_RESULTS_` |
 
 **Usage**:
 ```python
-from arandu.config import TranscriberConfig, QAConfig
+from arandu.transcription.config import TranscriberConfig
+from arandu.qa.config import QAConfig
 
 transcriber_config = TranscriberConfig()
 qa_config = QAConfig()
@@ -55,7 +57,7 @@ print(qa_config.provider)  # ollama
 
 Configuration settings for the transcription pipeline.
 
-**Environment Prefix**: `ARANDU_`
+**Module**: `arandu.transcription.config` &nbsp;|&nbsp; **Environment Prefix**: `ARANDU_`
 
 ### Model Settings
 
@@ -105,20 +107,20 @@ Configuration settings for the transcription pipeline.
 
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
-| `temp_dir` | `str` | `"/tmp/arandu"` (platform-specific) | Temporary directory for file processing |
+| `temp_dir` | `str` | `"<tmp>/arandu"` (platform-specific) | Temporary directory for file processing |
 | `max_retries` | `int` | `3` | Maximum number of retry attempts for failed operations |
 | `retry_delay` | `float` | `1.0` | Delay in seconds between retry attempts |
 
 **Example Configuration**:
 ```python
-from arandu.config import TranscriberConfig
+from arandu.transcription.config import TranscriberConfig
 
 config = TranscriberConfig()
 # Or with custom settings:
 config = TranscriberConfig(
     model_id="openai/whisper-large-v3",
     force_cpu=False,
-    workers=4
+    workers=4,
 )
 ```
 
@@ -128,7 +130,7 @@ config = TranscriberConfig(
 
 Configuration settings for the QA generation pipeline.
 
-**Environment Prefix**: `ARANDU_QA_`
+**Module**: `arandu.qa.config` &nbsp;|&nbsp; **Environment Prefix**: `ARANDU_QA_`
 
 ### LLM Provider Settings
 
@@ -144,9 +146,9 @@ Configuration settings for the QA generation pipeline.
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
 | `temperature` | `float` | `0.7` | Temperature for QA generation LLM (range: 0.0-2.0) |
-| `max_tokens` | `int` | `2048` | Max tokens for QA generation LLM (min: 1) |
+| `max_tokens` | `int` | `8192` | Max tokens for QA generation LLM. Sized for thinking models (Qwen3, Gemini 2.5) whose reasoning tokens consume the budget before the JSON output |
 
-> **Note**: The per-chunk ladder size is no longer a separate QAConfig knob. It is the sum of `CEPConfig.bloom_distribution` (the integer pair counts per Bloom level), so the distribution is the single source of truth.
+> **Note**: The per-chunk ladder size is not a QAConfig knob. It is the sum of `CEPConfig.bloom_distribution` (the integer pair counts per Bloom level), so the distribution is the single source of truth.
 
 ### Output Settings
 
@@ -163,12 +165,12 @@ Configuration settings for the QA generation pipeline.
 
 **Example Configuration**:
 ```python
-from arandu.config import QAConfig
+from arandu.qa.config import QAConfig
 
 config = QAConfig(
     provider="ollama",
     model_id="qwen3:14b",
-    language="pt"
+    language="pt",
 )
 ```
 
@@ -176,52 +178,49 @@ config = QAConfig(
 
 ## CEPConfig
 
-Configuration settings for the CEP (Cognitive Elicitation Pipeline) with Bloom's Taxonomy scaffolding and LLM-as-a-Judge validation.
+Configuration settings for the CEP (Cognitive Elicitation Pipeline) with Bloom's Taxonomy scaffolding. Generation and validation are separate steps: `generate-cep-qa` only generates pairs; `judge-qa` validates them using the scoring weights and threshold defined here.
 
-**Environment Prefix**: `ARANDU_CEP_`
+**Module**: `arandu.qa.config` &nbsp;|&nbsp; **Environment Prefix**: `ARANDU_CEP_`
 
 ### Module Toggles
 
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
 | `enable_reasoning_traces` | `bool` | `True` | Enable reasoning trace generation for answers |
-| `enable_validation` | `bool` | `True` | Enable LLM-as-a-Judge validation (requires additional LLM calls) |
+| `enable_scaffolding_context` | `bool` | `True` | Pass previously generated QA pairs as context to higher Bloom levels |
+| `enable_source_metadata_context` | `bool` | `True` | Include extracted source metadata (participant name, location, date) in CEP prompt context |
 
 ### Module I - Bloom Scaffolding Settings
 
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
-| `bloom_levels` | `list[str]` | `["remember", "understand", "analyze", "evaluate"]` | Bloom levels for question generation |
-| `bloom_distribution` | `dict[str, int]` | `{"remember": 3, "understand": 1, "analyze": 1, "evaluate": 1}` | Absolute number of QA pairs to generate at each Bloom level, per chunk. Counts must be non-negative and total at least 1; the per-chunk ladder size is their sum. |
-| `enable_scaffolding_context` | `bool` | `True` | Pass previously generated QA pairs as context to higher Bloom levels |
+| `bloom_distribution` | `dict[str, int]` | `{"remember": 3, "understand": 1, "analyze": 1, "evaluate": 1}` | Absolute number of QA pairs to generate at each Bloom level, per chunk (single source of truth). Counts must be non-negative; the total must be between 1 and `MAX_BLOOM_PAIRS_PER_CHUNK` (50). Locked at 3/1/1/1 for the thesis run. |
 | `max_scaffolding_pairs` | `int` | `10` | Max prior QA pairs to include as scaffolding context (min: 1, max: 50) |
 
 **Valid Bloom Levels**: `remember`, `understand`, `apply`, `analyze`, `evaluate`, `create`
+
+**Derived property**: `pairs_per_chunk` returns the sum of `bloom_distribution` values (the per-chunk ladder size). There is no `bloom_levels` field; the keys of `bloom_distribution` are the levels to generate.
 
 ### Module II - Reasoning Settings
 
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
 | `max_hop_count` | `int` | `3` | Maximum reasoning hops to detect for multi-hop questions (min: 1, max: 5) |
+| `reasoning_max_tokens` | `int` | `8192` | Max tokens for reasoning enrichment responses (min: 128, max: 8192). Sized for thinking models |
 
-### Module III - LLM-as-a-Judge Validation Settings
+### Judge Scoring Settings
+
+These fields drive `judge-qa` (the four-criterion LLM-as-a-Judge over generated pairs). The validator *client* settings (model, provider, base URL) live in [`JudgeConfig`](#judgeconfig).
 
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
-| `validator_provider` | `str` | `"ollama"` | LLM provider for validation: "openai", "ollama", "custom" |
-| `validator_model_id` | `str` | `"qwen3:14b"` | Model ID for LLM-as-a-Judge validation |
-| `validator_temperature` | `float` | `0.3` | Temperature for validator (low for consistent evaluation, range: 0.0-1.0) |
 | `validation_threshold` | `float` | `0.6` | Minimum overall score to pass validation (range: 0.0-1.0) |
+| `faithfulness_weight` | `float` | `0.30` | Weight for faithfulness score |
+| `bloom_calibration_weight` | `float` | `0.25` | Weight for Bloom calibration score |
+| `informativeness_weight` | `float` | `0.25` | Weight for informativeness score |
+| `self_containedness_weight` | `float` | `0.20` | Weight for self-containedness score |
 
-### Validation Scoring Weights
-
-| Setting | Type | Default | Description |
-|---------|------|---------|-------------|
-| `faithfulness_weight` | `float` | `0.4` | Weight for faithfulness score in overall calculation (range: 0.0-1.0) |
-| `bloom_calibration_weight` | `float` | `0.3` | Weight for Bloom calibration score in overall calculation (range: 0.0-1.0) |
-| `informativeness_weight` | `float` | `0.3` | Weight for informativeness score in overall calculation (range: 0.0-1.0) |
-
-> **Note**: The three scoring weights (`faithfulness_weight`, `bloom_calibration_weight`, `informativeness_weight`) must sum to 1.0. A `@model_validator` enforces this constraint.
+> **Note**: The four scoring weights must sum to 1.0. A `@model_validator` (`validate_scoring_weights`) enforces this constraint.
 
 ### Language Settings
 
@@ -231,14 +230,41 @@ Configuration settings for the CEP (Cognitive Elicitation Pipeline) with Bloom's
 
 **Example Configuration**:
 ```python
-from arandu.config import CEPConfig
+from arandu.qa.config import CEPConfig
 
 config = CEPConfig(
-    bloom_levels=["remember", "understand", "analyze"],
     bloom_distribution={"remember": 3, "understand": 2, "analyze": 1},
     enable_scaffolding_context=True,
-    validation_threshold=0.7
+    validation_threshold=0.7,
 )
+print(config.pairs_per_chunk)  # 6
+```
+
+---
+
+## JudgeConfig
+
+Configuration for the composable judge pipeline. Supplies the validator LLM client settings shared by the `judge-transcription` LLM filter stage and the `judge-qa` command. Replaces the removed `TranscriptionQualityConfig` (transcription validation is now a filter pipeline, not a weighted-score config; see the [Transcription Validation guide](transcription-validation.md)).
+
+**Module**: `arandu.qa.config` &nbsp;|&nbsp; **Environment Prefix**: `ARANDU_JUDGE_`
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `language` | `str` | `"pt"` | Language for judge criterion prompts (ISO 639-1: 'pt' or 'en') |
+| `temperature` | `float` | `0.3` | Temperature for judge LLM (low for consistent evaluation, range: 0.0-1.0) |
+| `max_tokens` | `int` | `8192` | Max tokens for judge responses (min: 128, max: 8192) |
+| `validator_model` | `str \| None` | `None` | Model ID enabling the LLM stage (e.g. `qwen3:14b`, `gemini-2.5-flash`). When unset, `judge-transcription` runs heuristic-only and skips the LLM stage |
+| `validator_provider` | `str \| None` | `None` | Provider: "openai", "ollama", or "custom". Inferred from `ARANDU_LLM_BASE_URL` (custom when set, else ollama) when unspecified |
+| `validator_base_url` | `str \| None` | `None` | Base URL for the validator provider. Inherits `ARANDU_LLM_BASE_URL` only when the resolved provider is "custom" |
+
+**Example Configuration**:
+```python
+from arandu.qa.config import JudgeConfig
+
+config = JudgeConfig()
+# Loaded from ARANDU_JUDGE_* env vars; e.g.
+# ARANDU_JUDGE_VALIDATOR_MODEL=qwen3:14b
+# ARANDU_JUDGE_VALIDATOR_PROVIDER=ollama
 ```
 
 ---
@@ -247,7 +273,14 @@ config = CEPConfig(
 
 Configuration settings for the knowledge graph construction pipeline.
 
-**Environment Prefix**: `ARANDU_KG_`
+**Module**: `arandu.kg.config` &nbsp;|&nbsp; **Environment Prefix**: `ARANDU_KG_`
+
+### Backend Settings
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `backend` | `str` | `"atlas"` | KGC backend: `"atlas"` (AutoSchemaKG). Must match pattern `^(atlas)$` |
+| `backend_options` | `dict` | `{}` | Backend-specific options passed through to the constructor (e.g., `chunk_size`, `batch_size_triple`, `max_workers`) |
 
 ### LLM Provider Settings
 
@@ -257,15 +290,6 @@ Configuration settings for the knowledge graph construction pipeline.
 | `model_id` | `str` | `"llama3.1:8b"` | Model ID for KG construction |
 | `ollama_url` | `str` | `"http://localhost:11434/v1"` | Ollama API base URL for KG construction |
 | `base_url` | `str \| None` | `None` | Custom base URL for OpenAI-compatible endpoints |
-
-### Backend Settings
-
-| Setting | Type | Default | Description |
-|---------|------|---------|-------------|
-| `backend` | `str` | `"atlas"` | KGC backend: `"atlas"` (AutoSchemaKG) |
-| `backend_options` | `dict` | `{}` | Backend-specific options (e.g., `chunk_size`, `batch_size_triple`, `max_workers`) |
-
-**Backend Validation**: Must match pattern `^(atlas)$`
 
 ### LLM Settings
 
@@ -289,7 +313,7 @@ Prompts are stored in `prompts/kg/atlas/` using language-keyed JSON files. The a
 
 **Example Configuration**:
 ```python
-from arandu.config import KGConfig
+from arandu.kg.config import KGConfig
 
 config = KGConfig(
     backend="atlas",
@@ -318,7 +342,7 @@ config = KGConfig(
 
 Configuration settings for the evaluation pipeline.
 
-**Environment Prefix**: `ARANDU_EVAL_`
+**Module**: `arandu.shared.config` &nbsp;|&nbsp; **Environment Prefix**: `ARANDU_EVAL_`
 
 ### Metrics Settings
 
@@ -349,11 +373,11 @@ Configuration settings for the evaluation pipeline.
 
 **Example Configuration**:
 ```python
-from arandu.config import EvaluationConfig
+from arandu.shared.config import EvaluationConfig
 
 config = EvaluationConfig(
     metrics=["qa", "entity", "semantic"],
-    embedding_model="sentence-transformers/all-MiniLM-L6-v2"
+    embedding_model="sentence-transformers/all-MiniLM-L6-v2",
 )
 ```
 
@@ -363,7 +387,7 @@ config = EvaluationConfig(
 
 Shared LLM configuration settings for API keys and shared LLM settings across pipelines.
 
-**Environment Prefix**: None (uses field aliases)
+**Module**: `arandu.shared.config` &nbsp;|&nbsp; **Environment Prefix**: None (uses field aliases)
 
 ### API Keys
 
@@ -374,7 +398,7 @@ Shared LLM configuration settings for API keys and shared LLM settings across pi
 
 **Example Configuration**:
 ```python
-from arandu.config import LLMConfig
+from arandu.shared.config import LLMConfig
 
 config = LLMConfig()
 # Loaded from OPENAI_API_KEY and ARANDU_LLM_BASE_URL env vars
@@ -392,7 +416,7 @@ export ARANDU_LLM_BASE_URL=https://my-custom-endpoint/v1
 
 Configuration for versioned results management.
 
-**Environment Prefix**: `ARANDU_RESULTS_`
+**Module**: `arandu.shared.config` &nbsp;|&nbsp; **Environment Prefix**: `ARANDU_RESULTS_`
 
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
@@ -401,66 +425,15 @@ Configuration for versioned results management.
 
 **Example Configuration**:
 ```python
-from arandu.config import ResultsConfig
+from pathlib import Path
+
+from arandu.shared.config import ResultsConfig
 
 config = ResultsConfig(
     base_dir=Path("/data/results"),
-    enable_versioning=True
+    enable_versioning=True,
 )
 ```
-
----
-
-## TranscriptionQualityConfig
-
-Configuration for transcription quality validation with heuristic quality checks.
-
-**Environment Prefix**: `ARANDU_QUALITY_`
-
-### General Settings
-
-| Setting | Type | Default | Description |
-|---------|------|---------|-------------|
-| `enabled` | `bool` | `True` | Enable transcription quality validation |
-| `quality_threshold` | `float` | `0.5` | Minimum quality score to mark transcription as valid (range: 0.0-1.0) |
-| `expected_language` | `str` | `"pt"` | Expected language code (e.g., 'pt', 'en') |
-
-### Scoring Weights
-
-| Setting | Type | Default | Description |
-|---------|------|---------|-------------|
-| `script_match_weight` | `float` | `0.35` | Weight for script/charset match check |
-| `repetition_weight` | `float` | `0.30` | Weight for repetition detection |
-| `segment_quality_weight` | `float` | `0.20` | Weight for segment pattern analysis |
-| `content_density_weight` | `float` | `0.15` | Weight for content density check |
-
-> **Note**: The four dimension weights must sum to 1.0. A `@model_validator` enforces this constraint at initialization.
-
-### Validation Thresholds
-
-| Setting | Type | Default | Description |
-|---------|------|---------|-------------|
-| `max_non_latin_ratio` | `float` | `0.1` | Maximum ratio of non-Latin characters for Latin languages |
-| `max_word_repetition_ratio` | `float` | `0.15` | Maximum ratio of most repeated word |
-| `max_phrase_repetition_count` | `int` | `4` | Maximum allowed repetitions of same phrase |
-| `suspicious_uniform_intervals` | `int` | `5` | Number of consecutive uniform 1-second intervals to flag |
-| `min_words_per_minute` | `float` | `30.0` | Minimum words per minute threshold |
-| `max_words_per_minute` | `float` | `300.0` | Maximum words per minute threshold |
-| `max_empty_segment_ratio` | `float` | `0.2` | Maximum ratio of empty segments before flagging |
-| `uniform_interval_tolerance` | `float` | `0.1` | Tolerance (±seconds) for detecting uniform 1-second intervals |
-
-**Example Configuration**:
-```python
-from arandu.config import TranscriptionQualityConfig
-
-config = TranscriptionQualityConfig(
-    enabled=True,
-    quality_threshold=0.6,
-    expected_language="pt"
-)
-```
-
-**See also**: [Transcription Validation Guide](transcription-validation.md) for full usage details
 
 ---
 
@@ -474,12 +447,12 @@ Configuration settings are loaded from environment variables with config-specifi
 |--------------|--------|---------|
 | `TranscriberConfig` | `ARANDU_` | `ARANDU_MODEL_ID` |
 | `QAConfig` | `ARANDU_QA_` | `ARANDU_QA_PROVIDER` |
-| `CEPConfig` | `ARANDU_CEP_` | `ARANDU_CEP_ENABLE_VALIDATION` |
+| `CEPConfig` | `ARANDU_CEP_` | `ARANDU_CEP_VALIDATION_THRESHOLD` |
+| `JudgeConfig` | `ARANDU_JUDGE_` | `ARANDU_JUDGE_VALIDATOR_MODEL` |
 | `KGConfig` | `ARANDU_KG_` | `ARANDU_KG_PROVIDER` |
 | `EvaluationConfig` | `ARANDU_EVAL_` | `ARANDU_EVAL_METRICS` |
 | `LLMConfig` | (No prefix) | `OPENAI_API_KEY`, `ARANDU_LLM_BASE_URL` |
 | `ResultsConfig` | `ARANDU_RESULTS_` | `ARANDU_RESULTS_BASE_DIR` |
-| `TranscriptionQualityConfig` | `ARANDU_QUALITY_` | `ARANDU_QUALITY_ENABLED` |
 
 ### Format
 
@@ -507,17 +480,24 @@ export ARANDU_QA_LANGUAGE=pt
 
 **CEPConfig** (`ARANDU_CEP_`):
 ```bash
-export ARANDU_CEP_ENABLE_VALIDATION=true
-export ARANDU_CEP_BLOOM_LEVELS=remember,understand,analyze
 export ARANDU_CEP_VALIDATION_THRESHOLD=0.7
-export ARANDU_CEP_VALIDATOR_PROVIDER=ollama
+export ARANDU_CEP_MAX_SCAFFOLDING_PAIRS=15
+export ARANDU_CEP_ENABLE_SOURCE_METADATA_CONTEXT=true
+# Bloom distribution is a dict; set it as JSON
+export ARANDU_CEP_BLOOM_DISTRIBUTION='{"remember": 3, "understand": 1, "analyze": 1, "evaluate": 1}'
+```
+
+**JudgeConfig** (`ARANDU_JUDGE_`):
+```bash
+export ARANDU_JUDGE_VALIDATOR_MODEL=qwen3:14b
+export ARANDU_JUDGE_VALIDATOR_PROVIDER=ollama
+export ARANDU_JUDGE_TEMPERATURE=0.3
 ```
 
 **KGConfig** (`ARANDU_KG_`):
 ```bash
 export ARANDU_KG_PROVIDER=openai
 export ARANDU_KG_MODEL_ID=gpt-4o
-export ARANDU_KG_MERGE_GRAPHS=true
 export ARANDU_KG_LANGUAGE=pt
 export ARANDU_KG_OLLAMA_URL=http://localhost:11434/v1
 ```
@@ -538,13 +518,6 @@ export ARANDU_LLM_BASE_URL=https://my-custom-endpoint/v1
 ```bash
 export ARANDU_RESULTS_BASE_DIR=/data/results
 export ARANDU_RESULTS_ENABLE_VERSIONING=true
-```
-
-**TranscriptionQualityConfig** (`ARANDU_QUALITY_`):
-```bash
-export ARANDU_QUALITY_ENABLED=true
-export ARANDU_QUALITY_QUALITY_THRESHOLD=0.6
-export ARANDU_QUALITY_EXPECTED_LANGUAGE=pt
 ```
 
 ### API Keys
@@ -585,29 +558,29 @@ ARANDU_QA_OLLAMA_URL=http://localhost:11434/v1
 ARANDU_QA_LANGUAGE=pt
 
 # CEP (Cognitive Elicitation Pipeline)
-ARANDU_CEP_ENABLE_VALIDATION=true
 ARANDU_CEP_VALIDATION_THRESHOLD=0.6
+
+# Judge (validator client for judge-qa / judge-transcription)
+ARANDU_JUDGE_VALIDATOR_MODEL=qwen3:14b
+ARANDU_JUDGE_VALIDATOR_PROVIDER=ollama
 
 # KG Construction
 ARANDU_KG_PROVIDER=ollama
 ARANDU_KG_MODEL_ID=llama3.1:8b
 ARANDU_KG_OLLAMA_URL=http://localhost:11434/v1
-ARANDU_KG_MERGE_GRAPHS=true
-ARANDU_KG_OUTPUT_FORMAT=graphml
 ARANDU_KG_LANGUAGE=pt
 
 # Evaluation
 ARANDU_EVAL_METRICS=qa,entity,relation,semantic
-
-# Transcription Quality Validation
-ARANDU_QUALITY_ENABLED=true
-ARANDU_QUALITY_QUALITY_THRESHOLD=0.5
 ```
 
 **CLI Usage**:
 ```bash
 # QA generation (uses .env settings)
 arandu generate-cep-qa results/
+
+# Validate the generated pairs (separate step)
+arandu judge-qa qa_dataset/
 
 # Override specific settings
 arandu generate-cep-qa results/ --bloom-dist "remember:3,understand:1,analyze:1,evaluate:1" --provider ollama
@@ -626,17 +599,15 @@ ARANDU_QA_MODEL_ID=gpt-4o-mini
 ARANDU_QA_TEMPERATURE=0.7
 ARANDU_QA_LANGUAGE=en
 
-# CEP with OpenAI
-ARANDU_CEP_ENABLE_VALIDATION=true
-ARANDU_CEP_VALIDATOR_PROVIDER=openai
-ARANDU_CEP_VALIDATOR_MODEL_ID=gpt-4o-mini
+# Judge with OpenAI
+ARANDU_JUDGE_VALIDATOR_PROVIDER=openai
+ARANDU_JUDGE_VALIDATOR_MODEL=gpt-4o-mini
 ARANDU_CEP_VALIDATION_THRESHOLD=0.7
 
 # KG Construction with OpenAI
 ARANDU_KG_PROVIDER=openai
 ARANDU_KG_MODEL_ID=gpt-4o
 ARANDU_KG_TEMPERATURE=0.5
-ARANDU_KG_MERGE_GRAPHS=true
 
 # Results versioning
 ARANDU_RESULTS_BASE_DIR=/data/transcriptions
@@ -696,8 +667,6 @@ docker compose --profile qa up arandu-qa --abort-on-container-exit
 
 **docker-compose.override.yml** (local overrides):
 ```yaml
-version: '3.8'
-
 services:
   arandu-qa:
     environment:
@@ -714,8 +683,6 @@ services:
       - ARANDU_KG_PROVIDER=ollama
       - ARANDU_KG_MODEL_ID=llama3.1:8b
       - ARANDU_KG_OLLAMA_URL=http://host.docker.internal:11434/v1
-      - ARANDU_KG_MERGE_GRAPHS=true
-      - ARANDU_KG_WORKERS=2
     volumes:
       - ./results:/app/results:ro
       - ./knowledge_graphs:/app/knowledge_graphs:rw
@@ -727,23 +694,23 @@ services:
 ```bash
 # CEP Settings
 ARANDU_CEP_ENABLE_REASONING_TRACES=true
-ARANDU_CEP_ENABLE_VALIDATION=true
 ARANDU_CEP_ENABLE_SCAFFOLDING_CONTEXT=true
 ARANDU_CEP_MAX_SCAFFOLDING_PAIRS=15
 
-# Bloom Levels (custom distribution)
-ARANDU_CEP_BLOOM_LEVELS=remember,understand,analyze,evaluate
+# Bloom distribution (integer pair counts per level; single source of truth)
+ARANDU_CEP_BLOOM_DISTRIBUTION='{"remember": 3, "understand": 1, "analyze": 1, "evaluate": 1}'
 
-# LLM-as-a-Judge Validation
-ARANDU_CEP_VALIDATOR_PROVIDER=ollama
-ARANDU_CEP_VALIDATOR_MODEL_ID=qwen3:14b
-ARANDU_CEP_VALIDATOR_TEMPERATURE=0.3
+# Judge scoring (used by judge-qa)
 ARANDU_CEP_VALIDATION_THRESHOLD=0.7
+ARANDU_CEP_FAITHFULNESS_WEIGHT=0.30
+ARANDU_CEP_BLOOM_CALIBRATION_WEIGHT=0.25
+ARANDU_CEP_INFORMATIVENESS_WEIGHT=0.25
+ARANDU_CEP_SELF_CONTAINEDNESS_WEIGHT=0.20
 
-# Scoring weights (must sum to 1.0)
-ARANDU_CEP_FAITHFULNESS_WEIGHT=0.4
-ARANDU_CEP_BLOOM_CALIBRATION_WEIGHT=0.3
-ARANDU_CEP_INFORMATIVENESS_WEIGHT=0.3
+# Validator client
+ARANDU_JUDGE_VALIDATOR_PROVIDER=ollama
+ARANDU_JUDGE_VALIDATOR_MODEL=qwen3:14b
+ARANDU_JUDGE_TEMPERATURE=0.3
 ```
 
 ---
@@ -752,54 +719,41 @@ ARANDU_CEP_INFORMATIVENESS_WEIGHT=0.3
 
 The configuration system includes validation rules enforced by Pydantic.
 
-### Type Validation
+### Custom Field Validation
 
 ```python
-# From CEPConfig — counts must be non-negative and total at least 1
+# From CEPConfig — counts must be non-negative, reference valid Bloom levels,
+# and total between 1 and MAX_BLOOM_PAIRS_PER_CHUNK (50)
 @field_validator("bloom_distribution")
 @classmethod
 def validate_bloom_distribution(cls, v: dict[str, int]) -> dict[str, int]:
-    ...  # each count >= 0, valid Bloom level, sum >= 1
+    ...  # each count >= 0, valid level, 1 <= sum <= 50
 ```
 
 ### Pattern Validation
 
 ```python
 # From KGConfig
-output_format: str = Field(
-    default="graphml",
-    pattern="^(graphml|json)$"  # Must match pattern
+backend: str = Field(
+    default="atlas",
+    pattern="^(atlas)$",  # only the atlas backend is supported
 )
-```
-
-### Custom Field Validation
-
-```python
-# From CEPConfig
-@field_validator("bloom_levels")
-@classmethod
-def validate_bloom_levels(cls, v: list[str]) -> list[str]:
-    valid_levels = {"remember", "understand", "apply", "analyze", "evaluate", "create"}
-    for level in v:
-        if level not in valid_levels:
-            raise ValueError(f"Invalid Bloom level: {level!r}")
-    return v
 ```
 
 ### Model Validation (Cross-Field)
 
 ```python
-# From TranscriptionQualityConfig
+# From CEPConfig — the four judge scoring weights must sum to 1.0
 @model_validator(mode="after")
-def validate_scoring_weights(self) -> TranscriptionQualityConfig:
+def validate_scoring_weights(self) -> CEPConfig:
     total = (
-        self.script_match_weight
-        + self.repetition_weight
-        + self.segment_quality_weight
-        + self.content_density_weight
+        self.faithfulness_weight
+        + self.bloom_calibration_weight
+        + self.informativeness_weight
+        + self.self_containedness_weight
     )
     if not (0.99 <= total <= 1.01):
-        raise ValueError(f"Quality scoring weights must sum to 1.0, got {total:.3f}")
+        raise ValueError(f"Scoring weights must sum to 1.0, got {total:.3f}")
     return self
 ```
 
@@ -826,7 +780,7 @@ Pydantic Settings loads configuration in the following priority order (highest t
    ARANDU_QA_MODEL_ID=qwen3:14b
    ```
 
-4. **Default values** in `config.py` (lowest priority):
+4. **Default values** in each config class (lowest priority):
    ```python
    provider: str = Field(default="ollama")
    model_id: str = Field(default="qwen3:14b")
@@ -921,7 +875,7 @@ ARANDU_QA_OLLAMA_URL=http://localhost:11434/v1
 
 # Generation
 ARANDU_QA_TEMPERATURE=0.7
-ARANDU_QA_MAX_TOKENS=2048
+ARANDU_QA_MAX_TOKENS=8192
 
 # Output
 ARANDU_QA_OUTPUT_DIR=qa_dataset
@@ -936,33 +890,42 @@ ARANDU_QA_WORKERS=2
 
 # Module toggles
 ARANDU_CEP_ENABLE_REASONING_TRACES=true
-ARANDU_CEP_ENABLE_VALIDATION=true
-
-# Bloom scaffolding
-ARANDU_CEP_BLOOM_LEVELS=remember,understand,analyze,evaluate
 ARANDU_CEP_ENABLE_SCAFFOLDING_CONTEXT=true
+ARANDU_CEP_ENABLE_SOURCE_METADATA_CONTEXT=true
+
+# Bloom scaffolding (integer pair counts per level; single source of truth)
+ARANDU_CEP_BLOOM_DISTRIBUTION='{"remember": 3, "understand": 1, "analyze": 1, "evaluate": 1}'
 ARANDU_CEP_MAX_SCAFFOLDING_PAIRS=10
 
 # Reasoning
 ARANDU_CEP_MAX_HOP_COUNT=3
 
-# LLM-as-a-Judge validation
-ARANDU_CEP_VALIDATOR_PROVIDER=ollama
-ARANDU_CEP_VALIDATOR_MODEL_ID=qwen3:14b
-ARANDU_CEP_VALIDATOR_TEMPERATURE=0.3
+# Judge scoring (used by judge-qa; weights must sum to 1.0)
 ARANDU_CEP_VALIDATION_THRESHOLD=0.6
-
-# Scoring weights (must sum to 1.0)
-ARANDU_CEP_FAITHFULNESS_WEIGHT=0.4
-ARANDU_CEP_BLOOM_CALIBRATION_WEIGHT=0.3
-ARANDU_CEP_INFORMATIVENESS_WEIGHT=0.3
+ARANDU_CEP_FAITHFULNESS_WEIGHT=0.30
+ARANDU_CEP_BLOOM_CALIBRATION_WEIGHT=0.25
+ARANDU_CEP_INFORMATIVENESS_WEIGHT=0.25
+ARANDU_CEP_SELF_CONTAINEDNESS_WEIGHT=0.20
 
 # Language
 ARANDU_CEP_LANGUAGE=pt
 
 # ============================================================================
+# JudgeConfig (ARANDU_JUDGE_) - validator client for judge-qa / judge-transcription
+# ============================================================================
+
+ARANDU_JUDGE_VALIDATOR_MODEL=qwen3:14b
+ARANDU_JUDGE_VALIDATOR_PROVIDER=ollama  # openai, ollama, custom
+# ARANDU_JUDGE_VALIDATOR_BASE_URL=  # For custom OpenAI-compatible endpoints
+ARANDU_JUDGE_TEMPERATURE=0.3
+ARANDU_JUDGE_LANGUAGE=pt
+
+# ============================================================================
 # KGConfig (ARANDU_KG_)
 # ============================================================================
+
+# Backend
+ARANDU_KG_BACKEND=atlas
 
 # LLM Provider
 ARANDU_KG_PROVIDER=ollama  # openai, ollama, custom
@@ -970,21 +933,14 @@ ARANDU_KG_MODEL_ID=llama3.1:8b
 ARANDU_KG_OLLAMA_URL=http://localhost:11434/v1
 # ARANDU_KG_BASE_URL=  # For custom OpenAI-compatible endpoints
 
-# Graph settings
-ARANDU_KG_MERGE_GRAPHS=true
-ARANDU_KG_OUTPUT_FORMAT=graphml  # graphml or json
-ARANDU_KG_SCHEMA_MODE=dynamic  # dynamic or predefined
-
 # LLM settings
 ARANDU_KG_TEMPERATURE=0.5
 
 # Language and prompts
 ARANDU_KG_LANGUAGE=pt
-ARANDU_KG_PROMPT_PATH=prompts/pt_prompts.json
 
 # Output
 ARANDU_KG_OUTPUT_DIR=knowledge_graphs
-ARANDU_KG_WORKERS=2
 
 # ============================================================================
 # EvaluationConfig (ARANDU_EVAL_)
@@ -1018,35 +974,10 @@ ARANDU_EVAL_OUTPUT_DIR=evaluation
 
 ARANDU_RESULTS_BASE_DIR=./results
 ARANDU_RESULTS_ENABLE_VERSIONING=true
-
-# ============================================================================
-# TranscriptionQualityConfig (ARANDU_QUALITY_)
-# ============================================================================
-
-# General
-ARANDU_QUALITY_ENABLED=true
-ARANDU_QUALITY_QUALITY_THRESHOLD=0.5
-ARANDU_QUALITY_EXPECTED_LANGUAGE=pt
-
-# Scoring weights (must sum to 1.0)
-ARANDU_QUALITY_SCRIPT_MATCH_WEIGHT=0.35
-ARANDU_QUALITY_REPETITION_WEIGHT=0.30
-ARANDU_QUALITY_SEGMENT_QUALITY_WEIGHT=0.20
-ARANDU_QUALITY_CONTENT_DENSITY_WEIGHT=0.15
-
-# Thresholds (advanced - usually keep defaults)
-# ARANDU_QUALITY_MAX_NON_LATIN_RATIO=0.1
-# ARANDU_QUALITY_MAX_WORD_REPETITION_RATIO=0.15
-# ARANDU_QUALITY_MAX_PHRASE_REPETITION_COUNT=4
-# ARANDU_QUALITY_SUSPICIOUS_UNIFORM_INTERVALS=5
-# ARANDU_QUALITY_MIN_WORDS_PER_MINUTE=30.0
-# ARANDU_QUALITY_MAX_WORDS_PER_MINUTE=300.0
-# ARANDU_QUALITY_MAX_EMPTY_SEGMENT_RATIO=0.2
-# ARANDU_QUALITY_UNIFORM_INTERVAL_TOLERANCE=0.1
 ```
 
 ---
 
-**Document Version**: 2.0  
-**Last Updated**: 2025-01-24  
-**Changes**: Complete rewrite to reflect actual implementation with 8 separate config classes
+**Document Version**: 3.0  
+**Last Updated**: 2026-06-16  
+**Changes**: Synced to the per-domain config modules (no flat `config.py`); replaced the removed `TranscriptionQualityConfig` with `JudgeConfig`; CEP now uses `bloom_distribution` (no `bloom_levels`/`enable_validation`) with four judge weights; removed nonexistent KG `merge_graphs`/`output_format`/`schema_mode`/`prompt_path` fields.


### PR DESCRIPTION
## Summary

Docs-only staleness sweep: brings four docs back in sync with the current code on `main` after the recent refactors (Bloom integer distribution #130, transcription judge filter pipeline, k-hop unification #129, per-domain config-class split). Each change was cross-checked against the actual `src/` file before editing.

Follows the already-merged #131 (methodology) and #132 (transcription-validation guide).

## Changes

- **`docs/user-guide/cli-reference.md`** — Drop the removed `generate-cep-qa` `--validate/--no-validate` and `--validator-model` flags; add a Judging Commands section (`judge-transcription`, `judge-qa`, `judge-answers`) and a Knowledge Graph & RAG (Phase C) section covering the full registered command set; fix the stale `ARANDU_CEP_ENABLE_VALIDATION` env example.
- **`docs/user-guide/configuration.md`** — Replace the nonexistent flat `arandu.config` module with the real per-domain modules and fix every import; replace the removed `TranscriptionQualityConfig` with `JudgeConfig`; CEP now uses `bloom_distribution` (no `bloom_levels`/`enable_validation`) with four judge weights (0.30/0.25/0.25/0.20); drop the nonexistent KG `merge_graphs`/`output_format`/`schema_mode`/`prompt_path` fields; fix `QAConfig.max_tokens` default (8192).
- **`docs/development/schemas.md`** — `EnrichedRecord` extends `InputRecord, JudgeResultMixin`; document the canonical `validation` (`JudgePipelineResult`) field + computed `is_valid`; replace the removed `TranscriptionQualityScore` weighted-average model with `JudgePipelineResult`/`JudgeStepResult`/`CriterionScore`.
- **`docs/user-guide/cep-qa-generation.md`** — Reframe validation around the separate `judge-qa` command (no `--no-validate`, no `ARANDU_CEP_ENABLE_VALIDATION`); document the four judge criteria with correct weights and the self-containedness rubric; fix programmatic imports (`arandu.qa.schemas`/`arandu.qa.config`) and replace `cep_config.enable_validation`/`bloom_levels` with `bloom_distribution`/`pairs_per_chunk`/`validation_threshold`.

## Verification

Cross-checked against `src/arandu/cli/{app,qa}.py`, `src/arandu/{transcription,qa,kg,shared}/config.py`, `src/arandu/shared/schemas.py`, and `src/arandu/shared/judge/schemas.py`. Confirmed there is no flat `config.py`, no `TranscriptionQualityConfig`, and no `ARANDU_QUALITY_*` in `src/`.

## Follow-up (not in this PR)

The QA-validation section of `schemas.md` (`ValidationScore` / `QAPairValidated`) carries the same weighted-average drift and is tracked separately.