### PR TITLE
fix(cep): add --rebuild to clear stale CEP outputs + checkpoint on re-run

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -371,6 +371,7 @@ services:
       /app/results
       --id ${PIPELINE_ID:-}
       --workers ${ARANDU_QA_WORKERS:-2}
+      ${CEP_REBUILD_FLAG:-}
 
     volumes:
       - ${ARANDU_RESULTS_DIR:-./results}:/app/results:rw

--- a/scripts/slurm/cep/cep_common.sh
+++ b/scripts/slurm/cep/cep_common.sh
@@ -95,6 +95,16 @@ mkdir -p logs
 export SLURM_JOB_ID="${SLURM_JOB_ID:-local}"
 export PIPELINE_ID="${PIPELINE_ID:-}"
 
+# Set CEP_REBUILD=1 to clear stale CEP outputs + checkpoint first (e.g. to
+# regenerate after a corpus dedup so dropped sources do not linger from a prior
+# run). Only the exact value "1" enables it (so CEP_REBUILD=0 is a real off).
+# Forwarded to the compose command as ${CEP_REBUILD_FLAG:-}.
+if [ "${CEP_REBUILD:-}" = "1" ]; then
+    export CEP_REBUILD_FLAG="--rebuild"
+else
+    export CEP_REBUILD_FLAG=""
+fi
+
 # -----------------------------------------------------------------------------
 # Determine Docker profile based on GPU mode
 # -----------------------------------------------------------------------------

--- a/src/arandu/cli/qa.py
+++ b/src/arandu/cli/qa.py
@@ -76,6 +76,14 @@ def generate_cep_qa(
         str | None,
         typer.Option("--id", help="Pipeline ID. Auto-resolves transcription outputs."),
     ] = None,
+    rebuild: Annotated[
+        bool,
+        typer.Option(
+            "--rebuild",
+            help="Clear existing CEP outputs + checkpoint before generating, so a "
+            "re-run on a changed source set (e.g. after a corpus dedup) starts clean.",
+        ),
+    ] = False,
 ) -> None:
     """Generate CEP (cognitive scaffolding) QA pairs from transcriptions.
 
@@ -188,6 +196,7 @@ def generate_cep_qa(
             cep_config,
             qa_config.workers,
             pipeline_id=pipeline_id,
+            rebuild=rebuild,
         )
 
         # Export to JSONL if requested

--- a/src/arandu/qa/batch.py
+++ b/src/arandu/qa/batch.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import json
 import logging
 import multiprocessing as mp
+import shutil
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from pathlib import Path  # noqa: TC003 — Pydantic needs Path at runtime
 
@@ -334,6 +335,7 @@ def run_batch_cep_generation(
     cep_config: CEPConfig,
     num_workers: int = 2,
     pipeline_id: str | None = None,
+    rebuild: bool = False,
 ) -> None:
     """Run batch CEP QA generation with parallel processing and checkpointing.
 
