### PR TITLE
chore(slurm): rename cep job to arandu-cep

### DIFF
--- a/scripts/slurm/cep/grace.slurm
+++ b/scripts/slurm/cep/grace.slurm
@@ -1,5 +1,5 @@
 #!/bin/bash
-#SBATCH --job-name=cep_qa_dataset_gen
+#SBATCH --job-name=arandu-cep
 #SBATCH --partition=grace
 #SBATCH --nodes=1
 #SBATCH --ntasks=1

--- a/scripts/slurm/cep/sirius.slurm
+++ b/scripts/slurm/cep/sirius.slurm
@@ -1,5 +1,5 @@
 #!/bin/bash
-#SBATCH --job-name=cep_qa_dataset_gen
+#SBATCH --job-name=arandu-cep
 #SBATCH --partition=sirius
 #SBATCH --nodes=1
 #SBATCH --ntasks=1

--- a/scripts/slurm/cep/tupi.slurm
+++ b/scripts/slurm/cep/tupi.slurm
@@ -1,5 +1,5 @@
 #!/bin/bash
-#SBATCH --job-name=cep_qa_dataset_gen
+#SBATCH --job-name=arandu-cep
 #SBATCH --partition=tupi
 #SBATCH --nodes=1
 #SBATCH --ntasks=1


### PR DESCRIPTION
Aligns the `generate-cep-qa` SBATCH `--job-name` (was `cep_qa_dataset_gen` on tupi/sirius/grace) to the `arandu-<stage>` convention of the other stages (`arandu-kg`, `arandu-judge-qa`, `arandu-rag-*`, and now `arandu-transcription` from #143). Matches the `arandu-cep` compose service name. Cosmetic (job name + `%x` log filename); applies to future submissions.