### PR TITLE
docs+ci: finish staleness sweep (deps, schemas QA, slurm, rag, docs-site) + fix deploy-docs build

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -27,12 +27,12 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: latest
+          version: 10
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
           cache-dependency-path: docs-site/pnpm-lock.yaml
 

--- a/docs-site/src/content/docs/configuration.md
+++ b/docs-site/src/content/docs/configuration.md
@@ -62,7 +62,7 @@ Current settings classes:
 | `ollama_url` | `ARANDU_QA_OLLAMA_URL` | `http://localhost:11434/v1` |
 | `base_url` | `ARANDU_QA_BASE_URL` | `None` |
 | `temperature` | `ARANDU_QA_TEMPERATURE` | `0.7` |
-| `max_tokens` | `ARANDU_QA_MAX_TOKENS` | `2048` |
+| `max_tokens` | `ARANDU_QA_MAX_TOKENS` | `8192` |
 | `output_dir` | `ARANDU_QA_OUTPUT_DIR` | `qa_dataset` |
 | `language` | `ARANDU_QA_LANGUAGE` | `pt` |
 | `workers` | `ARANDU_QA_WORKERS` | `2` |
@@ -72,12 +72,11 @@ Current settings classes:
 | Field | Env var | Default |
 |---|---|---|
 | `enable_reasoning_traces` | `ARANDU_CEP_ENABLE_REASONING_TRACES` | `true` |
-| `bloom_levels` | `ARANDU_CEP_BLOOM_LEVELS` | `remember,understand,analyze,evaluate` |
 | `bloom_distribution` | `ARANDU_CEP_BLOOM_DISTRIBUTION` | `{"remember":3,"understand":1,"analyze":1,"evaluate":1}` |
 | `enable_scaffolding_context` | `ARANDU_CEP_ENABLE_SCAFFOLDING_CONTEXT` | `true` |
 | `max_scaffolding_pairs` | `ARANDU_CEP_MAX_SCAFFOLDING_PAIRS` | `10` |
 | `max_hop_count` | `ARANDU_CEP_MAX_HOP_COUNT` | `3` |
-| `reasoning_max_tokens` | `ARANDU_CEP_REASONING_MAX_TOKENS` | `2048` |
+| `reasoning_max_tokens` | `ARANDU_CEP_REASONING_MAX_TOKENS` | `8192` |
 | `validation_threshold` | `ARANDU_CEP_VALIDATION_THRESHOLD` | `0.6` |
 | `faithfulness_weight` | `ARANDU_CEP_FAITHFULNESS_WEIGHT` | `0.30` |
 | `bloom_calibration_weight` | `ARANDU_CEP_BLOOM_CALIBRATION_WEIGHT` | `0.25` |
@@ -92,7 +91,7 @@ Current settings classes:
 |---|---|---|
 | `language` | `ARANDU_JUDGE_LANGUAGE` | `pt` |
 | `temperature` | `ARANDU_JUDGE_TEMPERATURE` | `0.3` |
-| `max_tokens` | `ARANDU_JUDGE_MAX_TOKENS` | `2048` |
+| `max_tokens` | `ARANDU_JUDGE_MAX_TOKENS` | `8192` |
 | `validator_model` | `ARANDU_JUDGE_VALIDATOR_MODEL` | `None` |
 | `validator_provider` | `ARANDU_JUDGE_VALIDATOR_PROVIDER` | `None` (inferred) |
 | `validator_base_url` | `ARANDU_JUDGE_VALIDATOR_BASE_URL` | `None` |

--- a/docs-site/src/content/docs/guides/cep-qa-generation.md
+++ b/docs-site/src/content/docs/guides/cep-qa-generation.md
@@ -26,7 +26,6 @@ arandu judge-qa cep_dataset/ --model qwen3:14b
 
 Main `ARANDU_CEP_*` knobs:
 
-- `ARANDU_CEP_BLOOM_LEVELS`
 - `ARANDU_CEP_BLOOM_DISTRIBUTION`
 - `ARANDU_CEP_ENABLE_REASONING_TRACES`
 - `ARANDU_CEP_MAX_HOP_COUNT`