@@ -348,6 +350,17 @@ def run_batch_cep_generation(
         cep_config: CEP configuration.
         num_workers: Number of parallel workers.
         pipeline_id: Optional pipeline ID for the ID-first results layout.
+        rebuild: When ``True``, clear any existing CEP outputs and reset the
+            checkpoint before processing, so a re-run yields a clean dataset.
+
+    Note:
+        Without ``rebuild``, resuming an existing ``pipeline_id`` skips sources
+        the checkpoint already marks completed and leaves their ``*_cep_qa.json``
+        files on disk — even when the source set has since changed (e.g. a
+        corpus dedup that dropped transcriptions). That leaves stale pair files
+        from an earlier run, inflating the dataset past the current source
+        count. Pass ``rebuild`` (or ``CEP_REBUILD=1`` via the SLURM script) to
+        start clean. This mirrors the chunk stage's ``rebuild``.
     """
     # Load results configuration
     results_config = ResultsConfig()
@@ -379,6 +392,15 @@ def run_batch_cep_generation(
     else:
         effective_output_dir = output_dir
         effective_checkpoint_file = output_dir / "cep_checkpoint.json"
+
+    # Rebuild: drop stale pair files + checkpoint so a re-run on a changed
+    # source set (e.g. after a corpus dedup) starts clean instead of layering
+    # new outputs on top of a prior run's completed-set.
+    if rebuild:
+        if effective_output_dir.exists():
+            shutil.rmtree(effective_output_dir)
+        if effective_checkpoint_file.exists():
+            effective_checkpoint_file.unlink()
 
     # Create output directory
     effective_output_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/qa/test_batch.py
+++ b/tests/qa/test_batch.py
@@ -641,6 +641,56 @@ class TestRunBatchCEPGeneration:
 
         assert self.outputs_dir.exists()
 
+    def test_run_batch_cep_rebuild_clears_stale_outputs(
+        self, tmp_path: Path, mocker: MockerFixture
+    ) -> None:
+        """rebuild=True drops stale CEP pair files before generating."""
+        mocker.patch("arandu.shared.llm_client.OpenAI")
+
+        input_dir = tmp_path / "input"
+        output_dir = tmp_path / "cep_output"
+        input_dir.mkdir()
+
+        # Pre-seed a stale pair file + checkpoint in the versioned outputs, as a
+        # prior (e.g. pre-dedup) run would have left behind.
+        self.outputs_dir.mkdir(parents=True, exist_ok=True)
+        stale = self.outputs_dir / "stale_id_cep_qa.json"
+        stale.write_text("{}")
+        self.versioned_checkpoint.parent.mkdir(parents=True, exist_ok=True)
+        self.versioned_checkpoint.write_text("{}")
+
+        qa_config = QAConfig(provider="ollama", model_id="llama3.1:8b")
+        cep_config = CEPConfig()
+
+        # Empty input -> early exit after the rebuild wipe runs.
+        run_batch_cep_generation(
+            input_dir, output_dir, qa_config, cep_config, num_workers=1, rebuild=True
+        )
+
+        assert not stale.exists()
+        assert self.outputs_dir.exists()
+
+    def test_run_batch_cep_no_rebuild_keeps_stale_outputs(
+        self, tmp_path: Path, mocker: MockerFixture
+    ) -> None:
+        """Without rebuild, a resumed run leaves prior pair files in place."""
+        mocker.patch("arandu.shared.llm_client.OpenAI")
+
+        input_dir = tmp_path / "input"
+        output_dir = tmp_path / "cep_output"
+        input_dir.mkdir()
+
+        self.outputs_dir.mkdir(parents=True, exist_ok=True)
+        stale = self.outputs_dir / "stale_id_cep_qa.json"
+        stale.write_text("{}")
+
+        qa_config = QAConfig(provider="ollama", model_id="llama3.1:8b")
+        cep_config = CEPConfig()
+
+        run_batch_cep_generation(input_dir, output_dir, qa_config, cep_config, num_workers=1)
+
+        assert stale.exists()
+
     def test_run_batch_cep_no_tasks_early_exit(
         self, tmp_path: Path, mocker: MockerFixture, caplog: pytest.LogCaptureFixture
     ) -> None:


### PR DESCRIPTION
## Problem

CEP generation resumes from `cep_checkpoint.json` and never clears its output dir. Re-running an existing `pipeline_id` on a **changed source set** (e.g. after a corpus dedup that dropped transcriptions) layers new pairs on top of a prior run's completed-set: stale `*_cep_qa.json` files linger and the dataset inflates past the current source count.

Observed on `thesis-run-01`: after deduping the corpus to 214 unique-valid transcriptions and resubmitting, cep reported `222/214` and rose to `230/214` (output file count climbing past the source count), because it resumed on top of two cancelled pre-dedup runs' checkpoint + outputs.

The CEP loader **already** filters judge-rejected transcriptions (`validation.passed is False`, batch.py) so this was **not** a validity-filter bug. The gap was purely stale on-disk state from an earlier run with no clean-start option, while the chunk stage already had one.

## Fix

Mirror the chunk stage's `rebuild`:
- `run_batch_cep_generation(..., rebuild=False)` — when `True`, `rmtree` the output dir and unlink the checkpoint before processing.
- `--rebuild` CLI option on `generate-cep-qa`.
- `CEP_REBUILD=1` SLURM hook in `cep_common.sh`, wired through `docker-compose.yml` as `${CEP_REBUILD_FLAG:-}`.

## Tests

- `test_run_batch_cep_rebuild_clears_stale_outputs` — rebuild drops a pre-seeded stale pair file.
- `test_run_batch_cep_no_rebuild_keeps_stale_outputs` — without rebuild, prior files survive (documents the resume behavior).

Full `tests/qa/test_batch.py` suite passes (33).