### PR TITLE
fix(cluster): tear down rag containers on SLURM timeout/scancel

### DIFF
--- a/scripts/slurm/rag/answer.slurm
+++ b/scripts/slurm/rag/answer.slurm
@@ -8,6 +8,10 @@
 #SBATCH --time=24:00:00
 #SBATCH --output=logs/rag_answer_%j.out
 #SBATCH --error=logs/rag_answer_%j.err
+# Send SIGTERM to the batch shell 60s before the time limit so rag_common.sh's
+# teardown trap can stop the docker containers before SLURM's SIGKILL (prevents
+# orphaned ollama-gpu / arandu-rag-run containers on the node; see rag_common).
+#SBATCH --signal=B:TERM@60
 
 # Phase C: answer every RetrievalRecord (LLM via ollama qwen3:14b), held constant
 # across arms. Reasoning-model headroom (max_tokens=8192) avoids the truncation

--- a/scripts/slurm/rag/generate-non-answerable.slurm
+++ b/scripts/slurm/rag/generate-non-answerable.slurm
@@ -8,6 +8,10 @@
 #SBATCH --time=12:00:00
 #SBATCH --output=logs/rag_nonans_%j.out
 #SBATCH --error=logs/rag_nonans_%j.err
+# Send SIGTERM to the batch shell 60s before the time limit so rag_common.sh's
+# teardown trap can stop the docker containers before SLURM's SIGKILL (prevents
+# orphaned ollama-gpu / arandu-rag-run containers on the node; see rag_common).
+#SBATCH --signal=B:TERM@60
 
 # Phase C: entity-perturbed non-answerable items (LLM via ollama qwen3:14b).
 # Set NONANSWERABLE_REGENERATE=1 to discard the checkpoint + prior items and

--- a/scripts/slurm/rag/judge-answers.slurm
+++ b/scripts/slurm/rag/judge-answers.slurm
@@ -8,6 +8,10 @@
 #SBATCH --time=24:00:00
 #SBATCH --output=logs/rag_judge_ans_%j.out
 #SBATCH --error=logs/rag_judge_ans_%j.err
+# Send SIGTERM to the batch shell 60s before the time limit so rag_common.sh's
+# teardown trap can stop the docker containers before SLURM's SIGKILL (prevents
+# orphaned ollama-gpu / arandu-rag-run containers on the node; see rag_common).
+#SBATCH --signal=B:TERM@60
 
 # Phase C: gated 5-criteria answer judge (LLM via ollama qwen3:14b). The heaviest
 # stage by call count (~58% of the LLM fan-out). Resumes by default; pass

--- a/scripts/slurm/rag/rag-analysis.slurm
+++ b/scripts/slurm/rag/rag-analysis.slurm
@@ -7,6 +7,10 @@
 #SBATCH --time=2:00:00
 #SBATCH --output=logs/rag_analysis_%j.out
 #SBATCH --error=logs/rag_analysis_%j.err
+# Send SIGTERM to the batch shell 60s before the time limit so rag_common.sh's
+# teardown trap can stop the docker container before SLURM's SIGKILL (prevents
+# an orphaned arandu-rag-cpu container on the node; see rag_common).
+#SBATCH --signal=B:TERM@60
 
 # Phase C: aggregate judged answers into report.json + tables.md (no LLM).
 # CPU-only: no GPU request, runs via arandu-rag-cpu.

--- a/scripts/slurm/rag/rag_common.sh
+++ b/scripts/slurm/rag/rag_common.sh
@@ -53,19 +53,27 @@ DOCKER_PROFILE="$RAG_PROFILE"
 # The stage launches containers via `docker compose run`/`up`, but those are
 # owned by the docker daemon, NOT by this job step's process tree. So when
 # SLURM ends the job WITHOUT a clean script exit (a TIME LIMIT timeout or an
-# `scancel`), it kills the shell before the teardown below can run, and the
+# `scancel`), it kills the shell before a normal teardown runs, and the
 # containers keep running on the node as ORPHANS: still holding the GPU and
 # writing outputs outside any allocation, contending with whatever SLURM
 # schedules onto the node next. Observed: judge-answers 799024 TIMEOUT left
 # `ollama-gpu-<jobid>` + `<project>-arandu-rag-run-*` alive on tupi2, degrading
-# another user's job. (The old `set +e` around the run only handled a non-zero
-# EXIT, never a signal.)
+# another user's job.
 #