@@ -36,7 +35,7 @@ Main `ARANDU_CEP_*` knobs:
 - `ARANDU_CEP_ENABLE_SOURCE_METADATA_CONTEXT`
 - `ARANDU_CEP_LANGUAGE`
 
-Legacy weighted-score fields still exist in `CEPConfig` for compatibility/reporting:
+Judge scoring fields live in `CEPConfig` and drive `judge-qa` (the four weights must sum to 1.0):
 
 - `ARANDU_CEP_VALIDATION_THRESHOLD`
 - `ARANDU_CEP_FAITHFULNESS_WEIGHT`

--- a/docs/deployment/slurm.md
+++ b/docs/deployment/slurm.md
@@ -199,22 +199,33 @@ Each partition script sources `cep_common.sh` which handles:
 |----------|-------------|---------|
 | `ARANDU_QA_WORKERS` | Parallel workers for CEP generation | Partition-dependent |
 | `USE_GPU_OLLAMA` | Enable GPU acceleration for Ollama | `true` (GPU partitions) |
-| `ARANDU_CEP_ENABLE_VALIDATION` | Enable LLM-as-a-Judge validation | `true` |
 | `ARANDU_CEP_LANGUAGE` | Prompt language (`pt` or `en`) | `pt` |
+
+> **Note**: `generate-cep-qa` only generates pairs; it has no validation toggle
+> (CEPConfig has no `enable_validation`). CEP-pair validation runs as the separate
+> `judge-qa` command, configured via `ARANDU_JUDGE_VALIDATOR_*`. Run it after
+> generation (e.g. a chained job with `--dependency=afterok:`).
 
 ### Override CEP Settings
 
 ```bash
-# Disable validation for faster processing
-ARANDU_CEP_ENABLE_VALIDATION=false \
-sbatch scripts/slurm/cep/tupi.slurm
-
-# Use custom validator model
-ARANDU_CEP_VALIDATOR_MODEL_ID=llama3.3:70b \
-sbatch scripts/slurm/cep/grace.slurm
-
 # Use English prompts
 ARANDU_CEP_LANGUAGE=en sbatch scripts/slurm/cep/tupi.slurm
+```
+
+### Validating CEP Pairs (separate job)
+
+Validation runs as the dedicated `judge-qa` job, configured with `ARANDU_JUDGE_*`:
+
+```bash
+# Judge a populated run's CEP dataset
+PIPELINE_ID=test-cep-01 \
+ARANDU_JUDGE_VALIDATOR_MODEL=llama3.3:70b \
+sbatch scripts/slurm/judge/qa/tupi.slurm
+
+# Force a fresh pass over already-judged pairs
+PIPELINE_ID=test-cep-01 JUDGE_REJUDGE=1 \
+sbatch scripts/slurm/judge/qa/tupi.slurm
 ```
 
 ### CEP Resource Recommendations

