### PR TITLE
fix(chunk): address code-review findings on PR #146

### DIFF
--- a/scripts/slurm/rag/chunk.slurm
+++ b/scripts/slurm/rag/chunk.slurm
@@ -11,8 +11,13 @@
 # Phase C: chunk transcriptions into the cep_4k view (no LLM). Prereq for cep + bm25.
 # CPU-only: no GPU request, runs via arandu-rag-cpu so it doesn't wait for a GPU.
 # Set CHUNK_REBUILD=1 to clear stale view outputs + checkpoint first (e.g. to
-# drop chunks of transcriptions the transcription judge rejected after a prior run).
-export RAG_CLI_ARGS="chunk /app/results/${PIPELINE_ID}/transcription/outputs --id ${PIPELINE_ID} --view cep_4k${CHUNK_REBUILD:+ --rebuild}"
+# drop chunks of transcriptions the transcription judge rejected after a prior
+# run). Only the exact value "1" enables it (so CHUNK_REBUILD=0 is a real off).
+REBUILD_FLAG=""
+if [ "${CHUNK_REBUILD:-}" = "1" ]; then
+    REBUILD_FLAG=" --rebuild"
+fi
+export RAG_CLI_ARGS="chunk /app/results/${PIPELINE_ID}/transcription/outputs --id ${PIPELINE_ID} --view cep_4k${REBUILD_FLAG}"
 export RAG_NEEDS_OLLAMA=false
 export RAG_SERVICE=arandu-rag-cpu
 export RAG_PROFILE=rag-cpu

