### PR TITLE
fix(slurm): reduce kg cpus-per-task 16 to 8

### DIFF
--- a/scripts/slurm/kg/tupi.slurm
+++ b/scripts/slurm/kg/tupi.slurm
@@ -3,7 +3,7 @@
 #SBATCH --partition=tupi
 #SBATCH --nodes=1
 #SBATCH --ntasks=1
-#SBATCH --cpus-per-task=16
+#SBATCH --cpus-per-task=8
 #SBATCH --gres=gpu:1
 #SBATCH --time=24:00:00
 #SBATCH --output=logs/kg_tupi_%x_%j.out


### PR DESCRIPTION
build-kg is GPU/ollama-bound: atlas-rag runs `max_workers=3` against the ollama-gpu sidecar, and `kg_common.sh` ties no parallelism to `SLURM_CPUS_PER_TASK` (it only echoes it). The 16-core request (copied from the transcription script, where whisper genuinely uses CPU decode) just delayed scheduling on the saturated `tupi` partition. 8 matches the other GPU/ollama stages (`cep`, `judge-qa`).

Already deployed + applied to the live thesis-run kg job (797202, NumCPUs=8 verified); this PR persists it in the repo so a clean redeploy keeps 8.