### PR TITLE
perf(rag): skip concept-hub edges in khop_triple subgraph iteration

### DIFF
--- a/src/arandu/shared/rag/retrievers/khop_triple.py
+++ b/src/arandu/shared/rag/retrievers/khop_triple.py
@@ -162,11 +162,25 @@ class KHopTripleRetriever:
         node_dist = subgraph_node_distances(self._kg, seeds, self._k_hop)
         if not node_dist:
             return []
-        induced = self._kg.subgraph(node_dist.keys())
+        # Induce the subgraph on triple-endpoint nodes ONLY, before iterating
+        # edges. Concept nodes are atlas-rag schema-induction hubs whose
+        # `has_concept` edges dominate the graph (this corpus: ~65k concept
+        # edges vs ~23k semantic triples), and every concept-touching edge is
+        # discarded by the `_TRIPLE_ENDPOINT_TYPES` filter below anyway.
+        # Dropping concept nodes from the induced subgraph excludes exactly
+        # those never-emitted edges from the O(edges) iteration; the emitted
+        # triple set is unchanged because scoring reads `node_dist`, which is
+        # computed over the full k-hop traversal above. Pure speedup for the
+        # triple arm on concept-heavy KGs.
+        endpoint_nodes = [
+            n for n in node_dist if self._kg.nodes[n].get("type") in _TRIPLE_ENDPOINT_TYPES
+        ]
+        induced = self._kg.subgraph(endpoint_nodes)
 
         # Collect entity-entity / event-entity / event-event triples — skip:
-        # - any edge touching a non-{entity,event} node (passages have 2 KB
-        #   text in `id`; concepts are atlas-rag schema-induction hubs);
+        # - any edge touching a non-{entity,event} node (defensive: the induced
+        #   subgraph above already excludes concept/passage endpoints, but the
+        #   guard keeps the invariant explicit and is now near-free);
         # - self-loops (`head == tail`): structurally weird, methodologically
         #   uninformative — a relation from an entity to itself doesn't
         #   carry the cross-entity semantic content §6.4 calls for.

--- a/tests/shared/rag/retrievers/test_khop_triple.py
+++ b/tests/shared/rag/retrievers/test_khop_triple.py
@@ -189,6 +189,39 @@ class TestKHopTripleRetrieve:
                 "the `has_concept` relation should never surface in scored triples"
             )
 
+    def test_concept_hub_does_not_drop_real_entity_triples(self, tmp_path: Path) -> None:
+        # Regression guard for the perf change that restricts the induced
+        # subgraph to triple-endpoint nodes BEFORE iterating edges. A concept
+        # hub with many entities attached (the atlas-rag `has_concept` star)
+        # is in the k-hop neighbourhood, but excluding it from the subgraph
+        # must NOT drop the genuine entity-entity edge — the emitted triple
+        # set stays identical, only the never-emitted concept edges leave the
+        # iteration.
+        kg = nx.DiGraph()
+        kg.add_node("e_a", type="entity", id="alpha rare")
+        kg.add_node("e_b", type="entity", id="beta")
+        kg.add_edge("e_a", "e_b", relation="knows")  # the ONLY entity-entity edge
+        # Concept hub: e_a, e_b and 10 fillers all attach to it via has_concept.
+        kg.add_node("c_hub", type="concept", id="hub concept")
+        kg.add_edge("e_a", "c_hub", relation="has_concept")
+        kg.add_edge("e_b", "c_hub", relation="has_concept")
+        for i in range(10):
+            kg.add_node(f"e_filler_{i}", type="entity", id=f"filler entity {i}")
+            kg.add_edge(f"e_filler_{i}", "c_hub", relation="has_concept")
+        path = _write_kg_layout(kg, tmp_path)
+
+        retriever = KHopTripleRetriever(kg_outputs_dir=path, k_hop=2)
+        results = retriever.retrieve("alpha", top_k=20)
+
+        # Exactly the one real entity-entity triple survives; the has_concept
+        # star (and the fillers reachable only through the concept hub) inject
+        # no triples.
+        assert len(results) == 1
+        assert results[0].payload == "[entity] alpha rare --[knows]--> [entity] beta"
+        for r in results:
+            assert "[concept]" not in r.payload
+            assert "has_concept" not in r.payload
+
     def test_rank_and_score_shape(self, tmp_path: Path) -> None:
         path = _write_kg_layout(_build_triple_kg(), tmp_path)
         retriever = KHopTripleRetriever(kg_outputs_dir=path, k_hop=2)


### PR DESCRIPTION
## Problem

The `khop_triple` retriever iterates **every edge** of the k-hop induced subgraph, then discards any edge touching a non-`{entity,event}` node at emission time (`_TRIPLE_ENDPOINT_TYPES`). On atlas-rag KGs the induced subgraph is dominated by `has_concept` edges — atlas-rag's AutoSchemaKG conceptualization attaches every entity to concept hubs.

Measured on the `thesis-run-01` KG:

| Edge kind | Count |
| --- | --- |
| `has_concept` (entity → concept) | ~64,975 (~85%) |
| semantic triples (entity → entity) | ~22,654 |
| concept hub nodes | 1,434 |

So ~85% of the per-question edge iteration was spent formatting-then-discarding concept-attachment edges. Combined with the 2-hop ego-graph reaching through those hubs, retrieval measured ~35s/question on the live run (khop_triple was on track to time out).

## Change

Restrict the induced subgraph to triple-endpoint nodes (`{entity, event}`) **before** iterating edges:

```python
endpoint_nodes = [n for n in node_dist if self._kg.nodes[n].get("type") in _TRIPLE_ENDPOINT_TYPES]
induced = self._kg.subgraph(endpoint_nodes)
```

**Behavior-preserving.** `self._kg.subgraph(nodes)` keeps only edges whose *both* endpoints are in the set — exactly the edges that already passed the endpoint filter. Concept-incident edges were never emitted, and scoring reads `node_dist` (computed over the full k-hop traversal), which is untouched. The emitted triple set is identical; only the never-emitted concept edges leave the O(edges) iteration.

## Tests

- All 130 retriever tests pass; the existing concept/passage-exclusion tests already pin output identity.
- Adds `test_concept_hub_does_not_drop_real_entity_triples`: a concept hub with 10+ attached entities still yields the genuine entity-entity triple and injects no concept noise.

## Scope / follow-up

This fixes the **triple arm's edge-iteration** cost center only. The deeper shared cost — the ego-graph explosion through concept hubs in `subgraph_node_distances` (also paid by `khop_passage`) — is a separate, methodology-sensitive decision (excluding/degree-capping concept hubs in the *traversal* changes which triples surface). Not touched here.