### PR TITLE
refactor(judge): standardize criteria instruction closings + drop dead rule

### DIFF
--- a/prompts/judge/criteria/abstention/en/prompt.md
+++ b/prompts/judge/criteria/abstention/en/prompt.md
@@ -21,4 +21,8 @@ Scoring levels (choose the closest value):
 - 0.25 = predominantly a substantive claim, with some caveat
 - 0.0 = substantive claim (the system gave a concrete answer)
 
+Instructions:
+1. Assign the score of the closest level following the rubric above.
+2. Provide a brief and clear rationale.
+
 Return only a JSON object: {"rationale": "<1-2 sentences>", "score": <0-1>}

--- a/prompts/judge/criteria/abstention/pt/prompt.md
+++ b/prompts/judge/criteria/abstention/pt/prompt.md
@@ -21,4 +21,8 @@ Níveis de pontuação (escolha o valor mais próximo):
 - 0.25 = predominantemente uma afirmação substantiva, com alguma ressalva
 - 0.0 = afirmação substantiva (o sistema deu uma resposta concreta)
 
+Instruções:
+1. Atribua a nota do nível mais próximo seguindo a rubrica acima.
+2. Forneça uma justificativa breve e clara.
+
 Retorne apenas um objeto JSON: {"rationale": "<1-2 frases>", "score": <0-1>}

--- a/prompts/judge/criteria/answer_correctness/en/prompt.md
+++ b/prompts/judge/criteria/answer_correctness/en/prompt.md
@@ -25,6 +25,7 @@ Instructions:
 2. Check whether the reference's essential information is present and correct, and whether anything contradicts it.
 3. Precedence: if the answer contradicts the reference on any essential point, cap the score at 0.25, regardless of how much correct information it also contains.
 4. Do not reward length: elaboration or verbosity alone must not raise the score; prefer concise answers with full coverage.
-5. Assign a score following the rubric above and justify briefly.
+5. Assign the score of the closest level following the rubric above.
+6. Provide a brief and clear rationale.
 
 Return only a JSON object: {"rationale": "<1-2 sentences>", "score": <0-1>}

--- a/prompts/judge/criteria/answer_correctness/pt/prompt.md
+++ b/prompts/judge/criteria/answer_correctness/pt/prompt.md
@@ -25,6 +25,7 @@ Instruções:
 2. Verifique se a informação essencial da referência está presente e correta, e se há contradições.
 3. Precedência: se a resposta contradiz a referência em algum ponto essencial, limite a nota a no máximo 0.25, independentemente de quanta informação correta também contenha.
 4. Não premie comprimento: elaboração ou verbosidade por si só não aumentam a nota; prefira concisão com cobertura completa.
-5. Atribua uma nota seguindo a rubrica acima e justifique brevemente.
+5. Atribua a nota do nível mais próximo seguindo a rubrica acima.
+6. Forneça uma justificativa breve e clara.
 
 Retorne apenas um objeto JSON: {"rationale": "<1-2 frases>", "score": <0-1>}

--- a/prompts/judge/criteria/answer_faithfulness/en/prompt.md
+++ b/prompts/judge/criteria/answer_faithfulness/en/prompt.md
@@ -22,6 +22,7 @@ Instructions:
 2. Identify any content that comes from external knowledge or is absent from the passages.
 3. Precedence: if the answer fabricates information absent from the passages or contradicts the passages, cap the score at 0.5, regardless of how much of the rest is covered.
 4. Do not reward length: elaboration or verbosity alone must not raise the score; prefer concise answers faithful to the passages.
-5. Assign a score following the rubric above and justify briefly.
+5. Assign the score of the closest level following the rubric above.
+6. Provide a brief and clear rationale.
 
 Return only a JSON object: {"rationale": "<1-2 sentences>", "score": <0-1>}

--- a/prompts/judge/criteria/answer_faithfulness/pt/prompt.md
+++ b/prompts/judge/criteria/answer_faithfulness/pt/prompt.md
@@ -22,6 +22,7 @@ Instruções:
 2. Identifique qualquer conteúdo que venha de conhecimento externo ou que não esteja nas passagens.
 3. Precedência: se a resposta inventa informação ausente das passagens ou contradiz as passagens, limite a nota a no máximo 0.5, independentemente da cobertura do restante.
 4. Não premie comprimento: elaboração ou verbosidade por si só não aumentam a nota; prefira concisão fiel às passagens.
-5. Atribua uma nota seguindo a rubrica acima e justifique brevemente.
+5. Atribua a nota do nível mais próximo seguindo a rubrica acima.
+6. Forneça uma justificativa breve e clara.
 
 Retorne apenas um objeto JSON: {"rationale": "<1-2 frases>", "score": <0-1>}

