### PR TITLE
fix(rag): filter judge-rejected QA pairs from the retrieve benchmark

### DIFF
--- a/src/arandu/qa/cep/judge.py
+++ b/src/arandu/qa/cep/judge.py
@@ -91,7 +91,10 @@ class QAJudge(BaseJudge):
         # Remember pairs are factual recall by design (the 3/1/1/1 factual base),
         # so informativeness (which scores down trivial/explicit content) is a
         # conceptual mismatch that rejected ~55% of remember pairs. Judge them on
-        # grounding + level only; self_containedness is auto-1.0 for remember.
+        # grounding + level only. self_containedness is dropped too (remember
+        # recall is not expected to be fully self-contained); it is simply NOT
+        # evaluated for remember pairs -- it is omitted from criterion_scores,
+        # not auto-scored 1.0.
         remember_criteria = [
             "faithfulness",
             "bloom_calibration",

--- a/src/arandu/shared/rag/retrieve/loader.py
+++ b/src/arandu/shared/rag/retrieve/loader.py
@@ -132,13 +132,20 @@ def load_questions(cep_dir: Path, nonanswerable_dir: Path | None = None) -> list
 
 
 def _iter_cep_questions(cep_dir: Path) -> Iterator[QuestionRecord]:
-    """Yield one :class:`QuestionRecord` per ``QAPairCEP`` in the dir.
+    """Yield one :class:`QuestionRecord` per judge-valid ``QAPairCEP`` in the dir.
 
     Each on-disk file is a :class:`QARecordCEP` holding many pairs. The
     composite ``qa_pair_id`` follows the schema's documented form:
     ``"<file_id>:<chunk_id or 'none'>:<idx>"``. ``idx`` is the pair's
     position within the record, so the id stays stable across reruns
     that produce the same file.
+
+    Pairs the judge-qa stage rejected (``is_judge_rejected``) are skipped so
+    the RAG benchmark evaluates only the approved question set, matching the
+    canonical drop-rule the chunk/kg consumers already use. ``idx`` is still
+    taken over ALL pairs (not the surviving subset), so a rejected pair in the
+    middle does not shift the ids of the pairs after it. Unjudged pairs
+    (``is_valid`` is None, e.g. a run where judge-qa has not run) are kept.
     """
     for path in sorted(cep_dir.glob("*.json")):
         try:
@@ -147,6 +154,8 @@ def _iter_cep_questions(cep_dir: Path) -> Iterator[QuestionRecord]:
             logger.warning("Skipping unreadable CEP file %s: %s", path, exc)
             continue
         for idx, pair in enumerate(record.qa_pairs):
+            if pair.is_judge_rejected:
+                continue
             chunk_id_segment = pair.chunk_id or "none"
             yield QuestionRecord(
                 qa_pair_id=f"{record.source_file_id}:{chunk_id_segment}:{idx}",

--- a/tests/shared/rag/retrieve/test_loader.py
+++ b/tests/shared/rag/retrieve/test_loader.py
@@ -45,8 +45,9 @@ def _qa_pair(
     answer: str = "Resposta.",
     chunk_id: str | None = None,
     bloom_level: str = "remember",
+    passed: bool | None = None,
 ) -> dict:
-    return {
+    pair = {
         "question": question,
         "answer": answer,
         "context": "Contexto.",
@@ -55,6 +56,11 @@ def _qa_pair(
         "bloom_level": bloom_level,
         "chunk_id": chunk_id,
     }
+    if passed is not None:
+        # Minimal JudgePipelineResult: is_valid derives from validation.passed,
+        # is_judge_rejected is (is_valid is False). Empty stage_results is valid.
+        pair["validation"] = {"stage_results": {}, "passed": passed}
+    return pair
 
 
 class TestLoadQuestionsCepOnly:
@@ -118,6 +124,38 @@ class TestLoadQuestionsCepOnly:
 
         questions = load_questions(cep_dir)
         assert [q.source_file_id for q in questions] == ["src_ok"]
+
+    def test_judge_rejected_pairs_excluded_idx_preserved(self, tmp_path: Path) -> None:
+        # The RAG benchmark must evaluate only judge-valid pairs. A rejected
+        # pair (validation.passed=False) is dropped, but idx is taken over ALL
+        # pairs so the ids of surviving pairs after it do not shift.
+        cep_dir = tmp_path / "cep"
+        cep_dir.mkdir()
+        _write_cep_record(
+            cep_dir,
+            source_file_id="src_a",
+            qa_pairs=[
+                _qa_pair("Approved 0?", chunk_id="chk", passed=True),
+                _qa_pair("Rejected 1?", chunk_id="chk", passed=False),
+                _qa_pair("Approved 2?", chunk_id="chk", passed=True),
+            ],
+        )
+
+        questions = load_questions(cep_dir)
+
+        # Rejected pair dropped; the third pair keeps idx 2 (not renumbered to 1).
+        assert [q.qa_pair_id for q in questions] == ["src_a:chk:0", "src_a:chk:2"]
+        assert [q.question for q in questions] == ["Approved 0?", "Approved 2?"]
+
+    def test_unjudged_pairs_kept(self, tmp_path: Path) -> None:
+        # Unjudged pairs (validation absent, is_valid is None) are NOT rejected,
+        # so a run where judge-qa has not run still retrieves every pair.
+        cep_dir = tmp_path / "cep"
+        cep_dir.mkdir()
+        _write_cep_record(cep_dir, "src_a", [_qa_pair("Unjudged?", chunk_id="chk")])
+
+        questions = load_questions(cep_dir)
+        assert [q.qa_pair_id for q in questions] == ["src_a:chk:0"]
 
 
 class TestLoadQuestionsNonAnswerable:


### PR DESCRIPTION
## Problem

`_iter_cep_questions` in `src/arandu/shared/rag/retrieve/loader.py` yielded **every** generated CEP pair with `is_answerable=True`, with no check on the judge-qa verdict. The whole RAG eval chain (retrieve → answer → judge-answers → rag-analysis) therefore ran over all generated pairs instead of the judge-approved set.

Measured on `thesis-run-01`:
- 2670 CEP pairs generated; 1579 approved (59.1%); **1091 (40.9%) rejected by judge-qa but still in the benchmark**.
- Answer records carry `is_valid=null` (the verdict was never propagated), and the analysis reported `n_answerable=2670` per arm, confirming no filtering happened anywhere.
- Concrete example: `1-ptIECorsTNLKe2pVKB5hap9IWKI6VM8:ede79617626bb678:23` ("Avalie a decisão de meditar...") was rejected by judge-qa (self_containedness 0.5 < 0.625) yet appears in `answers/`.

The judge-qa pass-rate was computed but never applied to the benchmark.

## Fix

Skip pairs where `is_judge_rejected` is true — the canonical drop-rule the chunk/kg consumers already use (`JudgeResultMixin.is_judge_rejected`).

- `idx` is still taken over **all** pairs (not the surviving subset), so a rejected pair in the middle does not renumber the `qa_pair_id` of later pairs. Ids stay stable and keep matching the cep/answer records.
- Unjudged pairs (`is_valid is None`, e.g. a run where judge-qa has not run) are **kept**, so the retrieve stage can still run before judging.

Also corrects a stale comment in `src/arandu/qa/cep/judge.py`: `self_containedness` is **omitted** from remember pairs' `criterion_scores`, not auto-scored 1.0. (The remember exemption itself is intended and unchanged: remember recall is not expected to be fully self-contained.)

## Impact on existing results

Re-analysing `thesis-run-01` over the approved subset (offline, reusing the production aggregators) leaves the **cross-arm ranking intact** (bm25 > atlas ≈ khop_passage > khop_triple > null) and hallucination rates identical; over-caution drops and abstention F1 rises (both were distorted by the rejected pairs). This PR only changes future runs; the current run's tables are corrected separately.

## Tests

- New: `test_judge_rejected_pairs_excluded_idx_preserved`, `test_unjudged_pairs_kept` in `tests/shared/rag/retrieve/test_loader.py`.
- `pytest tests/qa/cep tests/shared/rag/retrieve tests/shared/rag/analysis`: 179 passed.
- `ruff check` + `ruff format --check`: clean.