### PR TITLE
feat(scripts): add judge-qa threshold + cohort analysis tools

### DIFF
--- a/scripts/_judge_analysis_common.py
+++ b/scripts/_judge_analysis_common.py
@@ -1,0 +1,85 @@
+"""Shared helpers for the judge-qa threshold / cohort analysis scripts.
+
+These tools inspect a completed run's judge-qa verdicts (``cep/outputs``) and the
+RAG judged answers (``judge_answers/outputs``) without re-running any stage. The
+judge-qa criteria are 5-point Likert rubrics mapped to ``[0, 1]`` (anchors in
+``ANCHORS``), so ``pass`` at a threshold ``t`` is ``score >= t`` for every
+evaluated criterion. A pair carrying fewer criteria (remember pairs skip
+``informativeness`` + ``self_containedness`` by design) is judged on whatever it
+carries.
+
+Used by ``analyze_judge_thresholds``, ``analyze_qa_cohort_rag_outcome`` and
+``plot_judge_score_distributions``. Run those as modules from the repo root so
+this import resolves, e.g. ``uv run python -m scripts.analyze_judge_thresholds``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from pydantic import ValidationError
+
+from arandu.qa.schemas import QARecordCEP
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+CRITERIA = ["faithfulness", "bloom_calibration", "informativeness", "self_containedness"]
+ANCHORS = [0.0, 0.25, 0.5, 0.75, 1.0]
+DEFAULT_THRESHOLD = 0.625
+CEP_STAGE = "cep_validation"
+
+# qa_pair_id -> {criterion_name: score or None}; None means the criterion errored
+# or produced no score (treated as a fail at any threshold).
+PairScores = dict[str, dict[str, float | None]]
+
+
+def load_pair_scores(cep_dir: Path) -> PairScores:
+    """Read per-criterion judge-qa scores for every CEP pair.
+
+    The ``qa_pair_id`` is derived exactly as the retrieve loader and analysis
+    cross-cut map derive it (``"<file_id>:<chunk_id or 'none'>:<idx>"``), so ids
+    join cleanly onto the ``judge_answers`` records.
+
+    Args:
+        cep_dir: ``results/<id>/cep/outputs/``.
+
+    Returns:
+        Mapping ``qa_pair_id -> {criterion: score or None}`` over the criteria
+        the judge actually evaluated for that pair.
+    """
+    out: PairScores = {}
+    for path in sorted(cep_dir.glob("*.json")):
+        try:
+            record = QARecordCEP.model_validate_json(path.read_text(encoding="utf-8"))
+        except (OSError, ValidationError):
+            continue
+        for idx, pair in enumerate(record.qa_pairs):
+            seg = pair.chunk_id or "none"
+            pid = f"{record.source_file_id}:{seg}:{idx}"
+            scores: dict[str, float | None] = {}
+            if pair.validation is not None:
+                step = pair.validation.stage_results.get(CEP_STAGE)
+                if step is not None:
+                    for name, cs in step.criterion_scores.items():
+                        scores[name] = None if cs.error is not None else cs.score
+            out[pid] = scores
+    return out
+
+
+def approved_ids(scores: PairScores, threshold: float) -> set[str]:
+    """qa_pair_ids whose every evaluated criterion scores >= ``threshold``.
+
+    A pair with an unscored/errored criterion (score None) or no criteria at all
+    is excluded, mirroring ``CriterionScore.passed`` (error/None never passes).
+    """
+    return {
+        pid
+        for pid, crit in scores.items()
+        if crit and all(s is not None and s >= threshold for s in crit.values())
+    }
+
+
+def snap_to_anchor(score: float) -> float:
+    """Return the Likert anchor (0/.25/.5/.75/1) nearest to ``score``."""
+    return min(ANCHORS, key=lambda a: abs(a - score))

--- a/scripts/analyze_judge_thresholds.py
+++ b/scripts/analyze_judge_thresholds.py
@@ -1,0 +1,107 @@
+"""Judge-qa threshold sensitivity + score-distribution diagnostic (read-only).
+
+Because the RAG chain is evaluated over every generated CEP pair, this recomputes
+the approved set at several thresholds from the stored per-criterion scores and
+re-aggregates the cross-arm metrics (reusing the production aggregators), then
+prints the per-criterion score distribution. It answers two questions for the
+results chapter:
+
+  1. Is the cross-arm ranking robust to the judge-qa pass threshold?
+  2. Where do the criterion scores sit relative to the threshold (is it in a
+     dense region or an empty gap)?
+
+Run from the repo root:
+
+    uv run python -m scripts.analyze_judge_thresholds --id thesis-run-01
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+from pathlib import Path
+
+from arandu.shared.rag.analysis.batch import _group_by_arm
+from arandu.shared.rag.analysis.metrics import aggregate_arm
+from scripts._judge_analysis_common import (
+    ANCHORS,
+    CRITERIA,
+    DEFAULT_THRESHOLD,
+    approved_ids,
+    load_pair_scores,
+    snap_to_anchor,
+)
+
+
+def _fmt(x: float | None) -> str:
+    return "n/a" if x is None else f"{x:.3f}"
+
+
+def _sensitivity(cep_dir: Path, judged_dir: Path, thresholds: list[float]) -> None:
+    scores = load_pair_scores(cep_dir)
+    by_arm, _, _ = _group_by_arm(judged_dir)
+    arms = sorted(by_arm)
+    print("=" * 74)
+    print("Cross-arm joint metrics vs judge-qa threshold")
+    print("=" * 74)
+    for t in thresholds:
+        approved = approved_ids(scores, t)
+        print(f"\n### threshold = {t}  (approved answerable = {len(approved)})")
+        header = f"{'Arm':<20} {'KC':>7} {'Halluc':>7} {'OverC':>7} {'AbstF1':>7} {'PassCov':>8}"
+        print(header)
+        for arm in arms:
+            kept = [r for r in by_arm[arm] if (not r.is_answerable) or (r.qa_pair_id in approved)]
+            m = aggregate_arm(arm, kept, slice_name="joint")
+            print(
+                f"{arm:<20} {_fmt(m.knowledge_coverage.mean):>7} "
+                f"{_fmt(m.hallucination_rate.value):>7} "
+                f"{_fmt(m.over_cautiousness_rate.value):>7} {_fmt(m.abstention_f1):>7} "
+                f"{_fmt(m.passage_coverage.mean):>8}"
+            )
+
+
+def _distribution(cep_dir: Path, threshold: float) -> None:
+    scores = load_pair_scores(cep_dir)
+    print("\n" + "=" * 74)
+    print(f"Judge-qa score distribution per criterion (threshold {threshold})")
+    print("=" * 74)
+    for crit in CRITERIA:
+        vals = [s[crit] for s in scores.values() if crit in s and s[crit] is not None]
+        if not vals:
+            print(f"\n{crit}: (no scores)")
+            continue
+        n = len(vals)
+        below = sum(1 for v in vals if v < threshold)
+        hist: Counter[float] = Counter(snap_to_anchor(v) for v in vals)
+        mean = sum(vals) / n
+        print(f"\n{crit}: n={n}  mean={mean:.3f}  <{threshold} = {below} ({100 * below / n:.1f}%)")
+        peak = max(hist.values())
+        for a in ANCHORS:
+            c = hist.get(a, 0)
+            bar = "#" * round(50 * c / peak) if peak else ""
+            gap = "  <- threshold in gap" if a == 0.5 and threshold > 0.5 else ""
+            print(f"  {a:>4}: {c:>5} {bar}{gap}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Judge-qa threshold + distribution diagnostic.")
+    parser.add_argument("--id", required=True, help="Pipeline run id (e.g. thesis-run-01).")
+    parser.add_argument("--results-root", default="results", help="Results root dir.")
+    parser.add_argument(
+        "--thresholds",
+        default="0.5,0.625,0.7",
+        help="Comma-separated thresholds for the sensitivity sweep.",
+    )
+    args = parser.parse_args()
+
+    base = Path(args.results_root) / args.id
+    cep_dir = base / "cep" / "outputs"
+    judged_dir = base / "judge_answers" / "outputs"
+    thresholds = [float(t) for t in args.thresholds.split(",")]
+
+    _sensitivity(cep_dir, judged_dir, thresholds)
+    _distribution(cep_dir, DEFAULT_THRESHOLD)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/analyze_qa_cohort_rag_outcome.py
+++ b/scripts/analyze_qa_cohort_rag_outcome.py
@@ -1,0 +1,107 @@
+"""RAG outcome on the just-below-threshold (0.5) judge-qa cohort (read-only).
+
+The judge scores are quantized to 5 Likert anchors, so there is no continuous
+"near-threshold" band; the meaningful borderline set is the pairs admitted only
+at threshold 0.5 (minimum criterion score == 0.5). This characterizes how each
+RAG arm performs on that cohort vs the approved set, attributed by the criterion
+that scored 0.5.
+
+Interpretation caveat (why this is DESCRIPTIVE, not "the judge is too strict"):
+the 0.5 anchors are legitimate exclusion reasons, and RAG-answerability does not
+test them. self_containedness=0.5 ("partly needs context") is confounded because
+the arms retrieve the context; informativeness=0.5 ("moderately useful/generic")
+measures answer knowledge-value, which is orthogonal to answerability (generic
+questions are simply easier). Higher RAG scores on the excluded cohort therefore
+confirm the exclusions are well-motivated rather than mistaken.
+
+Run from the repo root:
+
+    uv run python -m scripts.analyze_qa_cohort_rag_outcome --id thesis-run-01
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from arandu.shared.rag.analysis.batch import _group_by_arm
+from arandu.shared.rag.analysis.metrics import aggregate_arm
+from scripts._judge_analysis_common import DEFAULT_THRESHOLD, load_pair_scores
+
+if TYPE_CHECKING:
+    from arandu.shared.rag.schemas import AnswerRecord
+
+
+def _fmt(x: float | None) -> str:
+    return "n/a" if x is None else f"{x:.3f}"
+
+
+def _build_cohorts(
+    scores: dict[str, dict[str, float | None]], threshold: float
+) -> dict[str, set[str]]:
+    """Partition pairs into approved, the 0.5 cohort, and pure-criterion subsets."""
+    approved: set[str] = set()
+    cohort05: set[str] = set()
+    sc_only: set[str] = set()
+    inf_only: set[str] = set()
+    for pid, raw in scores.items():
+        if not raw or any(v is None for v in raw.values()):
+            continue
+        sc = {k: float(v) for k, v in raw.items() if v is not None}
+        vals = list(sc.values())
+        if all(v >= threshold for v in vals):
+            approved.add(pid)
+        elif all(v >= 0.5 for v in vals) and min(vals) == 0.5:
+            cohort05.add(pid)
+            if sc.get("self_containedness") == 0.5 and all(
+                v >= 0.75 for k, v in sc.items() if k != "self_containedness"
+            ):
+                sc_only.add(pid)
+            if sc.get("informativeness") == 0.5 and all(
+                v >= 0.75 for k, v in sc.items() if k != "informativeness"
+            ):
+                inf_only.add(pid)
+    return {
+        f"APPROVED (>={threshold:.3f})": approved,
+        "0.5 COHORT (all)": cohort05,
+        "0.5 via self_containedness only": sc_only,
+        "0.5 via informativeness only": inf_only,
+    }
+
+
+def _report(name: str, ids: set[str], by_arm: dict[str, list[AnswerRecord]]) -> None:
+    print(f"\n### {name}  (|answerable| = {len(ids)})")
+    print(f"{'Arm':<20} {'n_ans':>6} {'KC':>7} {'Correct':>8} {'PassCov':>8} {'answered%':>10}")
+    for arm in sorted(by_arm):
+        recs = [r for r in by_arm[arm] if r.is_answerable and r.qa_pair_id in ids]
+        m = aggregate_arm(arm, recs, slice_name=name)
+        conf = m.confusion
+        answered = conf.get("TC", 0) + conf.get("TA", 0)
+        denom = sum(conf.get(k, 0) for k in ("TC", "TA", "FC", "FA"))
+        pct = f"{100 * answered / denom:.0f}%" if denom else "n/a"
+        print(
+            f"{arm:<20} {len(recs):>6} {_fmt(m.knowledge_coverage.mean):>7} "
+            f"{_fmt(m.answer_correctness.mean):>8} {_fmt(m.passage_coverage.mean):>8} {pct:>10}"
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="RAG outcome on the 0.5 judge-qa cohort.")
+    parser.add_argument("--id", required=True, help="Pipeline run id (e.g. thesis-run-01).")
+    parser.add_argument("--results-root", default="results", help="Results root dir.")
+    parser.add_argument(
+        "--threshold", type=float, default=DEFAULT_THRESHOLD, help="Approval threshold."
+    )
+    args = parser.parse_args()
+
+    base = Path(args.results_root) / args.id
+    scores = load_pair_scores(base / "cep" / "outputs")
+    by_arm, _, _ = _group_by_arm(base / "judge_answers" / "outputs")
+    cohorts = _build_cohorts(scores, args.threshold)
+    for name, ids in cohorts.items():
+        _report(name, ids, by_arm)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/plot_judge_score_distributions.py
+++ b/scripts/plot_judge_score_distributions.py
@@ -42,6 +42,17 @@ def _criterion_values(scores: dict[str, dict[str, float | None]], crit: str) -> 
     return [s[crit] for s in scores.values() if crit in s and s[crit] is not None]
 
 
+def _criterion_error_count(scores: dict[str, dict[str, float | None]], crit: str) -> int:
+    """Pairs where the criterion was evaluated but errored (score is None)."""
+    return sum(1 for s in scores.values() if crit in s and s[crit] is None)
+
+
+def _panel_title(crit: str, n: int, err: int, below: int, threshold: float) -> str:
+    """Subplot title: scored count, errored count, and count below threshold."""
+    pct = 100 * below / n if n else 0.0
+    return f"{crit}  (n={n}, err={err}, <{threshold} = {below} = {pct:.0f}%)"
+
+
 def _gaussian_kde(samples: list[float], grid: np.ndarray, bw: float) -> np.ndarray:
     """Simple Gaussian KDE (no scipy): mean of per-sample normal kernels."""
     s = np.asarray(samples, dtype=float)[:, None]
@@ -74,8 +85,9 @@ def _plot_bars(scores: dict, threshold: float, run_id: str) -> go.Figure:
             row=row + 1,
             col=col + 1,
         )
-        pct = 100 * below / n if n else 0.0
-        fig.layout.annotations[i].text = f"{crit}  (n={n}, <{threshold} = {below} = {pct:.0f}%)"
+        fig.layout.annotations[i].text = _panel_title(
+            crit, n, _criterion_error_count(scores, crit), below, threshold
+        )
     fig.update_layout(
         title_text=(
             f"judge-qa score distributions ({run_id}) - 5-point Likert; "
@@ -129,8 +141,9 @@ def _plot_hist(scores: dict, threshold: float, run_id: str) -> go.Figure:
         )
         n = len(vals)
         below = sum(1 for v in vals if v < threshold)
-        pct = 100 * below / n if n else 0.0
-        fig.layout.annotations[i].text = f"{crit}  (n={n}, <{threshold} = {below} = {pct:.0f}%)"
+        fig.layout.annotations[i].text = _panel_title(
+            crit, n, _criterion_error_count(scores, crit), below, threshold
+        )
     fig.update_layout(
         title_text=(
             f"judge-qa score histogram ({run_id}) - raw, bin=0.025 (no smoothing); "
@@ -187,8 +200,9 @@ def _plot_density(scores: dict, threshold: float, run_id: str) -> go.Figure:
             row=row + 1,
             col=col + 1,
         )
-        pct = 100 * below / n if n else 0.0
-        fig.layout.annotations[i].text = f"{crit}  (n={n}, <{threshold} = {below} = {pct:.0f}%)"
+        fig.layout.annotations[i].text = _panel_title(
+            crit, n, _criterion_error_count(scores, crit), below, threshold
+        )
     fig.update_layout(
         title_text=(
             f"judge-qa score density ({run_id}) - dashed = threshold {threshold}; "

--- a/scripts/plot_judge_score_distributions.py
+++ b/scripts/plot_judge_score_distributions.py
@@ -1,0 +1,101 @@
+"""Plot judge-qa score distributions per criterion, marking the pass threshold.
+
+Renders one bar panel per criterion over the 5 Likert anchors, colouring
+below-threshold anchors as rejected, and exports a static image. Shows the
+quantization and whether the threshold falls in an empty gap.
+
+Requires the ``report`` extra (plotly + kaleido). Run from the repo root:
+
+    uv run --extra report python -m scripts.plot_judge_score_distributions \
+        --id thesis-run-01 --out results/thesis-run-01/analysis/judge_score_distributions.png
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+from pathlib import Path
+
+import plotly.graph_objects as go
+from plotly.subplots import make_subplots
+
+from scripts._judge_analysis_common import (
+    ANCHORS,
+    CRITERIA,
+    DEFAULT_THRESHOLD,
+    load_pair_scores,
+    snap_to_anchor,
+)
+
+_REJECT = "#c0392b"
+_PASS = "#27ae60"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Plot judge-qa score distributions.")
+    parser.add_argument("--id", required=True, help="Pipeline run id (e.g. thesis-run-01).")
+    parser.add_argument("--results-root", default="results", help="Results root dir.")
+    parser.add_argument("--threshold", type=float, default=DEFAULT_THRESHOLD)
+    parser.add_argument(
+        "--out",
+        default=None,
+        help="Output image path (default: results/<id>/analysis/judge_score_distributions.png).",
+    )
+    args = parser.parse_args()
+
+    base = Path(args.results_root) / args.id
+    scores = load_pair_scores(base / "cep" / "outputs")
+    out = Path(args.out) if args.out else base / "analysis" / "judge_score_distributions.png"
+
+    fig = make_subplots(
+        rows=2,
+        cols=2,
+        subplot_titles=list(CRITERIA),
+        vertical_spacing=0.16,
+        horizontal_spacing=0.1,
+    )
+    for i, crit in enumerate(CRITERIA):
+        vals = [s[crit] for s in scores.values() if crit in s and s[crit] is not None]
+        hist: Counter[float] = Counter(snap_to_anchor(v) for v in vals)
+        heights = [hist.get(a, 0) for a in ANCHORS]
+        colours = [_REJECT if a < args.threshold else _PASS for a in ANCHORS]
+        n = len(vals)
+        below = sum(h for a, h in zip(ANCHORS, heights, strict=True) if a < args.threshold)
+        row, col = divmod(i, 2)
+        fig.add_trace(
+            go.Bar(
+                x=[str(a) for a in ANCHORS],
+                y=heights,
+                marker_color=colours,
+                text=heights,
+                textposition="outside",
+                showlegend=False,
+            ),
+            row=row + 1,
+            col=col + 1,
+        )
+        pct = 100 * below / n if n else 0.0
+        fig.layout.annotations[
+            i
+        ].text = f"{crit}  (n={n}, <{args.threshold} = {below} = {pct:.0f}%)"
+
+    fig.update_layout(
+        title_text=(
+            f"judge-qa score distributions ({args.id}) - 5-point Likert; "
+            f"threshold {args.threshold} between the 0.5 and 0.75 anchors"
+        ),
+        template="plotly_white",
+        height=720,
+        width=1100,
+        bargap=0.35,
+    )
+    fig.update_xaxes(title_text="score anchor")
+    fig.update_yaxes(title_text="pairs")
+
+    out.parent.mkdir(parents=True, exist_ok=True)
+    fig.write_image(str(out))
+    print(f"wrote {out.resolve()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/plot_judge_score_distributions.py
+++ b/scripts/plot_judge_score_distributions.py
@@ -1,13 +1,18 @@
 """Plot judge-qa score distributions per criterion, marking the pass threshold.
 
-Renders one bar panel per criterion over the 5 Likert anchors, colouring
-below-threshold anchors as rejected, and exports a static image. Shows the
-quantization and whether the threshold falls in an empty gap.
+Two styles:
+
+- ``bars`` (default): one bar panel per criterion over the 5 Likert anchors,
+  colouring below-threshold anchors as rejected. Faithful to the raw data.
+- ``density``: a Gaussian-KDE curve per criterion with a vertical threshold line
+  and a shaded reject region. NOTE the scores are quantized to 5 anchors, so the
+  density is a SMOOTHED view of those 5 points, not evidence of a continuum; the
+  caveat is annotated on the figure.
 
 Requires the ``report`` extra (plotly + kaleido). Run from the repo root:
 
     uv run --extra report python -m scripts.plot_judge_score_distributions \
-        --id thesis-run-01 --out results/thesis-run-01/analysis/judge_score_distributions.png
+        --id thesis-run-01 --style density
 """
 
 from __future__ import annotations
@@ -16,6 +21,7 @@ import argparse
 from collections import Counter
 from pathlib import Path
 
+import numpy as np
 import plotly.graph_objects as go
 from plotly.subplots import make_subplots
 
@@ -29,38 +35,32 @@ from scripts._judge_analysis_common import (
 
 _REJECT = "#c0392b"
 _PASS = "#27ae60"
+_KDE_BANDWIDTH = 0.08
 
 
-def main() -> None:
-    parser = argparse.ArgumentParser(description="Plot judge-qa score distributions.")
-    parser.add_argument("--id", required=True, help="Pipeline run id (e.g. thesis-run-01).")
-    parser.add_argument("--results-root", default="results", help="Results root dir.")
-    parser.add_argument("--threshold", type=float, default=DEFAULT_THRESHOLD)
-    parser.add_argument(
-        "--out",
-        default=None,
-        help="Output image path (default: results/<id>/analysis/judge_score_distributions.png).",
-    )
-    args = parser.parse_args()
+def _criterion_values(scores: dict[str, dict[str, float | None]], crit: str) -> list[float]:
+    return [s[crit] for s in scores.values() if crit in s and s[crit] is not None]
 
-    base = Path(args.results_root) / args.id
-    scores = load_pair_scores(base / "cep" / "outputs")
-    out = Path(args.out) if args.out else base / "analysis" / "judge_score_distributions.png"
 
+def _gaussian_kde(samples: list[float], grid: np.ndarray, bw: float) -> np.ndarray:
+    """Simple Gaussian KDE (no scipy): mean of per-sample normal kernels."""
+    s = np.asarray(samples, dtype=float)[:, None]
+    diff = (grid[None, :] - s) / bw
+    kernels = np.exp(-0.5 * diff**2) / (bw * np.sqrt(2 * np.pi))
+    return kernels.mean(axis=0)
+
+
+def _plot_bars(scores: dict, threshold: float, run_id: str) -> go.Figure:
     fig = make_subplots(
-        rows=2,
-        cols=2,
-        subplot_titles=list(CRITERIA),
-        vertical_spacing=0.16,
-        horizontal_spacing=0.1,
+        rows=2, cols=2, subplot_titles=list(CRITERIA), vertical_spacing=0.16, horizontal_spacing=0.1
     )
     for i, crit in enumerate(CRITERIA):
-        vals = [s[crit] for s in scores.values() if crit in s and s[crit] is not None]
+        vals = _criterion_values(scores, crit)
         hist: Counter[float] = Counter(snap_to_anchor(v) for v in vals)
         heights = [hist.get(a, 0) for a in ANCHORS]
-        colours = [_REJECT if a < args.threshold else _PASS for a in ANCHORS]
+        colours = [_REJECT if a < threshold else _PASS for a in ANCHORS]
         n = len(vals)
-        below = sum(h for a, h in zip(ANCHORS, heights, strict=True) if a < args.threshold)
+        below = sum(h for a, h in zip(ANCHORS, heights, strict=True) if a < threshold)
         row, col = divmod(i, 2)
         fig.add_trace(
             go.Bar(
@@ -75,14 +75,11 @@ def main() -> None:
             col=col + 1,
         )
         pct = 100 * below / n if n else 0.0
-        fig.layout.annotations[
-            i
-        ].text = f"{crit}  (n={n}, <{args.threshold} = {below} = {pct:.0f}%)"
-
+        fig.layout.annotations[i].text = f"{crit}  (n={n}, <{threshold} = {below} = {pct:.0f}%)"
     fig.update_layout(
         title_text=(
-            f"judge-qa score distributions ({args.id}) - 5-point Likert; "
-            f"threshold {args.threshold} between the 0.5 and 0.75 anchors"
+            f"judge-qa score distributions ({run_id}) - 5-point Likert; "
+            f"threshold {threshold} between the 0.5 and 0.75 anchors"
         ),
         template="plotly_white",
         height=720,
@@ -91,6 +88,91 @@ def main() -> None:
     )
     fig.update_xaxes(title_text="score anchor")
     fig.update_yaxes(title_text="pairs")
+    return fig
+
+
+def _plot_density(scores: dict, threshold: float, run_id: str) -> go.Figure:
+    grid = np.linspace(-0.05, 1.05, 300)
+    fig = make_subplots(
+        rows=2, cols=2, subplot_titles=list(CRITERIA), vertical_spacing=0.16, horizontal_spacing=0.1
+    )
+    for i, crit in enumerate(CRITERIA):
+        vals = _criterion_values(scores, crit)
+        row, col = divmod(i, 2)
+        if not vals:
+            continue
+        density = _gaussian_kde(vals, grid, _KDE_BANDWIDTH)
+        n = len(vals)
+        below = sum(1 for v in vals if v < threshold)
+        fig.add_trace(
+            go.Scatter(
+                x=grid,
+                y=density,
+                mode="lines",
+                line={"color": "#2c3e50", "width": 2},
+                fill="tozeroy",
+                fillcolor="rgba(44,62,80,0.12)",
+                showlegend=False,
+            ),
+            row=row + 1,
+            col=col + 1,
+        )
+        # Shade the reject region (score < threshold) and mark the threshold line.
+        fig.add_vrect(
+            x0=grid[0],
+            x1=threshold,
+            fillcolor=_REJECT,
+            opacity=0.08,
+            line_width=0,
+            row=row + 1,
+            col=col + 1,
+        )
+        fig.add_vline(
+            x=threshold,
+            line={"color": _REJECT, "width": 1.5, "dash": "dash"},
+            row=row + 1,
+            col=col + 1,
+        )
+        pct = 100 * below / n if n else 0.0
+        fig.layout.annotations[i].text = f"{crit}  (n={n}, <{threshold} = {below} = {pct:.0f}%)"
+    fig.update_layout(
+        title_text=(
+            f"judge-qa score density ({run_id}) - dashed = threshold {threshold}; "
+            "scores quantized to {0,.25,.5,.75,1} (KDE smoothed, bw="
+            f"{_KDE_BANDWIDTH})"
+        ),
+        template="plotly_white",
+        height=720,
+        width=1100,
+    )
+    fig.update_xaxes(title_text="score", range=[-0.05, 1.05])
+    fig.update_yaxes(title_text="density")
+    return fig
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Plot judge-qa score distributions.")
+    parser.add_argument("--id", required=True, help="Pipeline run id (e.g. thesis-run-01).")
+    parser.add_argument("--results-root", default="results", help="Results root dir.")
+    parser.add_argument("--threshold", type=float, default=DEFAULT_THRESHOLD)
+    parser.add_argument("--style", choices=["bars", "density"], default="bars")
+    parser.add_argument(
+        "--out",
+        default=None,
+        help="Output image path (default: results/<id>/analysis/judge_score_<style>.png).",
+    )
+    args = parser.parse_args()
+
+    base = Path(args.results_root) / args.id
+    scores = load_pair_scores(base / "cep" / "outputs")
+    if args.out:
+        out = Path(args.out)
+    else:
+        name = "judge_score_distributions" if args.style == "bars" else "judge_score_density"
+        out = base / "analysis" / f"{name}.png"
+
+    builder = _plot_bars if args.style == "bars" else _plot_density
+    fig = builder(scores, args.threshold, args.id)
 
     out.parent.mkdir(parents=True, exist_ok=True)
     fig.write_image(str(out))

--- a/scripts/plot_judge_score_distributions.py
+++ b/scripts/plot_judge_score_distributions.py
@@ -91,6 +91,60 @@ def _plot_bars(scores: dict, threshold: float, run_id: str) -> go.Figure:
     return fig
 
 
+def _plot_hist(scores: dict, threshold: float, run_id: str) -> go.Figure:
+    """Fine-binned histogram (no smoothing): shows the raw quantized spikes."""
+    fig = make_subplots(
+        rows=2, cols=2, subplot_titles=list(CRITERIA), vertical_spacing=0.16, horizontal_spacing=0.1
+    )
+    for i, crit in enumerate(CRITERIA):
+        vals = _criterion_values(scores, crit)
+        row, col = divmod(i, 2)
+        if not vals:
+            continue
+        fig.add_trace(
+            go.Histogram(
+                x=vals,
+                xbins={"start": -0.0125, "end": 1.0125, "size": 0.025},
+                histnorm="probability density",
+                marker_color="#2c3e50",
+                showlegend=False,
+            ),
+            row=row + 1,
+            col=col + 1,
+        )
+        fig.add_vrect(
+            x0=-0.05,
+            x1=threshold,
+            fillcolor=_REJECT,
+            opacity=0.08,
+            line_width=0,
+            row=row + 1,
+            col=col + 1,
+        )
+        fig.add_vline(
+            x=threshold,
+            line={"color": _REJECT, "width": 1.5, "dash": "dash"},
+            row=row + 1,
+            col=col + 1,
+        )
+        n = len(vals)
+        below = sum(1 for v in vals if v < threshold)
+        pct = 100 * below / n if n else 0.0
+        fig.layout.annotations[i].text = f"{crit}  (n={n}, <{threshold} = {below} = {pct:.0f}%)"
+    fig.update_layout(
+        title_text=(
+            f"judge-qa score histogram ({run_id}) - raw, bin=0.025 (no smoothing); "
+            f"dashed = threshold {threshold}"
+        ),
+        template="plotly_white",
+        height=720,
+        width=1100,
+    )
+    fig.update_xaxes(title_text="score", range=[-0.05, 1.05])
+    fig.update_yaxes(title_text="density")
+    return fig
+
+
 def _plot_density(scores: dict, threshold: float, run_id: str) -> go.Figure:
     grid = np.linspace(-0.05, 1.05, 300)
     fig = make_subplots(
@@ -155,7 +209,7 @@ def main() -> None:
     parser.add_argument("--id", required=True, help="Pipeline run id (e.g. thesis-run-01).")
     parser.add_argument("--results-root", default="results", help="Results root dir.")
     parser.add_argument("--threshold", type=float, default=DEFAULT_THRESHOLD)
-    parser.add_argument("--style", choices=["bars", "density"], default="bars")
+    parser.add_argument("--style", choices=["bars", "density", "hist"], default="bars")
     parser.add_argument(
         "--out",
         default=None,
@@ -165,14 +219,15 @@ def main() -> None:
 
     base = Path(args.results_root) / args.id
     scores = load_pair_scores(base / "cep" / "outputs")
-    if args.out:
-        out = Path(args.out)
-    else:
-        name = "judge_score_distributions" if args.style == "bars" else "judge_score_density"
-        out = base / "analysis" / f"{name}.png"
+    names = {
+        "bars": "judge_score_distributions",
+        "density": "judge_score_density",
+        "hist": "judge_score_hist",
+    }
+    out = Path(args.out) if args.out else base / "analysis" / f"{names[args.style]}.png"
 
-    builder = _plot_bars if args.style == "bars" else _plot_density
-    fig = builder(scores, args.threshold, args.id)
+    builders = {"bars": _plot_bars, "density": _plot_density, "hist": _plot_hist}
+    fig = builders[args.style](scores, args.threshold, args.id)
 
     out.parent.mkdir(parents=True, exist_ok=True)
     fig.write_image(str(out))

--- a/tests/scripts/test_judge_analysis_common.py
+++ b/tests/scripts/test_judge_analysis_common.py
@@ -1,0 +1,45 @@
+"""Tests for the judge-analysis shared helpers.
+
+Guards the load-bearing logic the threshold/cohort tools rest on: a pair is
+approved iff every evaluated criterion meets the threshold, and an unscored /
+errored / criterion-less pair never passes.
+"""
+
+from __future__ import annotations
+
+from scripts._judge_analysis_common import ANCHORS, approved_ids, snap_to_anchor
+
+
+def test_approved_requires_all_criteria_at_threshold() -> None:
+    scores = {
+        "pass": {"faithfulness": 0.75, "bloom_calibration": 1.0},
+        "one_below": {"faithfulness": 0.75, "informativeness": 0.5},
+        "exact": {"faithfulness": 0.625, "bloom_calibration": 0.625},
+    }
+    assert approved_ids(scores, 0.625) == {"pass", "exact"}
+
+
+def test_none_scored_and_empty_never_pass() -> None:
+    scores = {
+        "errored": {"faithfulness": None, "bloom_calibration": 1.0},
+        "empty": {},
+        "ok": {"faithfulness": 1.0},
+    }
+    assert approved_ids(scores, 0.625) == {"ok"}
+
+
+def test_threshold_in_quantization_gap_is_stable() -> None:
+    # Scores are Likert anchors; any threshold in (0.5, 0.75] gives the same set.
+    scores = {
+        "a": {"c": 0.5},
+        "b": {"c": 0.75},
+        "c": {"c": 1.0},
+    }
+    assert approved_ids(scores, 0.625) == approved_ids(scores, 0.7) == {"b", "c"}
+    assert approved_ids(scores, 0.5) == {"a", "b", "c"}
+
+
+def test_snap_to_anchor() -> None:
+    assert snap_to_anchor(0.72) == 0.75
+    assert snap_to_anchor(0.6) == 0.5
+    assert all(snap_to_anchor(a) == a for a in ANCHORS)


### PR DESCRIPTION
## What

Three read-only tools (plus a shared helper and a test) to inspect a completed run's judge-qa verdicts and the RAG judged answers, without re-running any stage. This is possible because the RAG chain was evaluated over every generated CEP pair, so the approved set can be recomputed offline at any threshold.

| Script | Purpose |
|--------|---------|
| `scripts/analyze_judge_thresholds.py` | Cross-arm metric sensitivity to the judge-qa pass threshold + per-criterion score distribution. |
| `scripts/analyze_qa_cohort_rag_outcome.py` | RAG outcome on the just-below-threshold (0.5) cohort vs the approved set, attributed by the criterion that scored 0.5. |
| `scripts/plot_judge_score_distributions.py` | Plotly bar panels per criterion with the threshold marked; exports a static image (`report` extra). |
| `scripts/_judge_analysis_common.py` | Shared loading + approval/threshold logic (DRY). |

## Findings these tools produced (on thesis-run-01)

- **Cross-arm ranking is threshold-invariant** (bm25 > atlas ≈ khop_passage > khop_triple > null across thresholds); hallucination identical. Robustness result for the results chapter.
- **Judge scores are a 5-point Likert** (anchors 0/.25/.5/.75/1); the 0.625 threshold sits in the empty 0.5–0.75 gap, so T=0.625 and T=0.7 give the same set. No continuous near-threshold band.
- **Rejections are driven by informativeness + self_containedness** (~41–43% sub-threshold), not faithfulness/bloom.
- **0.5 cohort is answered as well or better than the approved set** — but this is documented as *descriptive*, not "the judge is too strict": self_containedness=0.5 is confounded (arms retrieve the context) and informativeness=0.5 is orthogonal to answerability (generic questions are simply easier). Higher RAG scores on the excluded cohort confirm the exclusions are well-motivated.

## Usage

Run as modules from the repo root (they import the shared helper):

```
uv run python -m scripts.analyze_judge_thresholds --id thesis-run-01
uv run python -m scripts.analyze_qa_cohort_rag_outcome --id thesis-run-01
uv run --extra report python -m scripts.plot_judge_score_distributions --id thesis-run-01
```

All are parametrized by `--id` / `--results-root`; nothing is hardcoded to a single run.

## Tests / checks

- `tests/scripts/test_judge_analysis_common.py`: locks the approval predicate (all evaluated criteria ≥ threshold; errored/empty never pass) and the quantization-gap stability.
- `pytest tests/scripts tests/shared/rag/analysis`: 61 passed.
- `ruff check` + `ruff format --check`: clean.

The plot script depends on the existing `report` extra (plotly + kaleido); no new project dependency.