### PR TITLE
fix(docker): pass --id ${PIPELINE_ID} to transcription command

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,6 +61,7 @@ services:
       --credentials /app/credentials/credentials.json
       --token /app/credentials/token.json
       --output-dir /app/results
+      --id ${PIPELINE_ID:-}
       --workers ${ARANDU_WORKERS:-${WORKERS:-4}}
 
     # Resource limits (adjust based on partition)


### PR DESCRIPTION
The `arandu` (transcription) compose service ran `batch-transcribe` **without `--id`**, so `PIPELINE_ID` never reached the CLI and `ResultsManager` auto-generated a `<timestamp>_local` run id. This silently broke the ID-first results layout: when running an ID-pinned pipeline (e.g. a seeded thesis run + an afterok chain), transcription bypassed the seeded run dir and re-transcribed the whole corpus into a stray auto-id directory, while every downstream stage looked under the intended id.

`arandu-cep` and `arandu-kg` already pass `--id ${PIPELINE_ID:-}` in their compose command; this one-line change aligns the transcription service. Compose-only (no image rebuild). Found live while launching the thesis run (job 797190 wrote to `20260623_175813_local` instead of `thesis-run-01`).