--- a/src/arandu/cli/chunking.py
+++ b/src/arandu/cli/chunking.py
@@ -84,7 +84,12 @@ def chunk(
         print_error(str(exc))
         raise typer.Exit(code=1) from exc
 
-    if result.sources_processed == 0 and result.sources_resumed == 0 and result.skipped == 0:
+    if (
+        result.sources_processed == 0
+        and result.sources_resumed == 0
+        and result.skipped == 0
+        and result.skipped_invalid == 0
+    ):
         print_warning(f"No JSON files found in {input_dir}")
         return
 

--- a/src/arandu/kg/batch.py
+++ b/src/arandu/kg/batch.py
@@ -76,7 +76,9 @@ def _load_transcription_records(
             data = json.loads(json_file.read_text())
             record = EnrichedRecord.model_validate(data)
 
-            if record.is_valid is False:
+            # Shared predicate (JudgeResultMixin.is_judge_rejected): drop
+            # judge-failed records, keep unjudged. Same rule used by chunk.
+            if record.is_judge_rejected:
                 skipped += 1
                 continue
 

--- a/src/arandu/shared/chunking/batch.py
+++ b/src/arandu/shared/chunking/batch.py
@@ -95,6 +95,13 @@ def run_chunk_batch(
 
     Raises:
         ValueError: If ``views`` contains any unregistered chunker_id.
+
+    Note:
+        Without ``rebuild``, a re-run skips newly judge-rejected sources but
+        leaves their chunk files from an earlier run on disk; pass ``rebuild``
+        (or ``CHUNK_REBUILD=1`` via the SLURM script) to drop them. ``rebuild``
+        clears only the requested views while the checkpoint is run-wide, so
+        rebuild multiple views together in one call to keep them consistent.
     """
     _validate_views(views)
 
@@ -122,6 +129,13 @@ def run_chunk_batch(
     checkpoint = CheckpointManager(results_mgr.run_dir / CHECKPOINT_FILENAME)
     chunkers = {view_id: get_chunker(view_id) for view_id in views}
 
+    # Ensure each requested view dir exists even when every record is skipped
+    # (e.g. all transcriptions judge-rejected, or a rebuild that drops the last
+    # valid source), so downstream retrievers resolve an empty corpus dir instead
+    # of crashing on a missing path.
+    for view_id in views:
+        (results_mgr.outputs_dir / view_id).mkdir(parents=True, exist_ok=True)
+
     json_files = sorted(input_dir.glob("*.json"))
     checkpoint.set_total_files(len(json_files))
 
@@ -147,10 +161,11 @@ def run_chunk_batch(
             skipped += 1
             continue
 
-        # Skip transcriptions the transcription judge rejected (is_valid is
-        # False), so the retrieval corpus matches the QA/KG corpus. Mirrors
-        # qa/batch.py and kg/batch.py. Unjudged records (is_valid is None) pass.
-        if record.is_valid is False:
+        # Skip transcriptions the transcription judge rejected, so the retrieval
+        # corpus matches the QA/KG corpus. Unjudged records (is_valid is None)
+        # still pass so chunk can run before judging. Shared predicate lives on
+        # JudgeResultMixin (also used by kg/batch.py).
+        if record.is_judge_rejected:
             skipped_invalid += 1
             continue
 

--- a/src/arandu/shared/judge/schemas.py
+++ b/src/arandu/shared/judge/schemas.py
@@ -105,3 +105,15 @@ class JudgeResultMixin(BaseModel):
         Returns ``None`` when the record has not been judged.
         """
         return self.validation.passed if self.validation is not None else None
+
+    @property
+    def is_judge_rejected(self) -> bool:
+        """Whether the record was judged and FAILED (``is_valid is False``).
+
+        The canonical "drop this record" predicate for downstream stages that
+        should consume only judge-valid records (chunk, kg). Unjudged records
+        (``is_valid is None``) are NOT rejected, so a stage can still run before
+        judging. Kept here as the single authoritative home for the rule that
+        otherwise gets re-inlined in every consumer's batch loader.
+        """
+        return self.is_valid is False

--- a/tests/shared/chunking/test_batch.py
+++ b/tests/shared/chunking/test_batch.py
@@ -78,6 +78,28 @@ class TestValidityFilter:
         assert written == {"valid", "unjudged"}
         assert "rejected" not in written
 
+    def test_all_rejected_leaves_empty_view_dir(
+        self, tmp_path: Path, monkeypatch: MonkeyPatch
+    ) -> None:
+        """When every source is judge-rejected, the view dir exists but empty.
+
+        A missing dir would crash downstream retrievers resolving the corpus
+        path; an empty dir lets them see an empty corpus.
+        """
+        monkeypatch.setenv("ARANDU_RESULTS_BASE_DIR", str(tmp_path / "results"))
+        input_dir = tmp_path / "input"
+        input_dir.mkdir()
+        _write_transcription(input_dir, "r1", is_valid=False)
+        _write_transcription(input_dir, "r2", is_valid=False)
+
+        result = run_chunk_batch(input_dir=input_dir, views=["cep_4k"], pipeline_id="run1")
+
+        assert result.skipped_invalid == 2
+        assert result.sources_processed == 0
+        view_dir = Path(result.run_dir) / "outputs" / "cep_4k"
+        assert view_dir.is_dir()
+        assert list(view_dir.glob("*.json")) == []
+
 
 class TestRebuild:
     """The --rebuild flag clears stale view outputs + checkpoint."""


### PR DESCRIPTION
Follow-up to #146, fixing the verified code-review findings in one PR.

**Correctness:**
- **CLI empty-result guard** (`cli/chunking.py`) now includes `skipped_invalid`, so an all-rejected input dir no longer misreports "No JSON files found" (and still shows the skip count + Run ID).
- **`CHUNK_REBUILD` toggle** (`chunk.slurm`) now enables `--rebuild` only on the exact value `1` (so `CHUNK_REBUILD=0` is a real off), via an if-block that also avoids the `set -euo pipefail` command-substitution pitfall.
- **Empty view dir** (`chunking/batch.py`): each requested view dir is created even when every source is skipped, so downstream retrievers resolve an empty corpus dir instead of crashing on a missing path.

**DRY:** the judge-rejection rule moves to `JudgeResultMixin.is_judge_rejected` (one authoritative home), used by chunk/batch + kg/batch.

**Documented (not behaviour-changed), with rationale:** non-rebuild reruns leave stale chunks (use `--rebuild`/`CHUNK_REBUILD=1`); per-view rebuild vs run-wide checkpoint (rebuild views together); unjudged content-length floor and the legacy raw-validation-dict robustness are off the post-judge pipeline path.

173 chunking/kg/judge tests green; new test covers the all-rejected empty-dir case.