-# SLURM sends SIGTERM first and SIGKILL only after the KillWait grace period,
-# so trapping SIGTERM/SIGINT lets us tear the containers down in time. The
-# per-stage scripts also set `#SBATCH --signal=B:TERM@60` to widen that window.
-# `down --timeout 10 --remove-orphans` stops the run container + the ollama
-# sidecar well inside a default KillWait.
+# Two things are needed for the trap to actually fire in time:
+#   1. The stage command runs in the BACKGROUND and is `wait`-ed on (see below).
+#      bash does NOT run a trap while a foreground external command executes; it
+#      defers it until that command returns. A foreground `docker compose run`
+#      would therefore defer teardown until the container exits, i.e. never on a
+#      real timeout. `wait` is interruptible, so backgrounding + wait lets the
+#      SIGTERM/SIGINT handler run immediately.
+#   2. `#SBATCH --signal=B:TERM@60` (per-stage scripts) makes SLURM send SIGTERM
+#      to the batch shell 60s before the limit, well inside KillWait.
+#
+# Traps are armed LATER (via _rag_arm_traps, just before the first container
+# starts), so an early validation `exit 1` does not run `docker compose down`
+# while this job has no containers up (which could disturb a co-located job that
+# shares the compose project).
 _rag_teardown() {
     echo ""
     echo "[cleanup] tearing down containers (profile ${DOCKER_PROFILE})..."
@@ -73,17 +81,21 @@ _rag_teardown() {
         down --remove-orphans --timeout 10 2>/dev/null || true
 }
 _rag_on_signal() {
-    # Disarm all traps first so teardown runs exactly once (the explicit exit
-    # below would otherwise re-enter via the EXIT trap).
-    trap - EXIT INT TERM
+    # Ignore further INT/TERM while tearing down (a scancel retry or a short
+    # KillWait must not kill the shell mid-`down`) and disarm EXIT so teardown
+    # runs exactly once. $1 = signal name (for the log), $2 = exit code.
+    trap '' INT TERM
+    trap - EXIT
     echo ""
-    echo "[cleanup] caught ${1:-signal} (SLURM timeout/scancel); tearing down..."
+    echo "[cleanup] caught ${1} (SLURM timeout/scancel); tearing down..."
     _rag_teardown
-    exit 143  # 128 + SIGTERM(15), conventional signal-exit code
+    exit "${2}"
 }
-trap _rag_teardown EXIT
-trap '_rag_on_signal SIGINT' INT
-trap '_rag_on_signal SIGTERM' TERM
+_rag_arm_traps() {
+    trap _rag_teardown EXIT
+    trap '_rag_on_signal SIGINT 130' INT   # 128 + SIGINT(2)
+    trap '_rag_on_signal SIGTERM 143' TERM # 128 + SIGTERM(15)
+}
 
 echo "=============================================="
 echo "Arandu Phase C RAG stage"
@@ -138,6 +150,11 @@ echo ""
 echo "Building ${RAG_SERVICE} image (reuses the kg-extra image)..."
 docker compose -f "$COMPOSE_FILE" --profile "$DOCKER_PROFILE" build "$RAG_SERVICE"
 
+# From here on containers get started, so arm the teardown traps. (Kept out of
+# the early-validation/build path above so a pre-container `exit 1` cannot run
+# `docker compose down` when this job has nothing up.)
+_rag_arm_traps
+
 # ---------------------------------------------------------------------------
 # Ollama sidecar (LLM stages only)
 # ---------------------------------------------------------------------------
@@ -172,9 +189,17 @@ echo "=============================================="
 # set +e: under `set -e` a failing stage aborts the script HERE, skipping
 # the cleanup below and leaking the ollama sidecar on the shared node
 # (observed with judge-answers 795114). Capture the rc instead.
+#
+# Run in the BACKGROUND + `wait` (not foreground): bash defers signal traps
+# until a foreground external command returns, so a foreground run would keep
+# the SIGTERM teardown from firing until the container exits (never, on a real
+# timeout). `wait` is interruptible, so the trap runs immediately; if no signal
+# arrives, `wait` returns the container's real exit code.
 set +e
 # shellcheck disable=SC2086  # intentional word-splitting of the arg string
-docker compose -f "$COMPOSE_FILE" --profile "$DOCKER_PROFILE" run --rm "$RAG_SERVICE" ${RAG_CLI_ARGS}
+docker compose -f "$COMPOSE_FILE" --profile "$DOCKER_PROFILE" run --rm "$RAG_SERVICE" ${RAG_CLI_ARGS} &
+RUN_PID=$!
+wait "$RUN_PID"
 RUN_RC=$?
 set -e
 

--- a/scripts/slurm/rag/rag_common.sh
+++ b/scripts/slurm/rag/rag_common.sh
@@ -47,6 +47,44 @@ export SLURM_JOB_ID="${SLURM_JOB_ID:-local}"
 OLLAMA_SERVICE="ollama-gpu"
 DOCKER_PROFILE="$RAG_PROFILE"
 
+# ---------------------------------------------------------------------------
+# Container teardown trap.
+#
+# The stage launches containers via `docker compose run`/`up`, but those are
+# owned by the docker daemon, NOT by this job step's process tree. So when
+# SLURM ends the job WITHOUT a clean script exit (a TIME LIMIT timeout or an
+# `scancel`), it kills the shell before the teardown below can run, and the
+# containers keep running on the node as ORPHANS: still holding the GPU and
+# writing outputs outside any allocation, contending with whatever SLURM
+# schedules onto the node next. Observed: judge-answers 799024 TIMEOUT left
+# `ollama-gpu-<jobid>` + `<project>-arandu-rag-run-*` alive on tupi2, degrading
+# another user's job. (The old `set +e` around the run only handled a non-zero
+# EXIT, never a signal.)
+#
+# SLURM sends SIGTERM first and SIGKILL only after the KillWait grace period,
+# so trapping SIGTERM/SIGINT lets us tear the containers down in time. The
+# per-stage scripts also set `#SBATCH --signal=B:TERM@60` to widen that window.
+# `down --timeout 10 --remove-orphans` stops the run container + the ollama
+# sidecar well inside a default KillWait.
+_rag_teardown() {
+    echo ""
+    echo "[cleanup] tearing down containers (profile ${DOCKER_PROFILE})..."
+    docker compose -f "$COMPOSE_FILE" --profile "$DOCKER_PROFILE" \
+        down --remove-orphans --timeout 10 2>/dev/null || true
+}
+_rag_on_signal() {
+    # Disarm all traps first so teardown runs exactly once (the explicit exit
+    # below would otherwise re-enter via the EXIT trap).
+    trap - EXIT INT TERM
+    echo ""
+    echo "[cleanup] caught ${1:-signal} (SLURM timeout/scancel); tearing down..."
+    _rag_teardown
+    exit 143  # 128 + SIGTERM(15), conventional signal-exit code
+}
+trap _rag_teardown EXIT
+trap '_rag_on_signal SIGINT' INT
+trap '_rag_on_signal SIGTERM' TERM
+
 echo "=============================================="
 echo "Arandu Phase C RAG stage"
 echo "=============================================="
@@ -140,11 +178,10 @@ docker compose -f "$COMPOSE_FILE" --profile "$DOCKER_PROFILE" run --rm "$RAG_SER
 RUN_RC=$?
 set -e
 
-echo ""
-echo "Cleaning up containers..."
-docker compose -f "$COMPOSE_FILE" --profile "$DOCKER_PROFILE" down 2>/dev/null || true
-
 echo "=============================================="
 echo "Stage finished (rc=${RUN_RC}) at $(date)"
 echo "=============================================="
+# Container teardown is handled by the _rag_teardown EXIT trap set above, so it
+# runs here on normal exit AND on a SLURM SIGTERM (timeout/scancel). Do not add
+# a manual `docker compose down`; it would just double-run the trap.
 exit $RUN_RC

--- a/scripts/slurm/rag/retrieve.slurm
+++ b/scripts/slurm/rag/retrieve.slurm
@@ -8,6 +8,10 @@
 #SBATCH --time=8:00:00
 #SBATCH --output=logs/rag_retrieve_%j.out
 #SBATCH --error=logs/rag_retrieve_%j.err
+# Send SIGTERM to the batch shell 60s before the time limit so rag_common.sh's
+# teardown trap can stop the docker containers before SLURM's SIGKILL (prevents
+# orphaned ollama-gpu / arandu-rag-run containers on the node; see rag_common).
+#SBATCH --signal=B:TERM@60
 
 # Phase C: run all 5 arms. atlas_rag needs the LLM (NER + edge-filter) via ollama
 # and the local embedder for query encoding; bm25/khop/null need neither.


### PR DESCRIPTION
## Problem

`rag_common.sh` only tore down its docker containers on a **normal script exit**. On a SLURM **TIME LIMIT timeout** or **`scancel`**, SLURM kills the shell before the cleanup runs. Because the containers are owned by the docker daemon (not the job step's process tree), they **survive as orphans**: they keep holding the GPU and writing outputs outside any allocation, contending with whatever SLURM schedules onto the node next.

Observed on the thesis run: judge-answers job 799024 timed out and left `ollama-gpu-<jobid>` + `<project>-arandu-rag-run-*` running on tupi2, degrading another user's job (SLURM had re-allocated the node, considering it free). It could not be cleaned up remotely because `ssh <node>` is blocked by `pam_slurm_adopt`.

The pre-existing `set +e` around the run only handled a non-zero exit code, never a signal.

## Fix

- **`rag_common.sh`**: add `_rag_teardown()` + a trap on `EXIT INT TERM`. On timeout/scancel SLURM sends SIGTERM first (SIGKILL only after the KillWait grace period), so the trap runs `docker compose down --remove-orphans --timeout 10` in time to stop the run container and the ollama sidecar. The signal handler disarms all traps before exiting so teardown runs exactly once. The manual `docker compose down` at the end is removed (the EXIT trap now owns teardown).
- **`answer.slurm`, `judge-answers.slurm`, `retrieve.slurm`**: add `#SBATCH --signal=B:TERM@60` so SLURM signals the batch shell 60s before the time limit, giving the trap ample time before SIGKILL.

## Testing

- `bash -n` passes on all four scripts.
- No behavior change on the normal-exit path (same teardown, now via the EXIT trap).

## Notes

Preventive only: does not clean up any container already orphaned before this lands. The cluster checkout must be updated before the next long GPU stage is (re)submitted.