--- a/docs/development/dependencies.md
+++ b/docs/development/dependencies.md
@@ -6,10 +6,11 @@ Complete documentation of all project dependencies for the Knowledge Graph Const
 
 1. [Existing Dependencies](#existing-dependencies)
 2. [New Dependencies](#new-dependencies)
-3. [Dependency Groups](#dependency-groups)
-4. [Installation Instructions](#installation-instructions)
-5. [Version Compatibility](#version-compatibility)
-6. [License Information](#license-information)
+3. [Optional Dependencies (Extras)](#optional-dependencies-extras)
+4. [Dependency Groups](#dependency-groups)
+5. [Installation Instructions](#installation-instructions)
+6. [Version Compatibility](#version-compatibility)
+7. [License Information](#license-information)
 
 ---
 
@@ -23,6 +24,8 @@ Dependencies from the original transcription pipeline:
 |---------|---------|---------|
 | `accelerate` | >=1.12.0 | Model acceleration and device management |
 | `bitsandbytes` | >=0.49.1 | Quantization and memory optimization |
+| `fastapi` | >=0.115.0 | Web framework backing the report dashboard server (`serve-report`) |
+| `uvicorn[standard]` | >=0.34.0 | ASGI server for the dashboard |
 | `google-api-python-client` | >=2.100.0 | Google Drive API integration |
 | `google-auth-httplib2` | >=0.1.0 | Google authentication |
 | `google-auth-oauthlib` | >=1.0.0 | OAuth2 flow |
@@ -41,6 +44,48 @@ Dependencies from the original transcription pipeline:
 | `torch` | (via uv sources) | PyTorch deep learning framework (CUDA 12.4) |
 | `torchvision` | (via uv sources) | Vision processing utilities |
 | `torchaudio` | (via uv sources) | Audio processing |
+
+### RAG & NLP Dependencies
+
+Core dependencies powering Phase C retrieval and chunking:
+
+| Package | Version | Purpose |
+|---------|---------|---------|
+| `networkx` | >=3.1 | Graph data structures and algorithms (KG loading, metrics, k-hop traversal) |
+| `chonkie` | >=1.6.6 | Text chunking for the chunker views |
+| `rank-bm25` | >=0.2.2 | BM25 lexical retriever arm |
+| `spacy` | >=3.8.14 | Lemmatization for k-hop seed weighting (`shared/rag/retrievers/_khop_common.py`) |
+| `pt-core-news-sm` | (pinned wheel) | spaCy Portuguese model used for k-hop seed lemmatization |
+| `en-core-web-sm` | (pinned wheel) | spaCy English model for k-hop seed lemmatization |
+
+---
+
+## Optional Dependencies (Extras)
+
+Install with `uv sync --extra <name>` (or `pip install -e ".[<name>]"`).
+
+### `report`
+
+| Package | Version | Purpose |
+|---------|---------|---------|
+| `plotly` | >=6.0.0 | Interactive charts for the HTML report |
+| `jinja2` | >=3.1.0 | HTML templating |
+| `kaleido` | >=0.2.1 | Static PNG export of Plotly charts |
+
+### `kg`
+
+| Package | Version | Purpose |
+|---------|---------|---------|
+| `atlas-rag` | >=0.0.5 | AutoSchemaKG knowledge graph construction backend |
+| `pyarrow` | >=15,<21 | Columnar storage used by atlas-rag / datasets |
+| `datasets` | >=2.18 | Dataset loading for atlas-rag |
+| `faiss-cpu` | >=1.7 | Vector index for the atlas-rag retriever |
+
+### `dashboard`
+
+| Package | Version | Purpose |
+|---------|---------|---------|
+| `textual` | >=3.0.0 | Terminal UI dashboard |
 
 ---
 
@@ -61,12 +106,7 @@ Dependencies added for P2 functionality:
 
 The following dependencies are planned for future phases but are **not currently in `pyproject.toml`**:
 
-### Knowledge Graph Construction (Planned for KG Phase)
-
-| Package | Version | Purpose | Planned Module |
-|---------|---------|---------|---------|
-| `atlas-rag` | >=0.0.5 | AutoSchemaKG framework | `kg_builder.py` |
-| `networkx` | >=3.1 | Graph data structures and algorithms | `kg_builder.py`, `metrics.py` |
+> `atlas-rag` and `networkx` are no longer planned — both are installed (`networkx` is core; `atlas-rag` is in the `kg` extra). See the sections above.
 
 ### Evaluation and Metrics (Planned for Evaluation Phase)
 
@@ -92,6 +132,7 @@ Required for running the application:
 dependencies = [
     "accelerate>=1.12.0",
     "bitsandbytes>=0.49.1",
+    "fastapi>=0.115.0",
     "google-api-python-client>=2.100.0",
     "google-auth-httplib2>=0.1.0",
     "google-auth-oauthlib>=1.0.0",
@@ -102,10 +143,23 @@ dependencies = [
     "tenacity>=8.0.0",
     "transformers>=4.57.3",
     "typer[all]>=0.9.0",
+    "uvicorn[standard]>=0.34.0",
     # LLM Integration (OpenAI SDK supports Ollama and other compatible endpoints)
     "openai>=1.0.0",
     "httpx>=0.27.0",
+    # Graph loading, chunking, retrieval
+    "networkx>=3.1",
+    "chonkie>=1.6.6",
+    "rank-bm25>=0.2.2",
+    "spacy>=3.8.14",
+    "pt-core-news-sm",
+    "en-core-web-sm",
 ]
+
+[project.optional-dependencies]
+report = ["plotly>=6.0.0", "jinja2>=3.1.0", "kaleido>=0.2.1"]
+kg = ["atlas-rag>=0.0.5", "pyarrow>=15,<21", "datasets>=2.18", "faiss-cpu>=1.7"]
+dashboard = ["textual>=3.0.0"]
 ```
 
 ### Development Dependencies
@@ -328,15 +382,15 @@ For **general use**:
 
 ---
 
-## Planned Dependency Information
+## Dependency Information
 
-> **Note**: The following packages are not yet installed but are documented for future implementation phases.
+> **Note**: `atlas-rag` (kg extra) and `networkx` (core) are installed and in use. `scikit-learn`, `sentence-transformers`, `nltk`, and `sacrebleu` are still planned for the evaluation phase.
 
-### atlas-rag (>=0.0.5)
+### atlas-rag (>=0.0.5) — installed (`kg` extra)
 
 **Purpose**: AutoSchemaKG framework for knowledge graph construction
 
-**Features Planned**:
+**Features Used**:
 - Triple extraction
 - Dynamic schema induction
 - Graph construction
@@ -351,15 +405,15 @@ For **general use**:
 
 **Paper**: https://arxiv.org/abs/2505.23628
 
-### networkx (>=3.1)
+### networkx (>=3.1) — installed (core)
 
 **Purpose**: Graph data structures and algorithms
 
-**Features Planned**:
+**Features Used**:
 - Graph creation and manipulation
 - Node and edge attributes
 - Graph algorithms (connectivity, density)
-- JSON serialization
+- k-hop traversal for the `khop_passage` / `khop_triple` retriever arms
 - GraphML export
 
 **Documentation**: https://networkx.org/documentation/stable/
@@ -430,6 +484,10 @@ nltk.download('stopwords')
 - `pydantic`
 - `typer`
 - `rich`
+- `networkx`
+- `atlas-rag`
+- `rank-bm25`
+- `fastapi`
 
 ### Apache 2.0 Licensed
 
@@ -449,17 +507,15 @@ nltk.download('stopwords')
 
 ### MIT Licensed (Planned)
 
-- `networkx`
 - `nltk`
 - `sacrebleu`
-- `atlas-rag`
 
 ### Apache 2.0 Licensed (Planned)
 
 - `sentence-transformers`
 - `scikit-learn`
 
-### AutoSchemaKG Citation (When Added)
+### AutoSchemaKG Citation
 
 If using `atlas-rag` for published research, citation is required:
 
@@ -579,5 +635,5 @@ For reproducible builds, `uv.lock` is automatically maintained by uv.
 
 ---
 
-**Document Version**: 1.0
-**Last Updated**: 2026-01-14
+**Document Version**: 1.1
+**Last Updated**: 2026-06-17

--- a/docs/development/dependencies.md
+++ b/docs/development/dependencies.md
@@ -5,8 +5,8 @@ Complete documentation of all project dependencies for the Knowledge Graph Const
 ## Table of Contents
 
 1. [Existing Dependencies](#existing-dependencies)
-2. [New Dependencies](#new-dependencies)
-3. [Optional Dependencies (Extras)](#optional-dependencies-extras)
+2. [Optional Dependencies (Extras)](#optional-dependencies-extras)
+3. [New Dependencies](#new-dependencies)
 4. [Dependency Groups](#dependency-groups)
 5. [Installation Instructions](#installation-instructions)
 6. [Version Compatibility](#version-compatibility)

--- a/docs/development/schemas.md
+++ b/docs/development/schemas.md
@@ -73,7 +73,7 @@ The `detected_language` field provides the language code directly. There is **no
   ],
   "validation": {
     "stage_results": {
-      "heuristic": {
+      "heuristic_filter": {
         "criterion_scores": {
           "content_length": {
             "score": 1.0,
@@ -181,7 +181,7 @@ Result of running the full multi-stage judge pipeline.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `stage_results` | `dict[str, JudgeStepResult]` | Yes | Per-stage results, keyed by stage name (e.g. `"heuristic"`, `"llm"`) |
+| `stage_results` | `dict[str, JudgeStepResult]` | Yes | Per-stage results, keyed by stage name (e.g. `"heuristic_filter"`, `"llm_filter"` for transcription; `"cep_validation"` for QA) |
 | `passed` | `bool` | Yes | Whether the record cleared every non-skipped stage |
 | `rejected_at` | `str \| None` | No | Name of the stage that rejected the record, if any |
 
@@ -213,7 +213,7 @@ A continuous criterion's `passed` is `score >= threshold`; an ordinal criterion 
 ```json
 {
   "stage_results": {
-    "heuristic": {
+    "heuristic_filter": {
       "criterion_scores": {
         "script_match": {
           "score": 0.95,
@@ -365,7 +365,7 @@ There is no separate `ValidationScore` or `QAPairValidated` model. A judged CEP 
   "bloom_level": "analyze",
   "validation": {
     "stage_results": {
-      "qa_judge": {
+      "cep_validation": {
         "criterion_scores": {
           "faithfulness": {"score": 0.9, "scale": "continuous", "threshold": 0.6, "rationale": "..."},
           "bloom_calibration": {"score": 0.8, "scale": "continuous", "threshold": 0.6, "rationale": "..."},

--- a/docs/development/schemas.md
+++ b/docs/development/schemas.md
@@ -237,7 +237,7 @@ The QA generation pipeline uses the CEP (Cognitive Elicitation Pipeline) for cog
 
 ### QAPairCEP
 
-Extends `QAPair` with CEP cognitive elicitation fields. **Inherits from QAPair**, adding Bloom's taxonomy level, reasoning traces, and tacit knowledge inference for cognitive scaffolding-based QA generation.
+Extends `QAPair` and `JudgeResultMixin` with CEP cognitive elicitation fields, adding Bloom's taxonomy level, reasoning traces, and tacit knowledge inference for cognitive scaffolding-based QA generation. The judge verdict (`validation` + computed `is_valid`) comes from `JudgeResultMixin` — the same mixin used by `EnrichedRecord` — so a pair carries a [`JudgePipelineResult`](#judgepipelineresult) once `judge-qa` has run.
 
 **Fields** (in addition to QAPair base fields):
 
@@ -256,6 +256,10 @@ Extends `QAPair` with CEP cognitive elicitation fields. **Inherits from QAPair**
 | `hop_count` | `int \| None` | No | Number of reasoning hops (1-5 when is_multi_hop=True) |
 | `tacit_inference` | `str \| None` | No | Explanation of implicit domain knowledge surfaced |
 | `generation_prompt` | `str \| None` | No | LLM prompt used to generate this QA pair |
+| `generation_thinking` | `str \| None` | No | Model thinking/reasoning trace for this specific QA pair |
+| `chunk_id` | `str \| None` | No | Reference into the source ChunkSet for the chunker view used at generation |
+| `validation` | `JudgePipelineResult \| None` | No | Judge verdict (from `JudgeResultMixin`). None until judged by `judge-qa` |
+| `is_valid` | `bool \| None` | Computed | Derived from `validation.passed` (None when not yet judged) |
 
 **BloomLevel**: `Literal["remember", "understand", "apply", "analyze", "evaluate", "create"]`
 
@@ -296,8 +300,12 @@ from pydantic import BaseModel, Field, field_validator, model_validator
 
 BloomLevel = Literal["remember", "understand", "apply", "analyze", "evaluate", "create"]
 
-class QAPairCEP(QAPair):
-    """Extended QA pair with CEP cognitive elicitation fields."""
+class QAPairCEP(QAPair, JudgeResultMixin):
+    """Extended QA pair with CEP cognitive elicitation fields.
+
+    The ``validation`` (JudgePipelineResult) field and the computed ``is_valid``
+    property are inherited from ``JudgeResultMixin``; they are not declared here.
+    """
     bloom_level: BloomLevel = Field(
         ..., description="Bloom's taxonomy cognitive level for this question"
     )
@@ -325,6 +333,12 @@ class QAPairCEP(QAPair):
     generation_prompt: str | None = Field(
         None, description="LLM prompt used to generate this QA pair"
     )
+    generation_thinking: str | None = Field(
+        None, description="Model thinking/reasoning trace for this specific QA pair"
+    )
+    chunk_id: str | None = Field(
+        default=None, description="Reference into the source ChunkSet for the chunker view"
+    )
 
     @model_validator(mode="after")
     def validate_multi_hop(self) -> Self:
@@ -336,61 +350,11 @@ class QAPairCEP(QAPair):
         return self
 ```
 
-### ValidationScore
+### QA-pair validation
 
-Represents LLM-as-a-Judge validation scores for a QA pair.
+There is no separate `ValidationScore` or `QAPairValidated` model. A judged CEP pair is just a `QAPairCEP` whose `validation` field (from [`JudgeResultMixin`](#judgeresultmixin)) holds a [`JudgePipelineResult`](#judgepipelineresult); `is_valid` is computed from `validation.passed`. The four QA criteria (`faithfulness`, `bloom_calibration`, `informativeness`, `self_containedness`) are individual `CriterionScore` entries under the judge stage — there is no aggregate `overall_score` field on the pair. The criterion weights and `validation_threshold` that gate a pair live in `CEPConfig`.
 
-**Fields**:
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `faithfulness` | `float` | Yes | Answer grounded in context (0.0-1.0) |
-| `bloom_calibration` | `float` | Yes | Question matches declared cognitive level (0.0-1.0) |
-| `informativeness` | `float` | Yes | Answer reveals non-obvious knowledge (0.0-1.0) |
-| `overall_score` | `float` | Yes | Weighted average of criteria |
-| `judge_rationale` | `str \| None` | No | LLM's explanation of the scores |
-
-**Scoring Weights** (default):
-- Faithfulness: 40%
-- Bloom Calibration: 30%
-- Informativeness: 30%
-
-**Example**:
-```json
-{
-  "faithfulness": 0.85,
-  "bloom_calibration": 0.78,
-  "informativeness": 0.72,
-  "overall_score": 0.79,
-  "judge_rationale": "Answer well grounded, question requires appropriate analysis level."
-}
-```
-
-**Python Implementation**:
-```python
-from pydantic import BaseModel, Field
-
-class ValidationScore(BaseModel):
-    """LLM-as-a-Judge validation scores."""
-    faithfulness: float = Field(ge=0.0, le=1.0)
-    bloom_calibration: float = Field(ge=0.0, le=1.0)
-    informativeness: float = Field(ge=0.0, le=1.0)
-    overall_score: float = Field(ge=0.0, le=1.0)
-    judge_rationale: str | None = None
-```
-
-### QAPairValidated
-
-Extends QAPairCEP with validation results.
-
-**Fields** (in addition to QAPairCEP fields):
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `validation` | `ValidationScore \| None` | No | Validation scores from LLM-as-a-Judge |
-| `is_valid` | `bool` | Yes | Whether pair passes validation threshold |
-
-**Example**:
+**Example** (a judged `QAPairCEP`):
 ```json
 {
   "question": "Por que o pescador guarda o barco?",
@@ -400,10 +364,18 @@ Extends QAPairCEP with validation results.
   "confidence": 0.9,
   "bloom_level": "analyze",
   "validation": {
-    "faithfulness": 0.9,
-    "bloom_calibration": 0.8,
-    "informativeness": 0.7,
-    "overall_score": 0.81
+    "stage_results": {
+      "qa_judge": {
+        "criterion_scores": {
+          "faithfulness": {"score": 0.9, "scale": "continuous", "threshold": 0.6, "rationale": "..."},
+          "bloom_calibration": {"score": 0.8, "scale": "continuous", "threshold": 0.6, "rationale": "..."},
+          "informativeness": {"score": 0.7, "scale": "continuous", "threshold": 0.6, "rationale": "..."},
+          "self_containedness": {"score": 0.85, "scale": "continuous", "threshold": 0.6, "rationale": "..."}
+        }
+      }
+    },
+    "passed": true,
+    "rejected_at": null
   },
   "is_valid": true
 }
@@ -419,8 +391,10 @@ Complete CEP QA dataset for a single transcription with cognitive scaffolding me
 |-------|------|----------|-------------|
 | `source_file_id` | `str` | Yes | Unique identifier of the original media file (e.g. Google Drive file ID) |
 | `source_filename` | `str` | Yes | Original filename |
+| `source_metadata` | `SourceMetadata \| None` | No | Source interview metadata for provenance tracking |
 | `transcription_text` | `str` | Yes | Full transcription text |
-| `qa_pairs` | `list[QAPairValidated \| QAPairCEP]` | Yes | CEP-enhanced QA pairs (validated or unvalidated) |
+| `qa_pairs` | `list[QAPairCEP]` | Yes | CEP-enhanced QA pairs (each carries its own `validation` once judged) |
+| `chunker_id` | `str` | Yes | Chunker view used to slice `transcription_text` (default: "cep_4k") |
 | `model_id` | `str` | Yes | LLM model used for generation |
 | `validator_model_id` | `str \| None` | No | LLM model used for validation (if enabled) |
 | `provider` | `Literal["openai", "ollama", "custom"]` | Yes | LLM provider used |
@@ -434,8 +408,7 @@ Complete CEP QA dataset for a single transcription with cognitive scaffolding me
 | `cep_version` | `str` | Yes | CEP pipeline version (default: "1.0") |
 
 **Important Notes**:
-- `qa_pairs` accepts both `QAPairValidated` and `QAPairCEP` in a union type
-- `QAPairValidated` must be listed first in the union for Pydantic to correctly preserve validation fields
+- `qa_pairs` is `list[QAPairCEP]`; each pair carries its own `validation` (`JudgePipelineResult`) once `judge-qa` has run. There is no separate `QAPairValidated` type.
 - `validation_summary` is a plain `dict[str, float]`, **NOT** a ValidationSummary class (this class does not exist)
 - `validation_rate` is a computed property: `validated_pairs / total_pairs`
 
@@ -463,7 +436,7 @@ Complete CEP QA dataset for a single transcription with cognitive scaffolding me
     "avg_faithfulness": 0.85,
     "avg_bloom_calibration": 0.78,
     "avg_informativeness": 0.72,
-    "avg_overall_score": 0.79
+    "avg_self_containedness": 0.81
   },
   "validation_rate": 0.833,
   "cep_version": "1.0"
@@ -500,9 +473,13 @@ class QARecordCEP(BaseModel):
     """Extended QA dataset record with CEP metadata and validation summary."""
     source_file_id: str = Field(..., alias="source_gdrive_id", description="Unique identifier of the original media file")
     source_filename: str = Field(..., description="Original filename")
+    source_metadata: SourceMetadata | None = Field(
+        default=None, description="Source interview metadata for provenance tracking"
+    )
     transcription_text: str = Field(..., description="Full transcription text")
-    qa_pairs: list[QAPairValidated | QAPairCEP] = Field(
-        ..., description="List of CEP-enhanced QA pairs"
+    qa_pairs: list[QAPairCEP] = Field(..., description="List of CEP-enhanced QA pairs")
+    chunker_id: str = Field(
+        default="cep_4k", description="Chunker view used to slice transcription_text"
     )
     model_id: str = Field(..., description="LLM model used for generation")
     validator_model_id: str | None = Field(
@@ -1340,8 +1317,8 @@ graph TD
     A[EnrichedRecord] --> P[CEPQAGenerator]
     P --> Q[QARecordCEP]
     Q --> R[QAPairCEP]
-    R --> S[ValidationScore]
-    R --> T[QAPairValidated]
+    R --> S["validation: JudgePipelineResult (via JudgeResultMixin)"]
+    A --> S
 
     A --> E[AutoSchemaKG]
     E --> F[GraphML File]

--- a/docs/user-guide/rag-analysis.md
+++ b/docs/user-guide/rag-analysis.md
@@ -4,8 +4,10 @@ Interpret the cross-arm comparison report produced by `arandu rag-analysis`.
 
 This is the **last** stage of the Phase C RAG-evaluation pipeline. It reads
 the judged answers from `arandu judge-answers` and emits per-arm tables you
-can compare across retrieval strategies (BM25, atlas-rag, NetworkX subgraph,
-NetworkX triple, Null).
+can compare across the five retriever arms, identified by their canonical ids:
+`bm25` (lexical), `atlas_rag` (HippoRAG-style), `khop_passage` and `khop_triple`
+(k-hop over the atlas-rag KG, using lemmatized smoothed-IDF seed weighting and
+seed-proximity scoring, PR #129), and `null` (no-retrieval baseline).
 
 > **What changed (2026-05-26)**: Phase C replaces the legacy QA / KG
 > evaluation tables ([evaluation.md](evaluation.md)) for retrieval comparison.


### PR DESCRIPTION
## Summary

Second batch of the docs staleness sweep (follows #133, the High bucket). Covers the remaining Medium/Low tasks **and fixes the broken Deploy Docs GitHub Pages workflow**. Each doc change was cross-checked against `src/` / `pyproject.toml`.

## CI fix

- **`.github/workflows/deploy-docs.yml`** — The Starlight build was failing (`ERR_UNKNOWN_BUILTIN_MODULE: node:sqlite`). Root cause: `pnpm: version: latest` resolved to 11.7.0, which needs the `node:sqlite` builtin (Node 22+), while the workflow pinned Node 20. Bump Node to 22 and pin pnpm to a major (10) so `latest` can't drift the toolchain again. Verified locally: `pnpm 10 install --frozen-lockfile` + `astro build` → 16 pages.

## Docs changes

- **`docs/development/dependencies.md`** — Move `atlas-rag` (kg extra) and `networkx` (core) from Planned to installed; add the now-core deps (`fastapi`, `uvicorn[standard]`, `chonkie`, `rank-bm25`, `spacy`, `pt-core-news-sm`, `en-core-web-sm`); document the `report`/`kg`/`dashboard` extras. `scikit-learn`/`sentence-transformers`/`nltk`/`sacrebleu` remain genuinely absent (kept as planned).
- **`docs/development/schemas.md`** — QA-validation section: remove the removed `ValidationScore`/`QAPairValidated` models; `QAPairCEP` extends `QAPair, JudgeResultMixin` (validation = `JudgePipelineResult`, computed `is_valid`); `QARecordCEP.qa_pairs` is `list[QAPairCEP]`; add `source_metadata`/`chunker_id`; update the relationships diagram.
- **`docs/deployment/slurm.md`** — Drop the silently-ignored `ARANDU_CEP_ENABLE_VALIDATION`/`ARANDU_CEP_VALIDATOR_MODEL_ID`; document the separate `judge-qa` job (`scripts/slurm/judge/qa/tupi.slurm`) driven by `ARANDU_JUDGE_VALIDATOR_*`.
- **`docs/user-guide/rag-analysis.md`** — Use canonical arm ids (`bm25`, `atlas_rag`, `khop_passage`, `khop_triple`, `null`); note the lemmatized smoothed-IDF k-hop seeding (#129).
- **`docs-site/` (configuration.md, guides/cep-qa-generation.md)** — Drop the removed `bloom_levels`/`ARANDU_CEP_BLOOM_LEVELS`; fix QA/CEP/Judge `max_tokens` defaults to 8192 (`REASONING_MODEL_MAX_TOKENS`).

## Follow-up (out of scope, flagged)

`scripts/slurm/cep/cep_common.sh:200` still references `ARANDU_CEP_VALIDATOR_MODEL_ID` (to pull a validator model during the CEP job). That env var no longer maps to any config field — it's a script bug, not docs, and validation now lives in the separate `judge-qa` job. Not touched here.