### PR TITLE
refactor(judge): give abstention real instruction steps

### DIFF
--- a/prompts/judge/criteria/abstention/en/prompt.md
+++ b/prompts/judge/criteria/abstention/en/prompt.md
@@ -12,8 +12,6 @@ Evaluation Rubric: Abstention
 
 Evaluate whether the answer text expresses a genuine refusal/uncertainty (the system declared it cannot answer) or a substantive claim.
 
-When the Answer Text is empty, base your assessment on the System Rationale and the abstained field: an empty Answer Text with a refusal-style rationale (what was missing from the passages) is a genuine abstention (1.0).
-
 Scoring levels (choose the closest value):
 - 1.0 = genuine abstention (e.g., "there is not enough information in the passages")
 - 0.75 = predominantly a refusal, with minimal hedging
@@ -22,7 +20,9 @@ Scoring levels (choose the closest value):
 - 0.0 = substantive claim (the system gave a concrete answer)
 
 Instructions:
-1. Assign the score of the closest level following the rubric above.
-2. Provide a brief and clear rationale.
+1. Determine whether the Answer Text expresses a genuine refusal or uncertainty (the system declares it cannot answer) or a substantive claim.
+2. When the Answer Text is empty, base your assessment on the System Rationale and the abstained field: a refusal-style rationale (what was missing from the passages) indicates a genuine abstention.
+3. Assign the score of the closest level following the rubric above.
+4. Provide a brief and clear rationale.
 
 Return only a JSON object: {"rationale": "<1-2 sentences>", "score": <0-1>}

--- a/prompts/judge/criteria/abstention/pt/prompt.md
+++ b/prompts/judge/criteria/abstention/pt/prompt.md
@@ -12,8 +12,6 @@ Rubrica de Avaliação: Abstenção
 
 Avalie se o texto da resposta expressa uma recusa/incerteza genuína (o sistema declarou que não pode responder) ou uma afirmação substantiva.
 
-Quando o Texto da Resposta estiver vazio, baseie a avaliação na Justificativa do Sistema e no campo abstained: um Texto da Resposta vazio com uma justificativa de recusa (o que faltava nas passagens) é abstenção genuína (1.0).
-
 Níveis de pontuação (escolha o valor mais próximo):
 - 1.0 = abstenção genuína (e.g., "não há informação suficiente nas passagens")
 - 0.75 = predominantemente recusa, com hesitação mínima
@@ -22,7 +20,9 @@ Níveis de pontuação (escolha o valor mais próximo):
 - 0.0 = afirmação substantiva (o sistema deu uma resposta concreta)
 
 Instruções:
-1. Atribua a nota do nível mais próximo seguindo a rubrica acima.
-2. Forneça uma justificativa breve e clara.
+1. Determine se o Texto da Resposta expressa recusa ou incerteza genuína (o sistema declara que não pode responder) ou uma afirmação substantiva.
+2. Quando o Texto da Resposta estiver vazio, baseie a avaliação na Justificativa do Sistema e no campo abstained: uma justificativa de recusa (o que faltava nas passagens) indica abstenção genuína.
+3. Atribua a nota do nível mais próximo seguindo a rubrica acima.
+4. Forneça uma justificativa breve e clara.
 
 Retorne apenas um objeto JSON: {"rationale": "<1-2 frases>", "score": <0-1>}


### PR DESCRIPTION
Follow-up to #139. After the instruction-closing standardization, `abstention` was the only one of the 11 judge criteria whose instruction list held just the two boilerplate closing lines (assign + justify) with no criterion-specific guidance, while every other criterion carries 2+ real detection steps before the closing.

## Change
Add two substantive detection steps before the standard closing (PT+EN):
1. distinguish a genuine refusal/uncertainty from a substantive claim;
2. when the answer text is empty, judge from the System Rationale + the `abstained` field.

Step 2 folds in the standalone empty-text paragraph that previously sat above the scoring levels, so there is no duplication. The standard 2-line closing (assign-score + `Forneça uma justificativa breve e clara.`) is preserved as items 3 and 4.

## Tests
shared judge + rag judge-answers suites green (229). No test asserted the changed strings.

## Note
Prompts bake into the cluster images at build, so this should merge before the thesis-run deploy (alongside #138 and #139).