--- a/prompts/judge/criteria/bloom_calibration/en/prompt.md
+++ b/prompts/judge/criteria/bloom_calibration/en/prompt.md
@@ -28,7 +28,7 @@ Note on the ends of the ladder: "remember" is the lowest level (cannot be under-
 Instructions:
 1. Carefully read the question and identify the cognitive level it actually requires, using the reference definitions above
 2. Compare the required level with the declared level ($bloom_level)
-3. Assign a score from 0.0 to 1.0 following the rubric above
-4. Provide a rationale explaining the match or miscalibration
+3. Assign the score of the closest level following the rubric above.
+4. Provide a brief and clear rationale.
 
 Return only a JSON object: {"rationale": "<1-2 sentences>", "score": <0-1>}

--- a/prompts/judge/criteria/bloom_calibration/pt/prompt.md
+++ b/prompts/judge/criteria/bloom_calibration/pt/prompt.md
@@ -28,7 +28,7 @@ Nota sobre os extremos da escada: "remember" é o nível mais baixo (não pode s
 Instruções:
 1. Leia atentamente a pergunta e identifique o nível cognitivo que ela realmente exige, usando as definições de referência acima
 2. Compare o nível exigido com o nível declarado ($bloom_level)
-3. Atribua uma pontuação de 0.0 a 1.0 seguindo a rubrica acima
-4. Forneça uma justificativa explicando a correspondência ou descalibração
+3. Atribua a nota do nível mais próximo seguindo a rubrica acima.
+4. Forneça uma justificativa breve e clara.
 
 Retorne apenas um objeto JSON: {"rationale": "<1-2 frases>", "score": <0-1>}

--- a/prompts/judge/criteria/emic_validity/pt/prompt.md
+++ b/prompts/judge/criteria/emic_validity/pt/prompt.md
@@ -82,8 +82,9 @@ Par:
 - Pergunta: $question
 - Resposta: $answer
 
-Instruções de saída:
-
-Atribua uma nota inteira de 1 a 5 e uma justificativa curta (no máximo 3 frases). Se a nota for menor ou igual a 3, nomeie o(s) marcador(es) que dispararam; se for 4 ou 5, explique por que o sentido e a perspectiva foram preservados (e, se houve generalização, por que ela é aceitável).
+Instruções:
+1. Atribua uma nota inteira de 1 a 5 seguindo a rubrica acima.
+2. Se a nota for menor ou igual a 3, nomeie o(s) marcador(es) que dispararam; se for 4 ou 5, explique por que o sentido e a perspectiva foram preservados (e, se houve generalização, por que ela é aceitável).
+3. Forneça uma justificativa breve e clara.
 
 Responda em JSON: {"rationale": "<justificativa>", "score": <inteiro 1-5>}.

--- a/prompts/judge/criteria/faithfulness/en/prompt.md
+++ b/prompts/judge/criteria/faithfulness/en/prompt.md
@@ -25,7 +25,7 @@ Instructions:
 3. Identify any hallucinations, unverifiable information, or contradictions
 4. Precedence: if the answer fabricates information absent from the context or contradicts the context, cap the score at 0.5, regardless of how much of the rest is grounded
 5. Do not reward length: elaboration or verbosity alone must not raise the score; prefer concise answers faithful to the context
-6. Assign a score from 0.0 to 1.0 following the rubric above
-7. Provide a brief and clear rationale
+6. Assign the score of the closest level following the rubric above.
+7. Provide a brief and clear rationale.
 
 Return only a JSON object: {"rationale": "<1-2 sentences>", "score": <0-1>}

--- a/prompts/judge/criteria/faithfulness/pt/prompt.md
+++ b/prompts/judge/criteria/faithfulness/pt/prompt.md
@@ -25,7 +25,7 @@ Instruções:
 3. Identifique qualquer alucinação, informação não verificável ou contradição
 4. Precedência: se a resposta inventa informação ausente do contexto ou contradiz o contexto, limite a nota a no máximo 0.5, independentemente de quanto do restante esteja fundamentado
 5. Não premie comprimento: elaboração ou verbosidade por si só não aumentam a nota; prefira concisão fiel ao contexto
-6. Atribua uma pontuação de 0.0 a 1.0 seguindo a rubrica acima
-7. Forneça uma justificativa breve e clara
+6. Atribua a nota do nível mais próximo seguindo a rubrica acima.
+7. Forneça uma justificativa breve e clara.
 
 Retorne apenas um objeto JSON: {"rationale": "<1-2 frases>", "score": <0-1>}

--- a/prompts/judge/criteria/hallucination_loop/en/prompt.md
+++ b/prompts/judge/criteria/hallucination_loop/en/prompt.md
@@ -26,6 +26,7 @@ Instructions:
 2. Identify short repetitive loops that don't appear in natural conversation.
 3. Distinguish between natural repetition (e.g., "no, no, no" as emphatic negation, 1-2 occurrences) and hallucinated repetition (hundreds of identical occurrences).
 4. Language doesn't matter for this criterion: hallucinated content can be in any language, including the expected one.
-5. Empty or very short text should receive a score of 1.0 (not evaluable).
+5. Assign the score of the closest level following the rubric above.
+6. Provide a brief and clear rationale.
 
 Return only a JSON object: {"rationale": "<1-2 sentences>", "score": <0-1>}

--- a/prompts/judge/criteria/hallucination_loop/pt/prompt.md
+++ b/prompts/judge/criteria/hallucination_loop/pt/prompt.md
@@ -26,6 +26,7 @@ Instruções:
 2. Identifique loops repetitivos curtos que não aparecem em conversa natural.
 3. Distinga entre repetição natural (ex.: "não, não, não" como negativa enfática em 1-2 ocorrências) e repetição alucinatória (centenas de ocorrências idênticas).
 4. O idioma não importa para este critério: conteúdo alucinado pode estar em qualquer idioma, inclusive o esperado.
-5. Texto vazio ou muito curto deve receber nota 1.0 (não avaliável).
+5. Atribua a nota do nível mais próximo seguindo a rubrica acima.
+6. Forneça uma justificativa breve e clara.
 
 Retorne apenas um objeto JSON: {"rationale": "<1-2 frases>", "score": <0-1>}

--- a/prompts/judge/criteria/informativeness/en/prompt.md
+++ b/prompts/judge/criteria/informativeness/en/prompt.md
@@ -28,7 +28,7 @@ Instructions:
 1. Carefully read the answer and assess the informative value of the knowledge revealed
 2. Identify tacit knowledge / know-how per the reference definitions above (lived, situated, specific experience), distinguishing it from generic information
 3. Do not reward length: a long, generic answer is not more informative than a short, specific one; assess substance, not size
-4. Assign a score from 0.0 to 1.0 following the rubric above
-5. Provide a clear rationale about the informative value
+4. Assign the score of the closest level following the rubric above.
+5. Provide a brief and clear rationale.
 
 Return only a JSON object: {"rationale": "<1-2 sentences>", "score": <0-1>}

--- a/prompts/judge/criteria/informativeness/pt/prompt.md
+++ b/prompts/judge/criteria/informativeness/pt/prompt.md
@@ -28,7 +28,7 @@ Instruções:
 1. Leia atentamente a resposta e avalie o valor informativo do conhecimento revelado
 2. Identifique conhecimento tácito / saber-fazer conforme as definições de referência acima (experiência vivida, situada e específica), distinguindo-o de informação genérica
 3. Não premie comprimento: uma resposta longa e genérica não é mais informativa que uma curta e específica; avalie a substância, não o tamanho
-4. Atribua uma pontuação de 0.0 a 1.0 seguindo a rubrica acima
-5. Forneça uma justificativa clara sobre o valor informativo
+4. Atribua a nota do nível mais próximo seguindo a rubrica acima.
+5. Forneça uma justificativa breve e clara.
 
 Retorne apenas um objeto JSON: {"rationale": "<1-2 frases>", "score": <0-1>}

--- a/prompts/judge/criteria/language_drift/en/prompt.md
+++ b/prompts/judge/criteria/language_drift/en/prompt.md
@@ -21,5 +21,7 @@ Instructions:
 1. Identify the dominant language of the text.
 2. Compare against the expected language ($expected_language).
 3. Flag full sentences in another language as drift.
+4. Assign the score of the closest level following the rubric above.
+5. Provide a brief and clear rationale.
 
 Return only a JSON object: {"rationale": "<1-2 sentences>", "score": <0-1>}

--- a/prompts/judge/criteria/language_drift/pt/prompt.md
+++ b/prompts/judge/criteria/language_drift/pt/prompt.md
@@ -21,5 +21,7 @@ Instruções:
 1. Identifique qual é o idioma dominante do texto.
 2. Compare com o idioma esperado ($expected_language).
 3. Identifique sentenças completas em outro idioma como deriva.
+4. Atribua a nota do nível mais próximo seguindo a rubrica acima.
+5. Forneça uma justificativa breve e clara.
 
 Retorne apenas um objeto JSON: {"rationale": "<1-2 frases>", "score": <0-1>}

--- a/prompts/judge/criteria/passage_coverage/en/prompt.md
+++ b/prompts/judge/criteria/passage_coverage/en/prompt.md
@@ -24,6 +24,7 @@ Instructions:
 1. Read the reference answer and identify the information needed to derive it.
 2. Check whether that information is present in the retrieved passages, even if it requires combining excerpts.
 3. Judge the passages' coverage relative to the reference, not writing quality.
-4. Assign a score following the rubric above and justify briefly.
+4. Assign the score of the closest level following the rubric above.
+5. Provide a brief and clear rationale.
 
 Return only a JSON object: {"rationale": "<1-2 sentences>", "score": <0-1>}

--- a/prompts/judge/criteria/passage_coverage/pt/prompt.md
+++ b/prompts/judge/criteria/passage_coverage/pt/prompt.md
@@ -24,6 +24,7 @@ Instruções:
 1. Leia a resposta de referência e identifique a informação necessária para derivá-la.
 2. Verifique se essa informação está presente nas passagens recuperadas, ainda que exija juntar trechos.
 3. Avalie a cobertura das passagens em relação à referência, não a qualidade de redação.
-4. Atribua uma nota seguindo a rubrica acima e justifique brevemente.
+4. Atribua a nota do nível mais próximo seguindo a rubrica acima.
+5. Forneça uma justificativa breve e clara.
 
 Retorne apenas um objeto JSON: {"rationale": "<1-2 frases>", "score": <0-1>}

--- a/prompts/judge/criteria/self_containedness/en/prompt.md
+++ b/prompts/judge/criteria/self_containedness/en/prompt.md
@@ -20,7 +20,7 @@ Scoring levels (choose the closest value):
 Instructions:
 1. Check whether the question names its own entities, places and techniques rather than depending on the text
 2. Identify references to the text ('in the text', 'as mentioned', pronouns without antecedent)
-3. Assign a score from 0.0 to 1.0 following the rubric above
-4. Provide a clear rationale
+3. Assign the score of the closest level following the rubric above.
+4. Provide a brief and clear rationale.
 
 Return only a JSON object: {"rationale": "<1-2 sentences>", "score": <0-1>}

--- a/prompts/judge/criteria/self_containedness/pt/prompt.md
+++ b/prompts/judge/criteria/self_containedness/pt/prompt.md
@@ -20,7 +20,7 @@ Níveis de pontuação (escolha o valor mais próximo):
 Instruções:
 1. Verifique se a pergunta nomeia suas próprias entidades, locais e técnicas em vez de depender do texto
 2. Identifique referências ao texto ('no texto', 'conforme mencionado', pronomes sem antecedente)
-3. Atribua uma pontuação de 0.0 a 1.0 seguindo a rubrica acima
-4. Forneça uma justificativa clara
+3. Atribua a nota do nível mais próximo seguindo a rubrica acima.
+4. Forneça uma justificativa breve e clara.
 
 Retorne apenas um objeto JSON: {"rationale": "<1-2 frases>", "score": <0-1>}


### PR DESCRIPTION
Two pre-thesis-run prompt fixes across all 11 judge criteria (PT+EN), found during user review after #138.

## 1. Drop dead empty/short-text rule (hallucination_loop)
`hallucination_loop` PT+EN carried "empty or very short text should receive a score of 1.0 (not evaluable)". This is unreachable: `ContentLengthFloorCriterion` (heuristic gate, 200 chars / 30 words) hard-rejects short transcriptions and short-circuits the pipeline before the `llm_filter` stage runs (`transcription/judge.py`), so `hallucination_loop` never receives such text. Mirrors the same removal already done for `language_drift`.

## 2. Standardize instruction-list closings
Every criterion's instruction list now ends with two uniform items:
- assign-score line, and
- `Forneça uma justificativa breve e clara.` / `Provide a brief and clear rationale.`

All criteria use anchored "closest value" scales, so the assign line is uniformly `Atribua a nota do nível mais próximo seguindo a rubrica acima.` / `Assign the score of the closest level following the rubric above.` The prior `0.0 a 1.0` wording (in a few criteria) was itself inconsistent with the anchored scale.

- `abstention`, `language_drift`, `hallucination_loop` gained the closing they lacked.
- Combined "assign + justify" one-liners were split into two items.
- Per-criterion justify tails (e.g. "...sobre o valor informativo") were dropped.
- `emic_validity` keeps its ordinal 1-5 scale and its substantive marker-naming instruction; only its closing was aligned.

## Tests
474 judge/qa/transcription + 105 rag judge-answers green. No test asserted the changed strings.

## Note
Prompts bake into the cluster images at build, so this should merge before the thesis-run deploy.