### PR TITLE
fix(slurm): harden docker disk-preflight + CPU rag stages to draco

### DIFF
--- a/scripts/slurm/kg/kg_common.sh
+++ b/scripts/slurm/kg/kg_common.sh
@@ -144,12 +144,13 @@ fi
 # Fail fast if disk space is critically low (need ~15 GB for build + model)
 # Check Docker's storage partition, not the project directory
 MIN_DISK_GB=${MIN_DISK_GB:-15}
-DOCKER_ROOT=$(docker info --format '{{.DockerRootDir}}' 2>/dev/null || echo "/var/lib/docker")
-AVAIL_KB=$(df --output=avail "$DOCKER_ROOT" 2>/dev/null | tail -1 | tr -d ' ')
-AVAIL_GB=$((AVAIL_KB / 1024 / 1024))
+DOCKER_ROOT=$(docker info --format '{{.DockerRootDir}}' 2>/dev/null || true)
+[ -d "$DOCKER_ROOT" ] || DOCKER_ROOT=/var/lib/docker
+AVAIL_KB=$(df --output=avail "$DOCKER_ROOT" 2>/dev/null | tail -1 | tr -d ' ' || true)
+AVAIL_GB=$(( ${AVAIL_KB:-0} / 1024 / 1024 ))
 echo "Docker storage: $DOCKER_ROOT"
 echo "Available disk space: ${AVAIL_GB} GB (minimum: ${MIN_DISK_GB} GB)"
-if [ "$AVAIL_GB" -lt "$MIN_DISK_GB" ]; then
+if [ "${AVAIL_KB:-0}" -gt 0 ] && [ "$AVAIL_GB" -lt "$MIN_DISK_GB" ]; then
     echo "ERROR: Not enough disk space on Docker partition (${AVAIL_GB} GB < ${MIN_DISK_GB} GB). Aborting."
     echo "Tip: manually run 'docker system prune -af --volumes' on the node."
     exit 1

--- a/scripts/slurm/rag/chunk.slurm
+++ b/scripts/slurm/rag/chunk.slurm
@@ -1,6 +1,6 @@
 #!/bin/bash
 #SBATCH --job-name=arandu-rag-chunk
-#SBATCH --partition=tupi
+#SBATCH --partition=draco
 #SBATCH --nodes=1
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=8

--- a/scripts/slurm/rag/kg-link-passages.slurm
+++ b/scripts/slurm/rag/kg-link-passages.slurm
@@ -1,6 +1,6 @@
 #!/bin/bash
 #SBATCH --job-name=arandu-rag-kg-link
-#SBATCH --partition=tupi
+#SBATCH --partition=draco
 #SBATCH --nodes=1
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=8

--- a/scripts/slurm/rag/rag-analysis.slurm
+++ b/scripts/slurm/rag/rag-analysis.slurm
@@ -1,6 +1,6 @@
 #!/bin/bash
 #SBATCH --job-name=arandu-rag-analysis
-#SBATCH --partition=tupi
+#SBATCH --partition=draco
 #SBATCH --nodes=1
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=8

--- a/scripts/slurm/rag/rag_common.sh
+++ b/scripts/slurm/rag/rag_common.sh
@@ -86,11 +86,12 @@ find "$OLLAMA_MODELS_DIR" -name "*-partial" -delete 2>/dev/null || true
 find "$OLLAMA_MODELS_DIR" -name "*.tmp" -delete 2>/dev/null || true
 
 MIN_DISK_GB=${MIN_DISK_GB:-15}
-DOCKER_ROOT=$(docker info --format '{{.DockerRootDir}}' 2>/dev/null || echo "/var/lib/docker")
-AVAIL_KB=$(df --output=avail "$DOCKER_ROOT" 2>/dev/null | tail -1 | tr -d ' ')
-AVAIL_GB=$((AVAIL_KB / 1024 / 1024))
+DOCKER_ROOT=$(docker info --format '{{.DockerRootDir}}' 2>/dev/null || true)
+[ -d "$DOCKER_ROOT" ] || DOCKER_ROOT=/var/lib/docker
+AVAIL_KB=$(df --output=avail "$DOCKER_ROOT" 2>/dev/null | tail -1 | tr -d ' ' || true)
+AVAIL_GB=$(( ${AVAIL_KB:-0} / 1024 / 1024 ))
 echo "Docker storage: $DOCKER_ROOT — ${AVAIL_GB} GB available (min ${MIN_DISK_GB})"
-if [ "$AVAIL_GB" -lt "$MIN_DISK_GB" ]; then
+if [ "${AVAIL_KB:-0}" -gt 0 ] && [ "$AVAIL_GB" -lt "$MIN_DISK_GB" ]; then
     echo "ERROR: not enough disk on $DOCKER_ROOT (${AVAIL_GB} GB < ${MIN_DISK_GB} GB)." >&2
     exit 1
 fi


### PR DESCRIPTION
Two fixes found live during the thesis run.

**1. Disk-preflight crash.** `rag_common.sh`/`kg_common.sh` ran `AVAIL_KB=$(df --output=avail "$DOCKER_ROOT" ... )` unguarded under `set -euo pipefail`. When `docker info` yields an empty/invalid DockerRootDir on a node, df fails -> pipefail aborts the stage in ~1s with empty stderr. This killed `chunk` (797213) on tupi3 right after transcription finished. Guarded the df pipeline + arithmetic and only enforce the floor when the value is trustworthy.

**2. CPU stages -> draco.** `chunk`, `kg-link-passages`, `rag-analysis` are CPU-only (`RAG_NEEDS_OLLAMA=false`, `arandu-rag-cpu`) but were pinned to the saturated GPU partition `tupi`. Moved to the idle CPU partition `draco` (per the cluster layout) so they run immediately and stop queueing behind GPU work.