### PR TITLE
chore(slurm): rename transcription job to arandu-transcription

### DIFF
--- a/scripts/slurm/transcription/blaise.slurm
+++ b/scripts/slurm/transcription/blaise.slurm
@@ -1,5 +1,5 @@
 #!/bin/bash
-#SBATCH --job-name=arandu
+#SBATCH --job-name=arandu-transcription
 #SBATCH --partition=blaise
 #SBATCH --nodes=1
 #SBATCH --ntasks=1

--- a/scripts/slurm/transcription/draco.slurm
+++ b/scripts/slurm/transcription/draco.slurm
@@ -1,5 +1,5 @@
 #!/bin/bash
-#SBATCH --job-name=arandu
+#SBATCH --job-name=arandu-transcription
 #SBATCH --partition=draco
 #SBATCH --nodes=1
 #SBATCH --ntasks=1

--- a/scripts/slurm/transcription/grace.slurm
+++ b/scripts/slurm/transcription/grace.slurm
@@ -1,5 +1,5 @@
 #!/bin/bash
-#SBATCH --job-name=arandu
+#SBATCH --job-name=arandu-transcription
 #SBATCH --partition=grace
 #SBATCH --nodes=1
 #SBATCH --ntasks=1

--- a/scripts/slurm/transcription/sirius.slurm
+++ b/scripts/slurm/transcription/sirius.slurm
@@ -1,5 +1,5 @@
 #!/bin/bash
-#SBATCH --job-name=corpus_transcription
+#SBATCH --job-name=arandu-transcription
 #SBATCH --partition=sirius
 #SBATCH --nodes=1
 #SBATCH --ntasks=1

--- a/scripts/slurm/transcription/tupi.slurm
+++ b/scripts/slurm/transcription/tupi.slurm
@@ -1,5 +1,5 @@
 #!/bin/bash
-#SBATCH --job-name=corpus_transcription
+#SBATCH --job-name=arandu-transcription
 #SBATCH --partition=tupi
 #SBATCH --nodes=1
 #SBATCH --ntasks=1

--- a/scripts/slurm/transcription/turing.slurm
+++ b/scripts/slurm/transcription/turing.slurm
@@ -1,5 +1,5 @@
 #!/bin/bash
-#SBATCH --job-name=corpus_transcription
+#SBATCH --job-name=arandu-transcription
 #SBATCH --partition=turing
 #SBATCH --nodes=1
 #SBATCH --ntasks=1


### PR DESCRIPTION
The transcription SBATCH `--job-name` was inconsistent across partitions (`corpus_transcription` on tupi/turing/sirius, generic `arandu` on blaise/draco/grace). This aligns all six to `arandu-transcription`, matching the `arandu-<stage>` convention of the other stages (`arandu-kg`, `arandu-judge-qa`, `arandu-rag-*`). Cosmetic (job name + the `%x` log filename); applies to future submissions.