### PR TITLE
feat(emic): make the emic-validity judge runnable (rename, scope, concurrency, deploy)

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ Expected output (when implemented): `knowledge_graphs/corpus_graph.graphml`
 |---------|----------|----------|
 | `cep` (`cep-gpu`) | ollama, arandu-cep | CEP QA generation (`generate-cep-qa`) |
 | `judge` (`judge-gpu`) | ollama, arandu-judge | LLM-as-a-Judge (`judge-transcription` / `judge-qa`) |
+| `emic` (`emic-gpu`) | ollama, arandu-emic | Phase D emic-validity judge (`emic-judge`) |
 | `kg` (`kg-gpu`) | ollama, arandu-kg | KG construction (`build-kg`) |
 | `rag` (`rag-gpu` / `rag-cpu`) | ollama, arandu-rag | Phase C RAG evaluation chain |
 | `cpu` | arandu-cpu | Transcription (CPU) |
@@ -212,12 +213,13 @@ sourcing a shared `<step>_common.sh`. Submit with `PIPELINE_ID` set (see
 tupi/draco partition rules):
 
 ```bash
-# Transcription / CEP / Judge / KG / RAG — pick the partition script
+# Transcription / CEP / Judge / KG / RAG / Emic — pick the partition script
 PIPELINE_ID=run-01 sbatch scripts/slurm/transcription/tupi.slurm
 PIPELINE_ID=run-01 sbatch scripts/slurm/cep/tupi.slurm
 PIPELINE_ID=run-01 sbatch scripts/slurm/judge/qa/tupi.slurm
 PIPELINE_ID=run-01 sbatch scripts/slurm/kg/tupi.slurm
 PIPELINE_ID=run-01 sbatch scripts/slurm/rag/retrieve.slurm
+PIPELINE_ID=run-01 sbatch scripts/slurm/emic/tupi.slurm
 ```
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ sourcing a shared `<step>_common.sh`. Submit with `PIPELINE_ID` set (see
 tupi/draco partition rules):
 
 ```bash
-# Transcription / CEP / Judge / KG / RAG / Emic — pick the partition script
+# Transcription / CEP / Judge / KG / RAG / Emic: pick the partition script
 PIPELINE_ID=run-01 sbatch scripts/slurm/transcription/tupi.slurm
 PIPELINE_ID=run-01 sbatch scripts/slurm/cep/tupi.slurm
 PIPELINE_ID=run-01 sbatch scripts/slurm/judge/qa/tupi.slurm

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@
 #   profile (CPU / -gpu)   service          command            image
 #   cep    / cep-gpu       arandu-cep       generate-cep-qa    arandu:latest
 #   judge  / judge-gpu     arandu-judge     judge-*            arandu:latest
+#   emic   / emic-gpu      arandu-emic      emic-judge         arandu:latest
 #   kg     / kg-gpu        arandu-kg        build-kg           arandu-kg:latest (Dockerfile.kg, +extra kg)
 #   rag/rag-gpu/rag-cpu   arandu-rag(-cpu) chunk/retrieve/...  arandu-kg:latest
 #   (transcription uses arandu / arandu-cpu / arandu-rocm, no ollama sidecar)
@@ -221,6 +222,7 @@ services:
       - kg
       - cep
       - judge
+      - emic
       - ollama
 
   # Ollama with GPU support (use --profile ollama-gpu)
@@ -272,6 +274,7 @@ services:
       - kg-gpu
       - cep-gpu
       - judge-gpu
+      - emic-gpu
       - ollama-gpu
       - rag-gpu
 
@@ -329,6 +332,70 @@ services:
     profiles:
       - judge
       - judge-gpu
+
+  # Emic Validity Judge Service (Phase D, spec §5)
+  #
+  # Separate from arandu-judge on purpose: that service forwards ARANDU_JUDGE_*
+  # only, so running emic-judge through it would leave every ARANDU_EMIC_JUDGE_*
+  # setting silently at its default (the *Config classes use extra="ignore").
+  arandu-emic:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: arandu:latest
+    container_name: arandu-emic-${SLURM_JOB_ID:-local}
+    working_dir: /app
+
+    # No GPU needed on this container; the LLM lives in the ollama sidecar.
+    deploy: {}
+
+    depends_on:
+      ollama:
+        condition: service_healthy
+        required: false
+
+    environment:
+      # Emic-judge settings — default to the local Ollama sidecar so Gemini
+      # values that may live in .env (OPENAI_API_KEY / ARANDU_LLM_BASE_URL)
+      # don't leak into SLURM runs.
+      #
+      # MODEL_ID is a methodological parameter, not a budget knob: these scores
+      # are the study's measurement of emic validity and the human annotation
+      # round reports agreement with them, so a run feeding the agreement study
+      # must pin the model the dissertation describes.
+      - ARANDU_EMIC_JUDGE_MODEL_ID=${ARANDU_EMIC_JUDGE_MODEL_ID:-qwen3:14b}
+      - ARANDU_EMIC_JUDGE_PROVIDER=${ARANDU_EMIC_JUDGE_PROVIDER:-ollama}
+      - ARANDU_EMIC_JUDGE_BASE_URL=${ARANDU_EMIC_JUDGE_BASE_URL:-http://ollama:11434/v1}
+      - ARANDU_EMIC_JUDGE_LANGUAGE=${ARANDU_EMIC_JUDGE_LANGUAGE:-pt}
+      - ARANDU_EMIC_JUDGE_TEMPERATURE=${ARANDU_EMIC_JUDGE_TEMPERATURE:-0.1}
+      - ARANDU_EMIC_JUDGE_MAX_TOKENS=${ARANDU_EMIC_JUDGE_MAX_TOKENS:-8192}
+      # Client-side concurrency. Pair with OLLAMA_NUM_PARALLEL and the per-slot
+      # context VRAM budget; scripts/slurm/emic/tupi.slurm derives the server
+      # slots from this value so they cannot drift.
+      - ARANDU_EMIC_JUDGE_WORKERS=${ARANDU_EMIC_JUDGE_WORKERS:-1}
+      - HF_HOME=/app/.cache/huggingface
+      - TRANSFORMERS_CACHE=/app/.cache/huggingface/hub
+
+    # No `command:` block — rely on the image's `ENTRYPOINT ["arandu"]` and the
+    # CMD provided at invocation. The SLURM wrapper uses
+    # `docker compose run arandu-emic emic-judge --id ... --scope ...`.
+
+    volumes:
+      - ${ARANDU_RESULTS_DIR:-./results}:/app/results:rw
+      - ${ARANDU_HF_CACHE_DIR:-./cache/huggingface}:/app/.cache/huggingface:rw
+
+    shm_size: '8gb'
+    restart: "no"
+
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "100m"
+        max-file: "3"
+
+    profiles:
+      - emic
+      - emic-gpu
 
   # CEP QA Generation Service (Cognitive Elicitation Pipeline)
   arandu-cep:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -355,7 +355,7 @@ services:
         required: false
 
     environment:
-      # Emic-judge settings — default to the local Ollama sidecar so Gemini
+      # Emic-judge settings default to the local Ollama sidecar so Gemini
       # values that may live in .env (OPENAI_API_KEY / ARANDU_LLM_BASE_URL)
       # don't leak into SLURM runs.
       #
@@ -369,6 +369,12 @@ services:
       - ARANDU_EMIC_JUDGE_LANGUAGE=${ARANDU_EMIC_JUDGE_LANGUAGE:-pt}
       - ARANDU_EMIC_JUDGE_TEMPERATURE=${ARANDU_EMIC_JUDGE_TEMPERATURE:-0.1}
       - ARANDU_EMIC_JUDGE_MAX_TOKENS=${ARANDU_EMIC_JUDGE_MAX_TOKENS:-8192}
+      # Cloud-provider credentials. emic_common.sh skips the ollama sidecar
+      # when PROVIDER is not ollama, so without these a documented
+      # provider=openai/custom run reaches build_llm_client_from_settings with
+      # no key and dies after the image build and disk preflight.
+      - OPENAI_API_KEY=${OPENAI_API_KEY:-}
+      - ARANDU_EMIC_JUDGE_API_KEY_ENV=${ARANDU_EMIC_JUDGE_API_KEY_ENV:-OPENAI_API_KEY}
       # Client-side concurrency. Pair with OLLAMA_NUM_PARALLEL and the per-slot
       # context VRAM budget; scripts/slurm/emic/tupi.slurm derives the server
       # slots from this value so they cannot drift.
@@ -376,7 +382,7 @@ services:
       - HF_HOME=/app/.cache/huggingface
       - TRANSFORMERS_CACHE=/app/.cache/huggingface/hub
 
-    # No `command:` block — rely on the image's `ENTRYPOINT ["arandu"]` and the
+    # No `command:` block. Relies on the image's `ENTRYPOINT ["arandu"]` and the
     # CMD provided at invocation. The SLURM wrapper uses
     # `docker compose run arandu-emic emic-judge --id ... --scope ...`.
 

--- a/docs/user-guide/cli-reference.md
+++ b/docs/user-guide/cli-reference.md
@@ -9,9 +9,10 @@ Complete reference for all command-line interface commands in Arandu.
 3. [QA Generation Commands](#qa-generation-commands)
 4. [Judging Commands](#judging-commands)
 5. [Knowledge Graph & RAG Commands (Phase C)](#knowledge-graph--rag-commands-phase-c)
-6. [Utilities Commands](#utilities-commands)
-7. [Usage Examples](#usage-examples)
-8. [Common Patterns](#common-patterns)
+6. [Emic Validity Commands (Phase D)](#emic-validity-commands-phase-d)
+7. [Utilities Commands](#utilities-commands)
+8. [Usage Examples](#usage-examples)
+9. [Common Patterns](#common-patterns)
 
 ---
 
@@ -25,7 +26,8 @@ The Arandu CLI is built with [Typer](https://typer.tiangolo.com/) and provides r
 - **Transcription**: `transcribe`, `drive-transcribe`, `batch-transcribe`
 - **QA Generation**: `generate-cep-qa`, `generate-non-answerable`
 - **Judging**: `judge-transcription`, `judge-qa`, `judge-answers`
-- **Knowledge Graph & RAG (Phase C)**: `chunk`, `build-kg`, `kg-link-passages`, `kg-build-retriever-index`, `retrieve`, `answer`, `emic-judge`, `build-human-eval-sample`, `rag-analysis`
+- **Knowledge Graph & RAG (Phase C)**: `chunk`, `build-kg`, `kg-link-passages`, `kg-build-retriever-index`, `retrieve`, `answer`, `rag-analysis`
+- **Emic validity (Phase D)**: `emic-judge`, `build-human-eval-sample`
 - **Utilities**: `refresh-auth`, `enrich-metadata`, `replicate`, `info`, `list-runs`, `run-info`, `rebuild-index`, `report`, `serve-report`
 
 **Global Options**:
@@ -375,8 +377,6 @@ These commands implement the Phase C retrieval-augmented-generation evaluation c
 | `kg-build-retriever-index` | Build the atlas-rag retriever's precomputed index for a run |
 | `retrieve` | Run Phase C retrievers over a populated run |
 | `answer` | Run the Answerer LLM over every `RetrievalRecord` in a populated run |
-| `emic-judge` | Score canonical-approved CEP pairs for emic validity (ordinal 1-5) |
-| `build-human-eval-sample` | Build the stratified human-comparison sample (80 pairs) for a run |
 | `rag-analysis` | Aggregate judged answers and emit `report.json` + `tables.md` |
 
 **Typical Phase C chain**:
@@ -392,6 +392,48 @@ arandu answer project-001
 arandu judge-answers project-001
 arandu rag-analysis project-001
 ```
+
+---
+
+## Emic Validity Commands (Phase D)
+
+These commands implement the emic-validity study (spec §5-§6): score the run's
+QA pairs with the ordinal `emic_validity` criterion, then draw the stratified
+sample the human annotators rate so inter-rater agreement with the judge can be
+reported.
+
+| Command | Description |
+|---------|-------------|
+| `emic-judge` | Score a run's CEP pairs for emic validity (ordinal 1-5) |
+| `build-human-eval-sample` | Build the stratified human-comparison sample for a run |
+
+**The emic score is a measurement, not a filter.** It is what the study
+reports; the human annotation round validates it by agreement rather than
+replacing it. That makes `ARANDU_EMIC_JUDGE_MODEL_ID` a methodological
+parameter (it defines the instrument under test), so a run feeding the
+agreement study must pin the model the dissertation describes. See
+[EmicJudgeSettings](configuration.md#emicjudgesettings).
+
+**`emic-judge` options**:
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--id` | required | Pipeline ID. The `cep` stage must be populated, and judged when `--scope approved` |
+| `--scope` | `all` | `all` scores every pair and records its `judge-qa` verdict, enabling the emic-validity x approval cross-tabulation. `approved` scores only canonically-approved pairs |
+| `--rerun` / `--resume` | `--resume` | `--rerun` discards the checkpoint and re-scores every source |
+
+**Typical Phase D chain**:
+```bash
+# Score the corpus (long-running; on the cluster use scripts/slurm/emic/tupi.slurm)
+arandu emic-judge --id project-001 --scope all
+
+# Draw the stratified sample the annotators rate
+arandu build-human-eval-sample --id project-001 --seed 42
+```
+
+The sample builder keeps its frame on the judge-approved corpus even when
+`emic-judge` scored everything: pairs the judge rejected (or never judged) are
+dropped and counted in the manifest's `excluded_not_approved`.
 
 ---
 

--- a/docs/user-guide/cli-reference.md
+++ b/docs/user-guide/cli-reference.md
@@ -25,7 +25,7 @@ The Arandu CLI is built with [Typer](https://typer.tiangolo.com/) and provides r
 - **Transcription**: `transcribe`, `drive-transcribe`, `batch-transcribe`
 - **QA Generation**: `generate-cep-qa`, `generate-non-answerable`
 - **Judging**: `judge-transcription`, `judge-qa`, `judge-answers`
-- **Knowledge Graph & RAG (Phase C)**: `chunk`, `build-kg`, `kg-link-passages`, `kg-build-retriever-index`, `retrieve`, `answer`, `emic-prepass`, `build-human-eval-sample`, `rag-analysis`
+- **Knowledge Graph & RAG (Phase C)**: `chunk`, `build-kg`, `kg-link-passages`, `kg-build-retriever-index`, `retrieve`, `answer`, `emic-judge`, `build-human-eval-sample`, `rag-analysis`
 - **Utilities**: `refresh-auth`, `enrich-metadata`, `replicate`, `info`, `list-runs`, `run-info`, `rebuild-index`, `report`, `serve-report`
 
 **Global Options**:
@@ -375,7 +375,7 @@ These commands implement the Phase C retrieval-augmented-generation evaluation c
 | `kg-build-retriever-index` | Build the atlas-rag retriever's precomputed index for a run |
 | `retrieve` | Run Phase C retrievers over a populated run |
 | `answer` | Run the Answerer LLM over every `RetrievalRecord` in a populated run |
-| `emic-prepass` | Score canonical-approved CEP pairs for emic validity (ordinal 1-5) |
+| `emic-judge` | Score canonical-approved CEP pairs for emic validity (ordinal 1-5) |
 | `build-human-eval-sample` | Build the stratified human-comparison sample (80 pairs) for a run |
 | `rag-analysis` | Aggregate judged answers and emit `report.json` + `tables.md` |
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -9,11 +9,12 @@ Complete reference for all configuration settings in the Arandu pipeline.
 3. [QAConfig](#qaconfig)
 4. [CEPConfig](#cepconfig)
 5. [JudgeConfig](#judgeconfig)
-6. [KGConfig](#kgconfig)
-7. [LLMConfig](#llmconfig)
-8. [ResultsConfig](#resultsconfig)
-9. [Environment Variables](#environment-variables)
-10. [Configuration Examples](#configuration-examples)
+6. [EmicJudgeSettings](#emicjudgesettings)
+7. [KGConfig](#kgconfig)
+8. [LLMConfig](#llmconfig)
+9. [ResultsConfig](#resultsconfig)
+10. [Environment Variables](#environment-variables)
+11. [Configuration Examples](#configuration-examples)
 
 ---
 
@@ -34,6 +35,7 @@ The Arandu project uses **Pydantic Settings** for configuration management with 
 | `QAConfig` | `arandu.qa.config` | `ARANDU_QA_` |
 | `CEPConfig` | `arandu.qa.config` | `ARANDU_CEP_` |
 | `JudgeConfig` | `arandu.qa.config` | `ARANDU_JUDGE_` |
+| `EmicJudgeSettings` | `arandu.shared.emic.settings` | `ARANDU_EMIC_JUDGE_` |
 | `KGConfig` | `arandu.kg.config` | `ARANDU_KG_` |
 | `LLMConfig` | `arandu.shared.config` | (no prefix; uses aliases like `OPENAI_API_KEY`) |
 | `ResultsConfig` | `arandu.shared.config` | `ARANDU_RESULTS_` |
@@ -263,6 +265,55 @@ config = JudgeConfig()
 # Loaded from ARANDU_JUDGE_* env vars; e.g.
 # ARANDU_JUDGE_VALIDATOR_MODEL=qwen3:14b
 # ARANDU_JUDGE_VALIDATOR_PROVIDER=ollama
+```
+
+---
+
+## EmicJudgeSettings
+
+Configuration for `arandu emic-judge`, the Phase D ordinal emic-validity judge
+(spec §5). A thin subclass of the shared `LLMSettings`, so it inherits the
+canonical connection + sampling fields and overrides only the two defaults the
+emic judgment deliberately changes.
+
+**Module**: `arandu.shared.emic.settings` &nbsp;|&nbsp; **Environment Prefix**: `ARANDU_EMIC_JUDGE_`
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `provider` | `str` | `"ollama"` | LLM provider: "ollama", "openai", or "custom" |
+| `model_id` | `str` | `"qwen3:14b"` | Model identifier. **Methodological parameter** — see the note below |
+| `base_url` | `str \| None` | `None` | Base URL override; required when `provider == "custom"` |
+| `temperature` | `float` | `0.1` | Lower than the other judges: the emic judgment is structural, not creative (spec §4.2 principle 8) |
+| `max_tokens` | `int` | `8192` | Response budget. qwen3 burns thinking tokens against it |
+| `language` | `"pt"` | `"pt"` | Narrowed to `pt` — the only `emic_validity` prompt template that ships today |
+| `workers` | `int` | `1` | Client-side concurrent LLM requests, honoured via `map_concurrent` |
+
+**The model is not a budget knob.** The scores this stage produces are the
+study's measurement of emic validity; the human annotation round (spec §6)
+reports agreement with them rather than replacing them. Changing
+`ARANDU_EMIC_JUDGE_MODEL_ID` changes the instrument under test, so a run feeding
+the agreement study must pin the model the dissertation describes.
+
+**Scope.** `--scope all` (default) scores every CEP pair and records its
+`judge-qa` verdict on each score, which is what allows emic validity to be
+cross-tabulated against approval. `--scope approved` scores only
+canonically-approved pairs. The stratified human-comparison sample keeps its
+frame on the approved corpus either way.
+
+**Concurrency.** `workers` must be paired with server-side slots
+(`OLLAMA_NUM_PARALLEL`) and the per-slot context VRAM budget;
+`scripts/slurm/emic/tupi.slurm` derives the slots from the worker count so the
+two cannot drift. Note that a rate-limited call becomes a null score rather than
+being backed off and retried (`JudgeCriterion.evaluate` converts failures into
+error scores before the batch-level throttle can see them), so raise `workers`
+carefully against a metered provider.
+
+**Example Configuration**:
+```bash
+# Loaded from ARANDU_EMIC_JUDGE_* env vars; e.g.
+ARANDU_EMIC_JUDGE_MODEL_ID=qwen3:14b
+ARANDU_EMIC_JUDGE_PROVIDER=ollama
+ARANDU_EMIC_JUDGE_WORKERS=4
 ```
 
 ---

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -281,11 +281,11 @@ emic judgment deliberately changes.
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
 | `provider` | `str` | `"ollama"` | LLM provider: "ollama", "openai", or "custom" |
-| `model_id` | `str` | `"qwen3:14b"` | Model identifier. **Methodological parameter** — see the note below |
+| `model_id` | `str` | `"qwen3:14b"` | Model identifier. **Methodological parameter**: see the note below |
 | `base_url` | `str \| None` | `None` | Base URL override; required when `provider == "custom"` |
 | `temperature` | `float` | `0.1` | Lower than the other judges: the emic judgment is structural, not creative (spec §4.2 principle 8) |
 | `max_tokens` | `int` | `8192` | Response budget. qwen3 burns thinking tokens against it |
-| `language` | `"pt"` | `"pt"` | Narrowed to `pt` — the only `emic_validity` prompt template that ships today |
+| `language` | `"pt"` | `"pt"` | Narrowed to `pt`, the only `emic_validity` prompt template that ships today |
 | `workers` | `int` | `1` | Client-side concurrent LLM requests, honoured via `map_concurrent` |
 
 **The model is not a budget knob.** The scores this stage produces are the

--- a/scripts/slurm/AGENTS.md
+++ b/scripts/slurm/AGENTS.md
@@ -69,8 +69,17 @@ needed admin intervention). `scripts/slurm/container_teardown.sh` holds the
 shared fix; it only works when BOTH pieces are present: the stage command runs
 in the background and is `wait`-ed on (bash defers traps during a foreground
 external command), and the partition script carries
-`#SBATCH --signal=B:TERM@60`. Adopted by `rag/` (its own inlined copy, PR #152)
-and `emic/`. **`judge/`, `cep/` and `kg/` still lack it** and can still orphan.
+`#SBATCH --signal=B:TERM@60`. Sourced by `rag/` and `emic/`. **`judge/`, `cep/`
+and `kg/` still lack it** and can still orphan. A deploy that ships a
+`<step>_common.sh` without `container_teardown.sh` now aborts the job rather
+than running untrapped.
+
+**Compose project isolation.** Jobs share one compose project (named after the
+deploy directory) unless `COMPOSE_PROJECT_NAME` is set, and the ollama sidecars
+are listed under several profiles. So a `down --profile <x>` can stop a
+co-located job's sidecar, whose calls then fail into null results that its own
+checkpoint records as done. `emic/` scopes the project to the job id; the other
+steps do not yet.
 
 ## Submitting
 
@@ -94,7 +103,7 @@ PIPELINE_ID=<run-id> [overrides] sbatch [--exclude=<nodes>] scripts/slurm/<step>
 
 - **tupi** — the ONLY GPU partition we can use. Every GPU/ollama stage
   (build-kg, cep, judge-qa, emic-judge, answer, judge-answers, atlas_rag
-  retrieve) runs here. Frequently saturated by other users; when it is, **wait** — there is
+  retrieve) runs here. Frequently saturated by other users; when it is, **wait**: there is
   no faster GPU alternative for this account.
 - **draco** — **CPU-only, no GPU.** Idle and fast to schedule; use it for
   CPU-only work (root-container result prep, the khop retrieve, rag-analysis,

--- a/scripts/slurm/AGENTS.md
+++ b/scripts/slurm/AGENTS.md
@@ -19,6 +19,7 @@ env and writes `results/<id>/<stage>/outputs/`.
 | Transcription | `batch-transcribe` | `TranscriberConfig` · `ARANDU_` | `arandu` / `arandu-cpu` / `arandu-rocm` | (runtime GPU) | `arandu:latest` · `Dockerfile`; `arandu:rocm` · `Dockerfile.rocm` | `transcription/` |
 | CEP (QA) | `generate-cep-qa` | `QAConfig` + `CEPConfig` · `ARANDU_QA_`, `ARANDU_CEP_` | `arandu-cep` | `cep` / `cep-gpu` | `arandu:latest` · `Dockerfile` | `cep/` |
 | Judge | `judge-transcription`, `judge-qa` | `JudgeConfig` (+ `CEPConfig` weights) · `ARANDU_JUDGE_` | `arandu-judge` | `judge` / `judge-gpu` | `arandu:latest` · `Dockerfile` | `judge/{transcription,qa}/` |
+| Emic judge (Phase D) | `emic-judge` | `EmicJudgeSettings` · `ARANDU_EMIC_JUDGE_` | `arandu-emic` | `emic` / `emic-gpu` | `arandu:latest` · `Dockerfile` | `emic/` |
 | KG | `build-kg`, `kg-link-passages`, `kg-build-retriever-index` | `KGConfig` · `ARANDU_KG_` | `arandu-kg` | `kg` / `kg-gpu` | `arandu-kg:latest` · `Dockerfile.kg` | `kg/` |
 | RAG (Phase C) | `chunk`, `retrieve`, `answer`, `judge-answers`, `generate-non-answerable`, `rag-analysis` | rag settings + `RAG_*` runner vars | `arandu-rag` / `arandu-rag-cpu` | `rag` / `rag-gpu` / `rag-cpu` | `arandu-kg:latest` · `Dockerfile.kg` | `rag/` |
 
@@ -50,6 +51,8 @@ config field, so it did nothing — CEP-pair validation lives in the separate
 | ---- | ---- |
 | `transcription/<partition>.slurm` + `job_common.sh` | Whisper transcription (GPU) |
 | `cep/`, `judge/` + `*_common.sh` | CEP QA generation and LLM judges |
+| `emic/<partition>.slurm` + `emic_common.sh` | Phase D ordinal emic-validity judge |
+| `container_teardown.sh` | Shared SIGTERM/EXIT trap that stops containers on TIMEOUT/scancel |
 | `kg/<partition>.slurm` + `kg_common.sh` | atlas-rag KG construction (extraction + concept gen) |
 | `rag/<stage>.slurm` + `rag_common.sh` | Phase C eval chain (chunk, link-passages, retriever-index, non-answerable, retrieve, answer, judge-answers, rag-analysis) |
 | `general/cleanup.slurm`, `kg/pipeline-cleanup.slurm` | Docker/disk cleanup jobs |
@@ -58,6 +61,16 @@ config field, so it did nothing — CEP-pair validation lives in the separate
 The `rag/` per-stage scripts set `RAG_CLI_ARGS` (the `arandu` subcommand) and
 `RAG_NEEDS_OLLAMA`, then source `rag_common.sh`. CPU-only stages override
 `RAG_SERVICE=arandu-rag-cpu` / `RAG_PROFILE=rag-cpu` to avoid GPU contention.
+
+**Orphan containers on TIMEOUT.** Containers are owned by the docker daemon,
+not by the job's process tree, so a TIME LIMIT or `scancel` kills the shell and
+leaves them running on the node (observed: judge-answers 799024 on tupi2, which
+needed admin intervention). `scripts/slurm/container_teardown.sh` holds the
+shared fix; it only works when BOTH pieces are present: the stage command runs
+in the background and is `wait`-ed on (bash defers traps during a foreground
+external command), and the partition script carries
+`#SBATCH --signal=B:TERM@60`. Adopted by `rag/` (its own inlined copy, PR #152)
+and `emic/`. **`judge/`, `cep/` and `kg/` still lack it** and can still orphan.
 
 ## Submitting
 
@@ -71,14 +84,17 @@ PIPELINE_ID=<run-id> [overrides] sbatch [--exclude=<nodes>] scripts/slurm/<step>
 | `ARANDU_KG_MODEL_ID` | `llama3.1:8b` | Override for non-default models (e.g. `qwen3:14b`) |
 | `RAG_OLLAMA_MODEL` | `qwen3:14b` | Model pulled by `rag_common.sh` LLM stages |
 | `JUDGE_REJUDGE` | unset | Force re-judge instead of resume |
+| `EMIC_SCOPE` | `all` | `all` scores every CEP pair and records its judge-qa verdict; `approved` scores only approved ones |
+| `EMIC_RERUN` | `0` | Discard the emic checkpoint and re-score every source |
+| `ARANDU_EMIC_JUDGE_WORKERS` | 4 (tupi script) | Client-side concurrency; `OLLAMA_NUM_PARALLEL` follows it unless overridden |
 | `MIN_DISK_GB` | 15 | Disk-floor preflight on the Docker root partition |
 | `USE_GPU_OLLAMA` | set by partition script | Selects `kg-gpu` vs `kg` compose profile |
 
 ## Partitions: access + GPU (confirmed 2026-06-15 — do NOT re-test)
 
 - **tupi** — the ONLY GPU partition we can use. Every GPU/ollama stage
-  (build-kg, cep, judge-qa, answer, judge-answers, atlas_rag retrieve) runs
-  here. Frequently saturated by other users; when it is, **wait** — there is
+  (build-kg, cep, judge-qa, emic-judge, answer, judge-answers, atlas_rag
+  retrieve) runs here. Frequently saturated by other users; when it is, **wait** — there is
   no faster GPU alternative for this account.
 - **draco** — **CPU-only, no GPU.** Idle and fast to schedule; use it for
   CPU-only work (root-container result prep, the khop retrieve, rag-analysis,

--- a/scripts/slurm/container_teardown.sh
+++ b/scripts/slurm/container_teardown.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# =============================================================================
+# Shared container-teardown trap for SLURM job scripts.
+#
+# Source this from a `<step>_common.sh`, then call `arandu_arm_teardown_traps`
+# once, just before the first container starts.
+#
+# WHY THIS EXISTS
+#
+# Containers started with `docker compose run` / `up` are owned by the docker
+# daemon, NOT by the job step's process tree. When SLURM ends a job WITHOUT a
+# clean script exit (a TIME LIMIT timeout or an `scancel`), it kills the shell
+# before any normal teardown runs and the containers keep going on the node as
+# ORPHANS: still holding the GPU, still writing outputs, outside any
+# allocation, contending with whatever SLURM schedules next. Observed with
+# judge-answers 799024, whose TIMEOUT left `ollama-gpu-<jobid>` and
+# `<project>-arandu-rag-run-*` alive on tupi2 and degraded another user's job;
+# it could not be killed from the head node (ssh is blocked by
+# pam_slurm_adopt) and needed admin intervention.
+#
+# TWO THINGS ARE REQUIRED for the trap to actually fire in time:
+#
+#   1. The stage command must run in the BACKGROUND and be `wait`-ed on. bash
+#      does NOT run a trap while a foreground external command executes; it
+#      defers it until that command returns. A foreground `docker compose run`
+#      would therefore defer teardown until the container exits, i.e. never on
+#      a real timeout. `wait` is interruptible, so backgrounding + `wait` lets
+#      the SIGTERM/SIGINT handler run immediately:
+#
+#          docker compose ... run --rm "$SERVICE" $ARGS &
+#          RUN_PID=$!
+#          wait "$RUN_PID"
+#          RUN_RC=$?
+#
+#   2. The partition script must carry `#SBATCH --signal=B:TERM@60` so SLURM
+#      sends SIGTERM to the batch shell 60s before the limit, well inside
+#      KillWait.
+#
+# Arm the traps LATE (after validation and image build, just before the first
+# container starts) so an early `exit 1` does not run `docker compose down`
+# while this job has nothing up, which could disturb a co-located job sharing
+# the compose project.
+#
+# Required variables at teardown time: COMPOSE_FILE, DOCKER_PROFILE.
+#
+# Extracted from scripts/slurm/rag/rag_common.sh (PR #152), which still carries
+# its own copy; see the tracking task on unifying the remaining common scripts.
+# =============================================================================
+
+arandu_teardown_containers() {
+    echo ""
+    echo "[cleanup] tearing down containers (profile ${DOCKER_PROFILE})..."
+    docker compose -f "$COMPOSE_FILE" --profile "$DOCKER_PROFILE" \
+        down --remove-orphans --timeout 10 2>/dev/null || true
+}
+
+# $1 = signal name (for the log), $2 = exit code.
+arandu_on_teardown_signal() {
+    # Ignore further INT/TERM while tearing down (a scancel retry or a short
+    # KillWait must not kill the shell mid-`down`) and disarm EXIT so teardown
+    # runs exactly once.
+    trap '' INT TERM
+    trap - EXIT
+    echo ""
+    echo "[cleanup] caught ${1} (SLURM timeout/scancel); tearing down..."
+    arandu_teardown_containers
+    exit "${2}"
+}
+
+arandu_arm_teardown_traps() {
+    trap arandu_teardown_containers EXIT
+    trap 'arandu_on_teardown_signal SIGINT 130' INT   # 128 + SIGINT(2)
+    trap 'arandu_on_teardown_signal SIGTERM 143' TERM # 128 + SIGTERM(15)
+}

--- a/scripts/slurm/container_teardown.sh
+++ b/scripts/slurm/container_teardown.sh
@@ -43,8 +43,9 @@
 #
 # Required variables at teardown time: COMPOSE_FILE, DOCKER_PROFILE.
 #
-# Extracted from scripts/slurm/rag/rag_common.sh (PR #152), which still carries
-# its own copy; see the tracking task on unifying the remaining common scripts.
+# Extracted from scripts/slurm/rag/rag_common.sh (PR #152), which now sources
+# this file. judge/, cep/ and kg/ still have no teardown at all and can still
+# orphan containers on TIMEOUT; adopting it there is tracked separately.
 # =============================================================================
 
 arandu_teardown_containers() {

--- a/scripts/slurm/emic/emic_common.sh
+++ b/scripts/slurm/emic/emic_common.sh
@@ -1,0 +1,217 @@
+#!/bin/bash
+# =============================================================================
+# Arandu Emic Judge Common Job Script
+#
+# Shared logic for the `arandu emic-judge` SLURM scripts. Source this from a
+# partition-specific script; do not run directly.
+#
+# Runs the ordinal `emic_validity` criterion over the CEP pairs of a run and
+# writes per-source scores to results/$PIPELINE_ID/emic_judge/outputs/.
+#
+# Required environment variables:
+#   PIPELINE_ID                    - Pipeline directory under results/
+#
+# Optional environment variables:
+#   EMIC_SCOPE                     - all (default) | approved
+#   EMIC_RERUN                     - 1 to discard the checkpoint and re-score
+#   ARANDU_EMIC_JUDGE_MODEL_ID     - Model (default: qwen3:14b)
+#   ARANDU_EMIC_JUDGE_PROVIDER     - Provider (default: ollama)
+#   ARANDU_EMIC_JUDGE_BASE_URL     - Base URL (default: sidecar URL)
+#   ARANDU_EMIC_JUDGE_TEMPERATURE  - Sampling temperature (default: 0.1)
+#   ARANDU_EMIC_JUDGE_WORKERS      - Client-side concurrency (default: 4)
+#   USE_GPU_OLLAMA                 - "true" for the ollama-gpu sidecar
+# =============================================================================
+
+set -euo pipefail
+
+PROJECT_DIR="${PROJECT_DIR:-$HOME/etno-kgc-preprocessing}"
+
+# LLM settings — default to the local Ollama sidecar. Setting these explicitly
+# shields the job from whatever lives in the repo's .env (which may point
+# OPENAI_API_KEY / ARANDU_LLM_BASE_URL at a cloud provider).
+#
+# NOTE: the model is a METHODOLOGICAL parameter here, not a budget knob. These
+# scores are the study's measurement of emic validity and the human annotation
+# round reports agreement with them, so a run feeding the agreement study must
+# pin the same model the dissertation describes. Do not swap it to "go faster".
+export ARANDU_EMIC_JUDGE_MODEL_ID="${ARANDU_EMIC_JUDGE_MODEL_ID:-qwen3:14b}"
+export ARANDU_EMIC_JUDGE_PROVIDER="${ARANDU_EMIC_JUDGE_PROVIDER:-ollama}"
+export ARANDU_EMIC_JUDGE_BASE_URL="${ARANDU_EMIC_JUDGE_BASE_URL:-http://ollama:11434/v1}"
+export ARANDU_EMIC_JUDGE_TEMPERATURE="${ARANDU_EMIC_JUDGE_TEMPERATURE:-0.1}"
+export ARANDU_EMIC_JUDGE_LANGUAGE="${ARANDU_EMIC_JUDGE_LANGUAGE:-pt}"
+
+# Scope. "all" (the default, and the decided methodology) scores every pair and
+# records its judge-qa verdict, enabling the emic-validity x approval
+# cross-tabulation. "approved" scores only canonically-approved pairs.
+EMIC_SCOPE="${EMIC_SCOPE:-all}"
+case "$EMIC_SCOPE" in
+    all|approved) ;;
+    *)
+        echo "Error: EMIC_SCOPE must be 'all' or 'approved' (got '$EMIC_SCOPE')" >&2
+        exit 1
+        ;;
+esac
+
+# Resume vs rerun. Default resumes: sources already checkpointed are skipped,
+# so a re-submission after a wall hit only scores the remainder.
+EMIC_RERUN="${EMIC_RERUN:-0}"
+case "${EMIC_RERUN,,}" in
+    1|true|yes|on) EMIC_RERUN_FLAG="--rerun" ;;
+    0|false|no|off|"") EMIC_RERUN_FLAG="--resume" ;;
+    *)
+        echo "Error: EMIC_RERUN must be 0/1, true/false, yes/no, or on/off (got '$EMIC_RERUN')" >&2
+        exit 1
+        ;;
+esac
+
+USE_GPU_OLLAMA="${USE_GPU_OLLAMA:-false}"
+
+export ARANDU_RESULTS_DIR="${ARANDU_RESULTS_DIR:-$PROJECT_DIR/results}"
+export ARANDU_HF_CACHE_DIR="${ARANDU_HF_CACHE_DIR:-$PROJECT_DIR/cache/huggingface}"
+export OLLAMA_MODELS_DIR="${OLLAMA_MODELS_DIR:-$PROJECT_DIR/cache/ollama}"
+
+: "${PIPELINE_ID:?PIPELINE_ID env var is required (e.g. 'PIPELINE_ID=thesis-run-01 sbatch ...')}"
+export PIPELINE_ID
+
+INPUT_DIR_HOST="$ARANDU_RESULTS_DIR/$PIPELINE_ID/cep/outputs"
+OUTPUT_DIR_HOST="$ARANDU_RESULTS_DIR/$PIPELINE_ID/emic_judge/outputs"
+
+EMIC_CMD=(
+    "emic-judge"
+    "--id" "$PIPELINE_ID"
+    "--scope" "$EMIC_SCOPE"
+    "$EMIC_RERUN_FLAG"
+)
+
+echo "=============================================="
+echo "Arandu Emic Judge Job Started"
+echo "=============================================="
+echo "Job ID:         ${SLURM_JOB_ID:-local}"
+echo "Job Name:       ${SLURM_JOB_NAME:-arandu-emic}"
+echo "Partition:      ${SLURM_JOB_PARTITION:-N/A}"
+echo "Node:           $(hostname)"
+echo "Start Time:     $(date)"
+echo "Pipeline ID:    $PIPELINE_ID"
+echo "=============================================="
+echo "Scope:          $EMIC_SCOPE"
+echo "Mode:           ${EMIC_RERUN_FLAG#--}"
+echo "Model:          $ARANDU_EMIC_JUDGE_MODEL_ID"
+echo "Provider:       $ARANDU_EMIC_JUDGE_PROVIDER"
+echo "Base URL:       $ARANDU_EMIC_JUDGE_BASE_URL"
+echo "Temperature:    $ARANDU_EMIC_JUDGE_TEMPERATURE"
+echo "Workers:        ${ARANDU_EMIC_JUDGE_WORKERS:-<default>}"
+echo "Ollama slots:   ${OLLAMA_NUM_PARALLEL:-<compose default>}"
+echo "Ollama ctx:     ${OLLAMA_CONTEXT_LENGTH:-<compose default>}"
+echo "Ollama GPU:     $USE_GPU_OLLAMA"
+echo "Input Dir:      $INPUT_DIR_HOST"
+echo "Output Dir:     $OUTPUT_DIR_HOST"
+echo "=============================================="
+
+cd "$PROJECT_DIR"
+
+if [ ! -d "$INPUT_DIR_HOST" ]; then
+    echo "Error: CEP outputs not found at $INPUT_DIR_HOST" >&2
+    echo "       Run generate-cep-qa (and judge-qa) for '$PIPELINE_ID' first." >&2
+    exit 1
+fi
+
+mkdir -p "$OLLAMA_MODELS_DIR" "$ARANDU_HF_CACHE_DIR" logs
+
+export SLURM_JOB_ID="${SLURM_JOB_ID:-local}"
+
+if [ "$USE_GPU_OLLAMA" = "true" ]; then
+    DOCKER_PROFILE="emic-gpu"
+    OLLAMA_SERVICE="ollama-gpu"
+else
+    DOCKER_PROFILE="emic"
+    OLLAMA_SERVICE="ollama"
+fi
+
+COMPOSE_FILE="$PROJECT_DIR/docker-compose.yml"
+
+# shellcheck source=scripts/slurm/container_teardown.sh
+source "${SLURM_SUBMIT_DIR:-$PROJECT_DIR}/scripts/slurm/container_teardown.sh"
+
+# ---------------------------------------------------------------------------
+# Disk preflight + cleanup (mirrors rag_common.sh; cluster nodes fill up)
+# ---------------------------------------------------------------------------
+echo ""
+echo "Pruning unused Docker data to free disk space..."
+docker compose -f "$COMPOSE_FILE" --profile "$DOCKER_PROFILE" down --remove-orphans 2>/dev/null || true
+docker builder prune -af 2>/dev/null || true
+docker image prune -af 2>/dev/null || true
+find "$OLLAMA_MODELS_DIR" -name "*-partial" -delete 2>/dev/null || true
+find "$OLLAMA_MODELS_DIR" -name "*.tmp" -delete 2>/dev/null || true
+
+MIN_DISK_GB=${MIN_DISK_GB:-15}
+DOCKER_ROOT=$(docker info --format '{{.DockerRootDir}}' 2>/dev/null || true)
+[ -d "$DOCKER_ROOT" ] || DOCKER_ROOT=/var/lib/docker
+AVAIL_KB=$(df --output=avail "$DOCKER_ROOT" 2>/dev/null | tail -1 | tr -d ' ' || true)
+AVAIL_GB=$(( ${AVAIL_KB:-0} / 1024 / 1024 ))
+echo "Docker storage: $DOCKER_ROOT — ${AVAIL_GB} GB available (min ${MIN_DISK_GB})"
+if [ "${AVAIL_KB:-0}" -gt 0 ] && [ "$AVAIL_GB" -lt "$MIN_DISK_GB" ]; then
+    echo "ERROR: not enough disk on $DOCKER_ROOT (${AVAIL_GB} GB < ${MIN_DISK_GB} GB)." >&2
+    exit 1
+fi
+
+echo ""
+echo "Building arandu-emic image..."
+docker compose -f "$COMPOSE_FILE" --profile "$DOCKER_PROFILE" build arandu-emic
+
+# From here on containers get started, so arm the teardown traps. (Kept out of
+# the validation/build path above so a pre-container `exit 1` cannot run
+# `docker compose down` when this job has nothing up.)
+arandu_arm_teardown_traps
+
+if [ "$ARANDU_EMIC_JUDGE_PROVIDER" = "ollama" ]; then
+    echo ""
+    echo "Starting Ollama sidecar ($OLLAMA_SERVICE)..."
+    docker compose -f "$COMPOSE_FILE" --profile "$DOCKER_PROFILE" up -d "$OLLAMA_SERVICE"
+
+    OLLAMA_READY=false
+    for i in {1..30}; do
+        if docker compose -f "$COMPOSE_FILE" exec -T "$OLLAMA_SERVICE" ollama list &>/dev/null; then
+            OLLAMA_READY=true
+            break
+        fi
+        echo "  Waiting for Ollama... ($i/30)"
+        sleep 5
+    done
+    if [ "$OLLAMA_READY" = false ]; then
+        echo "ERROR: Ollama failed to start after 30 attempts" >&2
+        exit 1
+    fi
+
+    echo "Pulling model: $ARANDU_EMIC_JUDGE_MODEL_ID"
+    docker compose -f "$COMPOSE_FILE" exec -T "$OLLAMA_SERVICE" \
+        ollama pull "$ARANDU_EMIC_JUDGE_MODEL_ID"
+fi
+
+echo ""
+echo "Running: arandu ${EMIC_CMD[*]}"
+echo "=============================================="
+# Background + `wait` (not foreground): bash defers signal traps until a
+# foreground external command returns, so a foreground run would keep the
+# SIGTERM teardown from firing until the container exits (never, on a real
+# timeout). See scripts/slurm/container_teardown.sh.
+set +e
+docker compose -f "$COMPOSE_FILE" --profile "$DOCKER_PROFILE" \
+    run --rm arandu-emic "${EMIC_CMD[@]}" &
+RUN_PID=$!
+wait "$RUN_PID"
+EMIC_EXIT=$?
+set -e
+
+echo "=============================================="
+echo "Arandu Emic Judge Job Completed"
+echo "=============================================="
+echo "End Time:       $(date)"
+echo "Scope:          $EMIC_SCOPE"
+echo "Scores in:      $OUTPUT_DIR_HOST"
+echo "Exit Code:      $EMIC_EXIT"
+echo "=============================================="
+# Container teardown is handled by the EXIT trap armed above, so it runs here on
+# normal exit AND on a SLURM SIGTERM (timeout/scancel). Do not add a manual
+# `docker compose down`; it would just double-run the trap.
+
+exit $EMIC_EXIT

--- a/scripts/slurm/emic/emic_common.sh
+++ b/scripts/slurm/emic/emic_common.sh
@@ -26,7 +26,7 @@ set -euo pipefail
 
 PROJECT_DIR="${PROJECT_DIR:-$HOME/etno-kgc-preprocessing}"
 
-# LLM settings — default to the local Ollama sidecar. Setting these explicitly
+# LLM settings default to the local Ollama sidecar. Setting these explicitly
 # shields the job from whatever lives in the repo's .env (which may point
 # OPENAI_API_KEY / ARANDU_LLM_BASE_URL at a cloud provider).
 #
@@ -72,6 +72,20 @@ export OLLAMA_MODELS_DIR="${OLLAMA_MODELS_DIR:-$PROJECT_DIR/cache/ollama}"
 
 : "${PIPELINE_ID:?PIPELINE_ID env var is required (e.g. 'PIPELINE_ID=thesis-run-01 sbatch ...')}"
 export PIPELINE_ID
+# Isolate this job's compose project.
+#
+# Without this every arandu job on the node shares one project (named after the
+# deploy directory), so `docker compose --profile emic-gpu down` reaches any
+# service in that project matching the profile. The ollama sidecars are listed
+# under the emic profiles, so an emic job starting or finishing next to a live
+# judge-qa job on the same tupi node would stop that job's sidecar: its
+# remaining LLM calls turn into null scores, and its checkpoint records them as
+# done, so its own --resume never retries them.
+#
+# Scoping the project to the job id makes teardown affect only our containers.
+# The stage container and its sidecar share this value, so `depends_on` and the
+# internal network still resolve.
+export COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-arandu-emic-${SLURM_JOB_ID:-local}}"
 
 INPUT_DIR_HOST="$ARANDU_RESULTS_DIR/$PIPELINE_ID/cep/outputs"
 OUTPUT_DIR_HOST="$ARANDU_RESULTS_DIR/$PIPELINE_ID/emic_judge/outputs"
@@ -103,6 +117,7 @@ echo "Workers:        ${ARANDU_EMIC_JUDGE_WORKERS:-<default>}"
 echo "Ollama slots:   ${OLLAMA_NUM_PARALLEL:-<compose default>}"
 echo "Ollama ctx:     ${OLLAMA_CONTEXT_LENGTH:-<compose default>}"
 echo "Ollama GPU:     $USE_GPU_OLLAMA"
+echo "Compose proj:   $COMPOSE_PROJECT_NAME"
 echo "Input Dir:      $INPUT_DIR_HOST"
 echo "Output Dir:     $OUTPUT_DIR_HOST"
 echo "=============================================="
@@ -129,8 +144,18 @@ fi
 
 COMPOSE_FILE="$PROJECT_DIR/docker-compose.yml"
 
+
+# Deploy note: rsyncing this file without container_teardown.sh leaves the job
+# unable to start, which is the intended failure. Silently losing the trap would
+# mean orphaned GPU containers on the node.
+TEARDOWN_LIB="${SLURM_SUBMIT_DIR:-$PROJECT_DIR}/scripts/slurm/container_teardown.sh"
+if [ ! -f "$TEARDOWN_LIB" ]; then
+    echo "ERROR: $TEARDOWN_LIB not found; refusing to run without the teardown trap." >&2
+    echo "       Deploy scripts/slurm/container_teardown.sh alongside this script." >&2
+    exit 1
+fi
 # shellcheck source=scripts/slurm/container_teardown.sh
-source "${SLURM_SUBMIT_DIR:-$PROJECT_DIR}/scripts/slurm/container_teardown.sh"
+source "$TEARDOWN_LIB"
 
 # ---------------------------------------------------------------------------
 # Disk preflight + cleanup (mirrors rag_common.sh; cluster nodes fill up)
@@ -148,7 +173,7 @@ DOCKER_ROOT=$(docker info --format '{{.DockerRootDir}}' 2>/dev/null || true)
 [ -d "$DOCKER_ROOT" ] || DOCKER_ROOT=/var/lib/docker
 AVAIL_KB=$(df --output=avail "$DOCKER_ROOT" 2>/dev/null | tail -1 | tr -d ' ' || true)
 AVAIL_GB=$(( ${AVAIL_KB:-0} / 1024 / 1024 ))
-echo "Docker storage: $DOCKER_ROOT — ${AVAIL_GB} GB available (min ${MIN_DISK_GB})"
+echo "Docker storage: $DOCKER_ROOT: ${AVAIL_GB} GB available (min ${MIN_DISK_GB})"
 if [ "${AVAIL_KB:-0}" -gt 0 ] && [ "$AVAIL_GB" -lt "$MIN_DISK_GB" ]; then
     echo "ERROR: not enough disk on $DOCKER_ROOT (${AVAIL_GB} GB < ${MIN_DISK_GB} GB)." >&2
     exit 1

--- a/scripts/slurm/emic/tupi.slurm
+++ b/scripts/slurm/emic/tupi.slurm
@@ -14,7 +14,7 @@
 #SBATCH --signal=B:TERM@60
 
 # =============================================================================
-# Arandu Emic Judge — TUPI Partition
+# Arandu Emic Judge on the TUPI Partition
 #
 # Scores the CEP pairs of a run with the ordinal `emic_validity` criterion
 # (qwen3:14b on the GPU-accelerated Ollama sidecar) and writes per-source
@@ -46,7 +46,7 @@ export USE_GPU_OLLAMA=true
 # the template is ~7.5 KB (~2k tokens pt), the segment is one `cep_4k` chunk
 # (RecursiveChunker chunk_size=4000, so <=4k tokens), Q+A add a few hundred.
 # Input ceiling ~6.5k tokens; the response budget is max_tokens=8192
-# (REASONING_MODEL_MAX_TOKENS — qwen3 burns thinking tokens against it). So
+# (REASONING_MODEL_MAX_TOKENS; qwen3 burns thinking tokens against it). So
 # ~15k is the working ceiling and 16384 leaves headroom.
 #
 # 4 x 16384 ~ 9.8 GB KV + ~9.3 GB weights ~ 19 GB, inside the envelope

--- a/scripts/slurm/emic/tupi.slurm
+++ b/scripts/slurm/emic/tupi.slurm
@@ -1,0 +1,62 @@
+#!/bin/bash
+#SBATCH --job-name=arandu-emic-judge
+#SBATCH --partition=tupi
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=8
+#SBATCH --gres=gpu:1
+#SBATCH --time=24:00:00
+#SBATCH --output=logs/emic_judge_tupi_%j.out
+#SBATCH --error=logs/emic_judge_tupi_%j.err
+# Send SIGTERM to the batch shell 60s before the time limit so the teardown
+# trap can stop the docker containers before SLURM's SIGKILL (prevents orphaned
+# ollama-gpu / arandu-emic-run containers; see scripts/slurm/container_teardown.sh).
+#SBATCH --signal=B:TERM@60
+
+# =============================================================================
+# Arandu Emic Judge — TUPI Partition
+#
+# Scores the CEP pairs of a run with the ordinal `emic_validity` criterion
+# (qwen3:14b on the GPU-accelerated Ollama sidecar) and writes per-source
+# scores to results/$PIPELINE_ID/emic_judge/outputs/.
+#
+# These scores are the study's MEASUREMENT of emic validity; the human
+# annotation round (spec §6) reports agreement with them. The model is
+# therefore a methodological parameter, not a budget knob.
+#
+# Usage:
+#     # Default: scope=all, resume from the checkpoint
+#     PIPELINE_ID=thesis-run-01 sbatch scripts/slurm/emic/tupi.slurm
+#
+#     # Only canonically-approved pairs (cheaper, no cross-tabulation)
+#     PIPELINE_ID=thesis-run-01 EMIC_SCOPE=approved \
+#         sbatch scripts/slurm/emic/tupi.slurm
+#
+#     # Discard the checkpoint and re-score every source
+#     PIPELINE_ID=thesis-run-01 EMIC_RERUN=1 \
+#         sbatch scripts/slurm/emic/tupi.slurm
+# =============================================================================
+
+export USE_GPU_OLLAMA=true
+
+# Client-side concurrency must match the server slots, and slots x context KV
+# must fit the 24 GB card (KV ~0.15 GB per 1k ctx per slot, weights ~9.3 GB).
+#
+# Context sizing. The emic prompt is template + segment + question + answer:
+# the template is ~7.5 KB (~2k tokens pt), the segment is one `cep_4k` chunk
+# (RecursiveChunker chunk_size=4000, so <=4k tokens), Q+A add a few hundred.
+# Input ceiling ~6.5k tokens; the response budget is max_tokens=8192
+# (REASONING_MODEL_MAX_TOKENS — qwen3 burns thinking tokens against it). So
+# ~15k is the working ceiling and 16384 leaves headroom.
+#
+# 4 x 16384 ~ 9.8 GB KV + ~9.3 GB weights ~ 19 GB, inside the envelope
+# judge-answers already runs at (2 x 40960 ~ 22.8 GB). Emic gets twice the
+# concurrency because its prompts are ~4x shorter than the RAG judge's, which
+# carry retrieved passages.
+export ARANDU_EMIC_JUDGE_WORKERS="${ARANDU_EMIC_JUDGE_WORKERS:-4}"
+# Server slots follow the client worker count unless explicitly overridden, so
+# the two can never drift apart on a plain submit.
+export OLLAMA_NUM_PARALLEL="${OLLAMA_NUM_PARALLEL:-$ARANDU_EMIC_JUDGE_WORKERS}"
+export OLLAMA_CONTEXT_LENGTH="${OLLAMA_CONTEXT_LENGTH:-16384}"
+
+source "${SLURM_SUBMIT_DIR}/scripts/slurm/emic/emic_common.sh"

--- a/scripts/slurm/rag/rag_common.sh
+++ b/scripts/slurm/rag/rag_common.sh
@@ -48,54 +48,22 @@ OLLAMA_SERVICE="ollama-gpu"
 DOCKER_PROFILE="$RAG_PROFILE"
 
 # ---------------------------------------------------------------------------
-# Container teardown trap.
+# Container teardown trap. Shared with the other steps; see
+# scripts/slurm/container_teardown.sh for why it exists and for the two
+# conditions it needs to fire in time (background + `wait`, and
+# `#SBATCH --signal=B:TERM@60` on the per-stage script).
 #
-# The stage launches containers via `docker compose run`/`up`, but those are
-# owned by the docker daemon, NOT by this job step's process tree. So when
-# SLURM ends the job WITHOUT a clean script exit (a TIME LIMIT timeout or an
-# `scancel`), it kills the shell before a normal teardown runs, and the
-# containers keep running on the node as ORPHANS: still holding the GPU and
-# writing outputs outside any allocation, contending with whatever SLURM
-# schedules onto the node next. Observed: judge-answers 799024 TIMEOUT left
-# `ollama-gpu-<jobid>` + `<project>-arandu-rag-run-*` alive on tupi2, degrading
-# another user's job.
-#
-# Two things are needed for the trap to actually fire in time:
-#   1. The stage command runs in the BACKGROUND and is `wait`-ed on (see below).
-#      bash does NOT run a trap while a foreground external command executes; it
-#      defers it until that command returns. A foreground `docker compose run`
-#      would therefore defer teardown until the container exits, i.e. never on a
-#      real timeout. `wait` is interruptible, so backgrounding + wait lets the
-#      SIGTERM/SIGINT handler run immediately.
-#   2. `#SBATCH --signal=B:TERM@60` (per-stage scripts) makes SLURM send SIGTERM
-#      to the batch shell 60s before the limit, well inside KillWait.
-#
-# Traps are armed LATER (via _rag_arm_traps, just before the first container
-# starts), so an early validation `exit 1` does not run `docker compose down`
-# while this job has no containers up (which could disturb a co-located job that
-# shares the compose project).
-_rag_teardown() {
-    echo ""
-    echo "[cleanup] tearing down containers (profile ${DOCKER_PROFILE})..."
-    docker compose -f "$COMPOSE_FILE" --profile "$DOCKER_PROFILE" \
-        down --remove-orphans --timeout 10 2>/dev/null || true
-}
-_rag_on_signal() {
-    # Ignore further INT/TERM while tearing down (a scancel retry or a short
-    # KillWait must not kill the shell mid-`down`) and disarm EXIT so teardown
-    # runs exactly once. $1 = signal name (for the log), $2 = exit code.
-    trap '' INT TERM
-    trap - EXIT
-    echo ""
-    echo "[cleanup] caught ${1} (SLURM timeout/scancel); tearing down..."
-    _rag_teardown
-    exit "${2}"
-}
-_rag_arm_traps() {
-    trap _rag_teardown EXIT
-    trap '_rag_on_signal SIGINT 130' INT   # 128 + SIGINT(2)
-    trap '_rag_on_signal SIGTERM 143' TERM # 128 + SIGTERM(15)
-}
+# Deploy note: rsyncing this file without container_teardown.sh leaves the job
+# unable to start, which is the intended failure. Silently losing the trap
+# would mean orphaned GPU containers on the node.
+TEARDOWN_LIB="${SLURM_SUBMIT_DIR:-$PROJECT_DIR}/scripts/slurm/container_teardown.sh"
+if [ ! -f "$TEARDOWN_LIB" ]; then
+    echo "ERROR: $TEARDOWN_LIB not found; refusing to run without the teardown trap." >&2
+    echo "       Deploy scripts/slurm/container_teardown.sh alongside this script." >&2
+    exit 1
+fi
+# shellcheck source=scripts/slurm/container_teardown.sh
+source "$TEARDOWN_LIB"
 
 echo "=============================================="
 echo "Arandu Phase C RAG stage"
@@ -153,7 +121,7 @@ docker compose -f "$COMPOSE_FILE" --profile "$DOCKER_PROFILE" build "$RAG_SERVIC
 # From here on containers get started, so arm the teardown traps. (Kept out of
 # the early-validation/build path above so a pre-container `exit 1` cannot run
 # `docker compose down` when this job has nothing up.)
-_rag_arm_traps
+arandu_arm_teardown_traps
 
 # ---------------------------------------------------------------------------
 # Ollama sidecar (LLM stages only)
@@ -206,7 +174,7 @@ set -e
 echo "=============================================="
 echo "Stage finished (rc=${RUN_RC}) at $(date)"
 echo "=============================================="
-# Container teardown is handled by the _rag_teardown EXIT trap set above, so it
+# Container teardown is handled by the EXIT trap armed above, so it
 # runs here on normal exit AND on a SLURM SIGTERM (timeout/scancel). Do not add
 # a manual `docker compose down`; it would just double-run the trap.
 exit $RUN_RC

--- a/src/arandu/cli/AGENTS.md
+++ b/src/arandu/cli/AGENTS.md
@@ -11,7 +11,7 @@ orchestrator, and report via Rich. They are fire-and-forget: side effects land i
 | File | Role |
 | ---- | ---- |
 | `app.py` | Typer app + the single registration list (`app.command()(fn)` per command) |
-| `transcribe.py`, `qa.py`, `kg.py`, `chunking.py`, `retrieve.py`, `answer.py`, `judge_answers.py`, `emic_prepass.py`, `human_eval.py`, `rag_analysis.py`, `non_answerable.py`, `manage.py`, `report.py` | One command (or a few related commands) each |
+| `transcribe.py`, `qa.py`, `kg.py`, `chunking.py`, `retrieve.py`, `answer.py`, `judge_answers.py`, `emic_judge.py`, `human_eval.py`, `rag_analysis.py`, `non_answerable.py`, `manage.py`, `report.py` | One command (or a few related commands) each |
 | `_helpers.py` | Shared output/sanitization helpers |
 
 ## Patterns to follow

--- a/src/arandu/cli/app.py
+++ b/src/arandu/cli/app.py
@@ -50,7 +50,7 @@ def main(
 # Register commands from submodules
 from arandu.cli.answer import answer  # noqa: E402
 from arandu.cli.chunking import chunk  # noqa: E402
-from arandu.cli.emic_prepass import emic_prepass  # noqa: E402
+from arandu.cli.emic_judge import emic_judge  # noqa: E402
 from arandu.cli.human_eval import build_human_eval_sample  # noqa: E402
 from arandu.cli.judge_answers import judge_answers  # noqa: E402
 from arandu.cli.kg import build_kg, kg_build_retriever_index, kg_link_passages  # noqa: E402
@@ -89,7 +89,7 @@ app.command()(kg_build_retriever_index)
 app.command()(retrieve)
 app.command()(answer)
 app.command()(judge_answers)
-app.command()(emic_prepass)
+app.command()(emic_judge)
 app.command()(build_human_eval_sample)
 app.command()(rag_analysis)
 app.command()(generate_non_answerable)

--- a/src/arandu/cli/emic_judge.py
+++ b/src/arandu/cli/emic_judge.py
@@ -16,6 +16,7 @@ from typing import Annotated
 import typer
 
 from arandu.shared.emic.batch import run_emic_judge_batch
+from arandu.shared.emic.schemas import EmicScope  # noqa: TC001 (Typer needs runtime access)
 from arandu.shared.emic.settings import EmicJudgeSettings
 from arandu.utils.logger import print_error, print_info, print_success, print_warning
 
@@ -28,8 +29,8 @@ def emic_judge(
         typer.Option(
             "--id",
             help=(
-                "Pipeline ID for the run. The cep/ stage must be populated and "
-                "judged; only canonical-approved pairs (is_valid) are scored."
+                "Pipeline ID for the run. The cep/ stage must be populated, and "
+                "judged when --scope approved."
             ),
         ),
     ],
@@ -43,12 +44,26 @@ def emic_judge(
             ),
         ),
     ] = False,
+    scope: Annotated[
+        EmicScope,
+        typer.Option(
+            "--scope",
+            help=(
+                "all (default) scores every pair and records its judge-qa verdict, "
+                "enabling the emic-validity x approval cross-tabulation. approved "
+                "scores only canonically-approved pairs (cheaper; skips rejected "
+                "and never-judged ones)."
+            ),
+        ),
+    ] = "all",
 ) -> None:
-    """Score canonical-approved CEP pairs for emic validity (ordinal 1-5).
+    """Score CEP pairs for emic validity (ordinal 1-5).
 
     Builds the ``emic_validity`` ordinal criterion standalone (not a judge-qa
-    pipeline stage) and runs it over each approved pair's segment + question +
-    answer, persisting per-source ``EmicSourceScores``.
+    pipeline stage) and runs it over each in-scope pair's segment + question +
+    answer, persisting per-source ``EmicSourceScores``. Each score carries the
+    pair's ``judge-qa`` verdict, so ``--scope all`` supports cross-tabulating
+    emic validity against approval.
 
     The resulting scores are the study's measurement of emic validity. The
     human annotation round (spec §6) rates a stratified subsample and reports
@@ -60,7 +75,7 @@ def emic_judge(
     reports.
     """
     settings = EmicJudgeSettings()
-    print_info(f"Run: {pipeline_id}")
+    print_info(f"Run: {pipeline_id} | scope: {scope}")
     print_info(
         f"Emic LLM: provider={settings.provider}, model={settings.model_id}, "
         f"language={settings.language}, temperature={settings.temperature}"
@@ -69,7 +84,9 @@ def emic_judge(
         print_warning("--rerun: clearing checkpoint; every source will be re-scored.")
 
     try:
-        result = run_emic_judge_batch(pipeline_id=pipeline_id, settings=settings, rerun=rerun)
+        result = run_emic_judge_batch(
+            pipeline_id=pipeline_id, settings=settings, rerun=rerun, scope=scope
+        )
     except FileNotFoundError as exc:
         print_error(str(exc))
         raise typer.Exit(code=1) from exc
@@ -85,15 +102,21 @@ def emic_judge(
             f"{result.failed_sources} source(s) failed to load and were skipped (see logs)."
         )
     if result.unjudged_pairs:
+        disposition = "scored with a null verdict" if scope == "all" else "skipped"
         print_warning(
-            f"{result.unjudged_pairs} pair(s) had no judge verdict and were skipped; "
+            f"{result.unjudged_pairs} pair(s) had no judge verdict and were {disposition}; "
             "the run may not have been fully judged (`arandu judge-qa`)."
         )
     if result.failed_pairs:
-        print_warning(f"{result.failed_pairs} approved pair(s) errored while scoring (see logs).")
+        print_warning(f"{result.failed_pairs} pair(s) errored while scoring (see logs).")
     print_success(
-        f"Scored {result.scored_pairs}/{result.approved_pairs} approved pairs this run "
+        f"Scored {result.scored_pairs}/{result.selected_pairs} selected pairs this run "
         f"across {result.completed_sources} new source(s); "
         f"{result.resumed_sources} resumed, {result.failed_sources} failed "
         f"({result.sources} total)."
+    )
+    print_info(
+        f"Corpus split seen: {result.approved_pairs} approved, "
+        f"{result.rejected_pairs} rejected, {result.unjudged_pairs} unjudged "
+        f"({result.skipped_pairs} skipped by scope)."
     )

--- a/src/arandu/cli/emic_judge.py
+++ b/src/arandu/cli/emic_judge.py
@@ -1,4 +1,4 @@
-"""CLI command: ``arandu emic-judge`` — ordinal emic-validity scoring of approved CEP pairs.
+"""CLI command ``arandu emic-judge``: ordinal emic-validity scoring of CEP pairs.
 
 Runs the ``emic_validity`` ordinal criterion over the canonical-approved pairs
 of a populated run and writes per-source ordinal scores under
@@ -74,23 +74,26 @@ def emic_judge(
     test, a run feeding the agreement study must pin the model the thesis
     reports.
     """
-    settings = EmicJudgeSettings()
+    # Built inside the try: an out-of-range ARANDU_EMIC_JUDGE_* value raises
+    # pydantic.ValidationError (a ValueError), which the handler below turns
+    # into a readable message instead of a raw traceback in the SLURM log.
     print_info(f"Run: {pipeline_id} | scope: {scope}")
-    print_info(
-        f"Emic LLM: provider={settings.provider}, model={settings.model_id}, "
-        f"language={settings.language}, temperature={settings.temperature}, "
-        f"workers={settings.workers}"
-    )
-    if settings.workers > 1:
-        print_info(
-            f"Scoring {settings.workers} pairs concurrently "
-            "(ARANDU_EMIC_JUDGE_WORKERS). Match this with server-side slots "
-            "(OLLAMA_NUM_PARALLEL) and the per-slot VRAM budget."
-        )
     if rerun:
         print_warning("--rerun: clearing checkpoint; every source will be re-scored.")
 
     try:
+        settings = EmicJudgeSettings()
+        print_info(
+            f"Emic LLM: provider={settings.provider}, model={settings.model_id}, "
+            f"language={settings.language}, temperature={settings.temperature}, "
+            f"workers={settings.workers}"
+        )
+        if settings.workers > 1:
+            print_info(
+                f"Scoring {settings.workers} pairs concurrently "
+                "(ARANDU_EMIC_JUDGE_WORKERS). Match this with server-side slots "
+                "(OLLAMA_NUM_PARALLEL) and the per-slot VRAM budget."
+            )
         result = run_emic_judge_batch(
             pipeline_id=pipeline_id, settings=settings, rerun=rerun, scope=scope
         )
@@ -98,7 +101,9 @@ def emic_judge(
         print_error(str(exc))
         raise typer.Exit(code=1) from exc
     except (RuntimeError, ValueError) as exc:
-        print_error(f"Invalid emic-judge configuration: {exc}")
+        # Covers both invalid ARANDU_EMIC_JUDGE_* values (pydantic
+        # ValidationError is a ValueError) and the unjudged-corpus preflight.
+        print_error(f"Cannot run the emic judge: {exc}")
         raise typer.Exit(code=1) from exc
     except OSError as exc:
         print_error(f"I/O error during the emic judge run: {exc}")

--- a/src/arandu/cli/emic_judge.py
+++ b/src/arandu/cli/emic_judge.py
@@ -1,10 +1,11 @@
-"""CLI command: ``arandu emic-prepass`` — ordinal emic-validity scoring of approved CEP pairs.
+"""CLI command: ``arandu emic-judge`` — ordinal emic-validity scoring of approved CEP pairs.
 
 Runs the ``emic_validity`` ordinal criterion over the canonical-approved pairs
 of a populated run and writes per-source ordinal scores under
-``results/<id>/emic_prepass/outputs/<source>.json``. The scores bound the
-sampling bands for the stratified human-comparison sample (the annotators are
-the ground truth; this is a sampling aid).
+``results/<id>/emic_judge/outputs/<source>.json``. These scores are the study's
+measurement of emic validity; the human annotation round validates them by
+agreement (spec §6). They also band the stratified human-comparison sample, but
+that is a downstream use rather than their purpose.
 """
 
 from __future__ import annotations
@@ -14,14 +15,14 @@ from typing import Annotated
 
 import typer
 
-from arandu.shared.emic.batch import run_emic_prepass_batch
-from arandu.shared.emic.settings import EmicPrepassSettings
+from arandu.shared.emic.batch import run_emic_judge_batch
+from arandu.shared.emic.settings import EmicJudgeSettings
 from arandu.utils.logger import print_error, print_info, print_success, print_warning
 
 logger = logging.getLogger(__name__)
 
 
-def emic_prepass(
+def emic_judge(
     pipeline_id: Annotated[
         str,
         typer.Option(
@@ -47,14 +48,18 @@ def emic_prepass(
 
     Builds the ``emic_validity`` ordinal criterion standalone (not a judge-qa
     pipeline stage) and runs it over each approved pair's segment + question +
-    answer, persisting per-source ``EmicSourceScores`` for the stratified
-    sample builder.
+    answer, persisting per-source ``EmicSourceScores``.
 
-    LLM configuration is read from ``ARANDU_EMIC_PREPASS_*`` env vars; see
-    :class:`EmicPrepassSettings`. The score is a sampling aid, not ground
-    truth — the human annotators are the reference.
+    The resulting scores are the study's measurement of emic validity. The
+    human annotation round (spec §6) rates a stratified subsample and reports
+    agreement with them; it validates the measurement rather than replacing it.
+
+    LLM configuration is read from ``ARANDU_EMIC_JUDGE_*`` env vars; see
+    :class:`EmicJudgeSettings`. Because the model defines the instrument under
+    test, a run feeding the agreement study must pin the model the thesis
+    reports.
     """
-    settings = EmicPrepassSettings()
+    settings = EmicJudgeSettings()
     print_info(f"Run: {pipeline_id}")
     print_info(
         f"Emic LLM: provider={settings.provider}, model={settings.model_id}, "
@@ -64,15 +69,15 @@ def emic_prepass(
         print_warning("--rerun: clearing checkpoint; every source will be re-scored.")
 
     try:
-        result = run_emic_prepass_batch(pipeline_id=pipeline_id, settings=settings, rerun=rerun)
+        result = run_emic_judge_batch(pipeline_id=pipeline_id, settings=settings, rerun=rerun)
     except FileNotFoundError as exc:
         print_error(str(exc))
         raise typer.Exit(code=1) from exc
     except (RuntimeError, ValueError) as exc:
-        print_error(f"Invalid emic-prepass configuration: {exc}")
+        print_error(f"Invalid emic-judge configuration: {exc}")
         raise typer.Exit(code=1) from exc
     except OSError as exc:
-        print_error(f"I/O error during emic pre-pass: {exc}")
+        print_error(f"I/O error during the emic judge run: {exc}")
         raise typer.Exit(code=1) from exc
 
     if result.failed_sources:

--- a/src/arandu/cli/emic_judge.py
+++ b/src/arandu/cli/emic_judge.py
@@ -78,8 +78,15 @@ def emic_judge(
     print_info(f"Run: {pipeline_id} | scope: {scope}")
     print_info(
         f"Emic LLM: provider={settings.provider}, model={settings.model_id}, "
-        f"language={settings.language}, temperature={settings.temperature}"
+        f"language={settings.language}, temperature={settings.temperature}, "
+        f"workers={settings.workers}"
     )
+    if settings.workers > 1:
+        print_info(
+            f"Scoring {settings.workers} pairs concurrently "
+            "(ARANDU_EMIC_JUDGE_WORKERS). Match this with server-side slots "
+            "(OLLAMA_NUM_PARALLEL) and the per-slot VRAM budget."
+        )
     if rerun:
         print_warning("--rerun: clearing checkpoint; every source will be re-scored.")
 

--- a/src/arandu/cli/human_eval.py
+++ b/src/arandu/cli/human_eval.py
@@ -1,7 +1,7 @@
 """CLI command: ``arandu build-human-eval-sample`` — stratified 80-pair sample (spec §5).
 
 Builds the human-comparison study sample (4 Bloom x 2 emic bands x 10) from the
-emic pre-pass scores of a run, joining each pair's CEP payload, and writes
+emic-judge scores of a run, joining each pair's CEP payload, and writes
 ``sample.jsonl`` + ``sample_manifest.json`` under
 ``results/<id>/human_eval/outputs/``.
 """
@@ -24,9 +24,7 @@ def build_human_eval_sample(
         str,
         typer.Option(
             "--id",
-            help=(
-                "Pipeline ID for the run. The emic_prepass and cep stages must both be populated."
-            ),
+            help=("Pipeline ID for the run. The emic_judge and cep stages must both be populated."),
         ),
     ],
     seed: Annotated[
@@ -39,11 +37,12 @@ def build_human_eval_sample(
 ) -> None:
     """Build the stratified human-comparison sample (80 pairs) for a run.
 
-    Pools the canonical-approved pairs scored by ``arandu emic-prepass``, bands
+    Pools the canonical-approved pairs scored by ``arandu emic-judge``, bands
     them by emic validity (duvidosa <=3 / limpa >=4), and draws 10 pairs from
     each of the 8 cells (4 Bloom levels x 2 bands) with a fixed seed. The
-    emic score is a sampling aid to cover the bands, not ground truth; the
-    human annotators remain the reference. Writes the sample + manifest under
+    emic score is the study's measurement of emic validity; this sample is
+    what the human annotators rate so agreement with it can be reported (spec
+    §6). Writes the sample + manifest under
     ``results/<id>/human_eval/outputs/``.
     """
     print_info(f"Run: {pipeline_id} | seed: {seed}")

--- a/src/arandu/cli/human_eval.py
+++ b/src/arandu/cli/human_eval.py
@@ -60,9 +60,10 @@ def build_human_eval_sample(
         raise typer.Exit(code=1) from exc
 
     excluded_bloom_total = sum(manifest.excluded_bloom.values())
-    if manifest.excluded_none_score or excluded_bloom_total:
+    if manifest.excluded_none_score or excluded_bloom_total or manifest.excluded_not_approved:
         print_warning(
-            f"Excluded from frame: {manifest.excluded_none_score} null-score pair(s), "
+            f"Excluded from frame: {manifest.excluded_not_approved} not judge-approved "
+            f"pair(s), {manifest.excluded_none_score} null-score pair(s), "
             f"{excluded_bloom_total} out-of-frame-Bloom pair(s) "
             f"({manifest.excluded_bloom or 'none'})."
         )

--- a/src/arandu/shared/emic/__init__.py
+++ b/src/arandu/shared/emic/__init__.py
@@ -1,13 +1,18 @@
-"""Emic-validity pre-pass: ordinal scoring of approved CEP pairs (spec §5)."""
+"""Emic-validity judge: ordinal scoring of approved CEP pairs (spec §5).
 
-from arandu.shared.emic.batch import run_emic_prepass_batch
-from arandu.shared.emic.schemas import EmicPrepassResult, EmicScore, EmicSourceScores
-from arandu.shared.emic.settings import EmicPrepassSettings
+The ordinal ``emic_validity`` score this stage produces is the study's
+measurement of emic validity. The human annotation round (spec §6) measures
+agreement with it; it is not a ground truth that supersedes it.
+"""
+
+from arandu.shared.emic.batch import run_emic_judge_batch
+from arandu.shared.emic.schemas import EmicJudgeResult, EmicScore, EmicSourceScores
+from arandu.shared.emic.settings import EmicJudgeSettings
 
 __all__ = [
-    "EmicPrepassResult",
-    "EmicPrepassSettings",
+    "EmicJudgeResult",
+    "EmicJudgeSettings",
     "EmicScore",
     "EmicSourceScores",
-    "run_emic_prepass_batch",
+    "run_emic_judge_batch",
 ]

--- a/src/arandu/shared/emic/__init__.py
+++ b/src/arandu/shared/emic/__init__.py
@@ -1,4 +1,4 @@
-"""Emic-validity judge: ordinal scoring of approved CEP pairs (spec §5).
+"""Emic-validity judge: ordinal scoring of CEP pairs (spec §5).
 
 The ordinal ``emic_validity`` score this stage produces is the study's
 measurement of emic validity. The human annotation round (spec §6) measures
@@ -6,12 +6,18 @@ agreement with it; it is not a ground truth that supersedes it.
 """
 
 from arandu.shared.emic.batch import run_emic_judge_batch
-from arandu.shared.emic.schemas import EmicJudgeResult, EmicScore, EmicSourceScores
+from arandu.shared.emic.schemas import (
+    EmicJudgeResult,
+    EmicScope,
+    EmicScore,
+    EmicSourceScores,
+)
 from arandu.shared.emic.settings import EmicJudgeSettings
 
 __all__ = [
     "EmicJudgeResult",
     "EmicJudgeSettings",
+    "EmicScope",
     "EmicScore",
     "EmicSourceScores",
     "run_emic_judge_batch",

--- a/src/arandu/shared/emic/batch.py
+++ b/src/arandu/shared/emic/batch.py
@@ -1,10 +1,15 @@
-"""Batch orchestrator for ``arandu emic-prepass`` (spec §5).
+"""Batch orchestrator for ``arandu emic-judge`` (spec §5).
 
 Runs the ``emic_validity`` ordinal criterion over the canonical-approved CEP
 pairs of a populated run and writes per-source ordinal scores under
-``results/<id>/emic_prepass/outputs/<source>.json``. These scores feed the
-stratified sample builder (they bound the sampling bands; the human annotators
-remain the ground truth).
+``results/<id>/emic_judge/outputs/<source>.json``.
+
+These scores are the study's **measurement** of emic validity, not a
+preliminary aid. The human annotation round (spec §6) rates a stratified
+subsample and reports agreement with them (Krippendorff alpha over the raters,
+weighted Cohen kappa of this judge against each annotator); it validates the
+measurement rather than replacing it. The same scores also band the stratified
+sample builder, but that is a downstream use, not their purpose.
 
 The criterion is built standalone via ``OrdinalLLMCriterion.from_config`` — it
 is not wired into the ``judge-qa`` pipeline (that, with a filter threshold, is
@@ -21,8 +26,8 @@ from pydantic import ValidationError
 from arandu.qa.schemas import QARecordCEP
 from arandu.shared.checkpoint import CheckpointManager
 from arandu.shared.config import ResultsConfig
-from arandu.shared.emic.schemas import EmicPrepassResult, EmicScore, EmicSourceScores
-from arandu.shared.emic.settings import EmicPrepassSettings
+from arandu.shared.emic.schemas import EmicJudgeResult, EmicScore, EmicSourceScores
+from arandu.shared.emic.settings import EmicJudgeSettings
 from arandu.shared.judge.criterion import OrdinalLLMCriterion
 from arandu.shared.llm_client import build_llm_client_from_settings
 from arandu.shared.results_manager import ResultsManager
@@ -34,35 +39,35 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-CHECKPOINT_FILENAME = "emic_prepass_checkpoint.json"
+CHECKPOINT_FILENAME = "emic_judge_checkpoint.json"
 EMIC_CRITERION_NAME = "emic_validity"
 
 
-def run_emic_prepass_batch(
+def run_emic_judge_batch(
     pipeline_id: str,
     *,
-    settings: EmicPrepassSettings | None = None,
+    settings: EmicJudgeSettings | None = None,
     base_dir: Path | None = None,
     rerun: bool = False,
-) -> EmicPrepassResult:
+) -> EmicJudgeResult:
     """Score the canonical-approved CEP pairs of ``pipeline_id`` for emic validity.
 
     Args:
         pipeline_id: Run identifier. The ``cep`` stage must be populated and
             judged (only pairs with ``is_valid`` are scored).
-        settings: Emic-prepass LLM configuration. Defaults to
-            :class:`EmicPrepassSettings` (reads ``ARANDU_EMIC_PREPASS_*``).
+        settings: Emic-judge LLM configuration. Defaults to
+            :class:`EmicJudgeSettings` (reads ``ARANDU_EMIC_JUDGE_*``).
         base_dir: Override the project ``results/`` root.
         rerun: If True, clear the checkpoint so every source is re-scored.
 
     Returns:
-        :class:`EmicPrepassResult` summary.
+        :class:`EmicJudgeResult` summary.
 
     Raises:
         FileNotFoundError: If the cep stage outputs aren't present.
         RuntimeError: If a cloud-provider API key env var is unset.
     """
-    resolved = settings if settings is not None else EmicPrepassSettings()
+    resolved = settings if settings is not None else EmicJudgeSettings()
     base = base_dir if base_dir is not None else ResultsConfig().base_dir
 
     cep_outputs = base / pipeline_id / "cep" / "outputs"
@@ -82,7 +87,7 @@ def run_emic_prepass_batch(
         max_tokens=resolved.max_tokens,
     )
 
-    results_mgr = ResultsManager(base, PipelineType.EMIC_PREPASS, pipeline_id=pipeline_id)
+    results_mgr = ResultsManager(base, PipelineType.EMIC_JUDGE, pipeline_id=pipeline_id)
     results_mgr.create_run(
         resolved,
         input_source=str(cep_outputs),
@@ -168,7 +173,7 @@ def run_emic_prepass_batch(
     results_mgr.complete_run(success=(failed_sources == 0))
 
     logger.info(
-        "Emic pre-pass complete: %d/%d sources scored (%d resumed, %d failed), "
+        "Emic judge complete: %d/%d sources scored (%d resumed, %d failed), "
         "%d approved pairs, %d scored, %d failed, %d unjudged.",
         completed_sources,
         len(cep_paths),
@@ -179,7 +184,7 @@ def run_emic_prepass_batch(
         failed,
         unjudged,
     )
-    return EmicPrepassResult(
+    return EmicJudgeResult(
         pipeline_id=pipeline_id,
         sources=len(cep_paths),
         completed_sources=completed_sources,

--- a/src/arandu/shared/emic/batch.py
+++ b/src/arandu/shared/emic/batch.py
@@ -13,7 +13,7 @@ weighted Cohen kappa of this judge against each annotator); it validates the
 measurement rather than replacing it. The same scores also band the stratified
 sample builder, but that is a downstream use, not their purpose.
 
-The criterion is built standalone via ``OrdinalLLMCriterion.from_config`` — it
+The criterion is built standalone via ``OrdinalLLMCriterion.from_config``; it
 is not wired into the ``judge-qa`` pipeline (that, with a filter threshold, is
 the separate ``emic-filter-stage`` task).
 """
@@ -30,6 +30,7 @@ from arandu.shared.checkpoint import CheckpointManager
 from arandu.shared.config import ResultsConfig
 from arandu.shared.emic.schemas import (
     EmicJudgeResult,
+    EmicJudgeRunConfig,
     EmicScope,
     EmicScore,
     EmicSourceScores,
@@ -54,6 +55,39 @@ CHECKPOINT_FILENAME = "emic_judge_checkpoint.json"
 EMIC_CRITERION_NAME = "emic_validity"
 
 
+def _require_a_judged_pair(cep_paths: list[Path], pipeline_id: str) -> None:
+    """Abort unless at least one CEP pair carries a ``judge-qa`` verdict.
+
+    Under ``scope="all"`` nothing else would stop a never-judged corpus from
+    being scored end to end: every pair is in scope, the LLM is called for all
+    of them, and each score is written with a null verdict. On the cluster that
+    is a full GPU allocation spent producing output the sample builder then
+    discards wholesale, because its frame is the approved corpus.
+
+    Short-circuits on the first judged pair, so a healthy run pays for one file
+    read.
+
+    Args:
+        cep_paths: The CEP record files discovered for the run.
+        pipeline_id: Run identifier, for the error message.
+
+    Raises:
+        ValueError: If no pair in any record has been judged.
+    """
+    for path in cep_paths:
+        try:
+            record = QARecordCEP.model_validate_json(path.read_text(encoding="utf-8"))
+        except (OSError, ValidationError):
+            continue  # unreadable sources are reported by the main loop
+        if any(pair.is_valid is not None for pair in record.qa_pairs):
+            return
+    raise ValueError(
+        f"No pair in {pipeline_id!r} carries a judge-qa verdict, so every emic score would "
+        f"be recorded against a null verdict and the human-eval frame (the approved corpus) "
+        f"would be empty. Run `arandu judge-qa` first."
+    )
+
+
 def run_emic_judge_batch(
     pipeline_id: str,
     *,
@@ -76,13 +110,14 @@ def run_emic_judge_batch(
             cross-tabulated against approval; ``"approved"`` scores only
             canonically-approved pairs. Defaults to ``"all"`` because the emic
             score is the study's corpus-wide measurement, not a filter applied
-            after ``judge-qa`` — at the cost of scoring the rejected pairs too.
+            after ``judge-qa``, at the cost of scoring the rejected pairs too.
 
     Returns:
         :class:`EmicJudgeResult` summary.
 
     Raises:
         FileNotFoundError: If the cep stage outputs aren't present.
+        ValueError: If no pair in the run carries a ``judge-qa`` verdict.
         RuntimeError: If a cloud-provider API key env var is unset.
     """
     resolved = settings if settings is not None else EmicJudgeSettings()
@@ -95,6 +130,11 @@ def run_emic_judge_batch(
             f"Run `arandu generate-cep-qa` and `arandu judge-qa` first."
         )
 
+    cep_paths = sorted(cep_outputs.glob("*_cep_qa.json"))
+    # Before building a client or creating a run: an unjudged corpus must not
+    # leave an IN_PROGRESS run dir behind, and must not reach the LLM at all.
+    _require_a_judged_pair(cep_paths, pipeline_id)
+
     llm_client = build_llm_client_from_settings(resolved)
     criterion = OrdinalLLMCriterion.from_config(
         name=EMIC_CRITERION_NAME,
@@ -106,8 +146,11 @@ def run_emic_judge_batch(
     )
 
     results_mgr = ResultsManager(base, PipelineType.EMIC_JUDGE, pipeline_id=pipeline_id)
+    # Snapshot the scope alongside the LLM settings: it is a CLI argument, not a
+    # settings field, so passing `resolved` alone would leave no artifact
+    # recording which pairs the run was even allowed to score.
     results_mgr.create_run(
-        resolved,
+        EmicJudgeRunConfig(scope=scope, llm=resolved),
         input_source=str(cep_outputs),
         checkpoint_filename=CHECKPOINT_FILENAME,
     )
@@ -132,14 +175,18 @@ def run_emic_judge_batch(
             answer=pair.answer,
         )
 
-    cep_paths = sorted(cep_outputs.glob("*_cep_qa.json"))
     checkpoint.set_total_files(len(cep_paths))
 
     completed_sources = resumed_sources = failed_sources = 0
     selected = scored = failed = skipped = 0
     approved = rejected = unjudged = 0
     for path in cep_paths:
-        ckpt_key = path.stem
+        # The scope is part of the resume identity. Keying on the filename alone
+        # would let a run switched from `approved` to `all` skip every already
+        # completed source, silently producing a corpus that is missing the
+        # rejected pairs the `all` scope exists to score while the result still
+        # reports scope=all.
+        ckpt_key = f"{path.stem}:{scope}"
         if checkpoint.is_completed(ckpt_key):
             resumed_sources += 1
             continue
@@ -170,7 +217,9 @@ def run_emic_judge_batch(
                 continue
             in_scope.append((idx, pair))
 
-        selected += len(in_scope)
+        selected_here = len(in_scope)
+        failed_here = 0
+        selected += selected_here
         # Workers only run `_score_pair`; the checkpoint write and the source
         # file save stay on this thread, so no locking is needed (same split as
         # judge-answers). Concurrency is per source rather than across the whole
@@ -201,6 +250,7 @@ def run_emic_judge_batch(
                 # whole source.
                 logger.warning("Scoring pair %d of %s failed: %s", idx, path.name, error)
                 failed += 1
+                failed_here += 1
                 by_index[idx] = EmicScore(
                     pair_index=idx,
                     bloom_level=pair.bloom_level,
@@ -212,6 +262,7 @@ def run_emic_judge_batch(
                 continue
             if evaluation.ordinal_score is None:
                 failed += 1
+                failed_here += 1
             else:
                 scored += 1
             by_index[idx] = EmicScore(
@@ -230,8 +281,27 @@ def run_emic_judge_batch(
         EmicSourceScores(
             source_file_id=record.source_file_id,
             source_filename=record.source_filename,
+            scope=scope,
             scores=scores,
         ).save(results_mgr.outputs_dir / f"{path.stem}.json")
+
+        # A source whose every selected pair errored is a failure, not a
+        # completion. JudgeCriterion.evaluate turns a dead sidecar into a full
+        # set of null scores instead of an exception, so checkpointing this as
+        # done would record an outage as a successful run that `--resume` skips
+        # forever. Guarded on `selected_here` so a source with nothing in scope
+        # (legitimately zero pairs) still completes.
+        if selected_here > 0 and failed_here == selected_here:
+            logger.warning(
+                "All %d selected pair(s) of %s failed to score; marking the source failed "
+                "so --resume retries it (check the LLM endpoint).",
+                selected_here,
+                path.name,
+            )
+            checkpoint.mark_failed(ckpt_key, f"all {selected_here} selected pair(s) errored")
+            failed_sources += 1
+            continue
+
         checkpoint.mark_completed(ckpt_key)
         completed_sources += 1
 

--- a/src/arandu/shared/emic/batch.py
+++ b/src/arandu/shared/emic/batch.py
@@ -1,8 +1,10 @@
 """Batch orchestrator for ``arandu emic-judge`` (spec §5).
 
-Runs the ``emic_validity`` ordinal criterion over the canonical-approved CEP
-pairs of a populated run and writes per-source ordinal scores under
-``results/<id>/emic_judge/outputs/<source>.json``.
+Runs the ``emic_validity`` ordinal criterion over the CEP pairs of a populated
+run and writes per-source ordinal scores under
+``results/<id>/emic_judge/outputs/<source>.json``. The ``scope`` argument picks
+the pairs: ``all`` (default) scores every pair and records its ``judge-qa``
+verdict on the score, ``approved`` scores only canonically-approved ones.
 
 These scores are the study's **measurement** of emic validity, not a
 preliminary aid. The human annotation round (spec §6) rates a stratified
@@ -26,7 +28,12 @@ from pydantic import ValidationError
 from arandu.qa.schemas import QARecordCEP
 from arandu.shared.checkpoint import CheckpointManager
 from arandu.shared.config import ResultsConfig
-from arandu.shared.emic.schemas import EmicJudgeResult, EmicScore, EmicSourceScores
+from arandu.shared.emic.schemas import (
+    EmicJudgeResult,
+    EmicScope,
+    EmicScore,
+    EmicSourceScores,
+)
 from arandu.shared.emic.settings import EmicJudgeSettings
 from arandu.shared.judge.criterion import OrdinalLLMCriterion
 from arandu.shared.llm_client import build_llm_client_from_settings
@@ -49,16 +56,23 @@ def run_emic_judge_batch(
     settings: EmicJudgeSettings | None = None,
     base_dir: Path | None = None,
     rerun: bool = False,
+    scope: EmicScope = "all",
 ) -> EmicJudgeResult:
-    """Score the canonical-approved CEP pairs of ``pipeline_id`` for emic validity.
+    """Score the CEP pairs of ``pipeline_id`` for emic validity.
 
     Args:
-        pipeline_id: Run identifier. The ``cep`` stage must be populated and
-            judged (only pairs with ``is_valid`` are scored).
+        pipeline_id: Run identifier. The ``cep`` stage must be populated, and
+            judged if ``scope`` is ``"approved"``.
         settings: Emic-judge LLM configuration. Defaults to
             :class:`EmicJudgeSettings` (reads ``ARANDU_EMIC_JUDGE_*``).
         base_dir: Override the project ``results/`` root.
         rerun: If True, clear the checkpoint so every source is re-scored.
+        scope: Which pairs to score. ``"all"`` (default) scores every pair and
+            records its ``judge-qa`` verdict, so emic validity can be
+            cross-tabulated against approval; ``"approved"`` scores only
+            canonically-approved pairs. Defaults to ``"all"`` because the emic
+            score is the study's corpus-wide measurement, not a filter applied
+            after ``judge-qa`` — at the cost of scoring the rejected pairs too.
 
     Returns:
         :class:`EmicJudgeResult` summary.
@@ -109,7 +123,8 @@ def run_emic_judge_batch(
     checkpoint.set_total_files(len(cep_paths))
 
     completed_sources = resumed_sources = failed_sources = 0
-    approved = scored = failed = unjudged = 0
+    selected = scored = failed = skipped = 0
+    approved = rejected = unjudged = 0
     for path in cep_paths:
         ckpt_key = path.stem
         if checkpoint.is_completed(ckpt_key):
@@ -126,11 +141,22 @@ def run_emic_judge_batch(
         scores: list[EmicScore] = []
         for idx, pair in enumerate(record.qa_pairs):
             if pair.is_valid is None:
-                unjudged += 1  # never judged; can't be canonically approved
+                unjudged += 1  # never judged; cannot be canonically approved
+            elif pair.is_valid:
+                approved += 1
+            else:
+                rejected += 1
+
+            # Under "approved" only canonically-approved pairs are scored; a
+            # never-judged pair is not approved, so it is skipped too. Under
+            # "all" every pair is scored and its verdict (including None) is
+            # recorded on the score, which is what makes the emic-validity x
+            # judge-approval cross-tabulation possible downstream.
+            if scope == "approved" and pair.is_valid is not True:
+                skipped += 1
                 continue
-            if not pair.is_valid:
-                continue  # judged and rejected — only approved pairs are scored
-            approved += 1
+
+            selected += 1
             result = criterion.evaluate(
                 context=pair.context,
                 question=pair.question,
@@ -147,6 +173,7 @@ def run_emic_judge_batch(
                     emic_score=result.ordinal_score,
                     rationale=result.rationale,
                     error=result.error,
+                    is_valid=pair.is_valid,
                 )
             )
 
@@ -160,9 +187,10 @@ def run_emic_judge_batch(
 
     if unjudged:
         logger.warning(
-            "%d pair(s) had no judge verdict (is_valid is None) and were skipped; "
-            "the run may not have been fully judged via `arandu judge-qa`.",
+            "%d pair(s) had no judge verdict (is_valid is None); they were %s. "
+            "The run may not have been fully judged via `arandu judge-qa`.",
             unjudged,
+            "scored with a null verdict" if scope == "all" else "skipped",
         )
 
     # Mirror the judge-answers convention: record progress and finalize the run
@@ -173,25 +201,34 @@ def run_emic_judge_batch(
     results_mgr.complete_run(success=(failed_sources == 0))
 
     logger.info(
-        "Emic judge complete: %d/%d sources scored (%d resumed, %d failed), "
-        "%d approved pairs, %d scored, %d failed, %d unjudged.",
+        "Emic judge complete (scope=%s): %d/%d sources scored (%d resumed, %d failed), "
+        "%d pairs selected, %d scored, %d failed, %d skipped; "
+        "corpus split %d approved / %d rejected / %d unjudged.",
+        scope,
         completed_sources,
         len(cep_paths),
         resumed_sources,
         failed_sources,
-        approved,
+        selected,
         scored,
         failed,
+        skipped,
+        approved,
+        rejected,
         unjudged,
     )
     return EmicJudgeResult(
         pipeline_id=pipeline_id,
+        scope=scope,
         sources=len(cep_paths),
         completed_sources=completed_sources,
         resumed_sources=resumed_sources,
         failed_sources=failed_sources,
-        approved_pairs=approved,
+        selected_pairs=selected,
         scored_pairs=scored,
         failed_pairs=failed,
+        skipped_pairs=skipped,
+        approved_pairs=approved,
+        rejected_pairs=rejected,
         unjudged_pairs=unjudged,
     )

--- a/src/arandu/shared/emic/batch.py
+++ b/src/arandu/shared/emic/batch.py
@@ -39,10 +39,14 @@ from arandu.shared.judge.criterion import OrdinalLLMCriterion
 from arandu.shared.llm_client import build_llm_client_from_settings
 from arandu.shared.results_manager import ResultsManager
 from arandu.shared.schemas import PipelineType
+from arandu.utils.concurrency import map_concurrent
 from arandu.utils.paths import get_project_root
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+    from arandu.qa.schemas import QAPairCEP
+    from arandu.shared.judge.schemas import CriterionScore
 
 logger = logging.getLogger(__name__)
 
@@ -119,6 +123,15 @@ def run_emic_judge_batch(
             stale.unlink()
     checkpoint = CheckpointManager(checkpoint_path)
 
+    def _score_pair(item: tuple[int, QAPairCEP]) -> CriterionScore:
+        """Evaluate one pair. Runs on a worker thread; must not touch state."""
+        _, pair = item
+        return criterion.evaluate(
+            context=pair.context,
+            question=pair.question,
+            answer=pair.answer,
+        )
+
     cep_paths = sorted(cep_outputs.glob("*_cep_qa.json"))
     checkpoint.set_total_files(len(cep_paths))
 
@@ -138,7 +151,7 @@ def run_emic_judge_batch(
             failed_sources += 1
             continue
 
-        scores: list[EmicScore] = []
+        in_scope: list[tuple[int, QAPairCEP]] = []
         for idx, pair in enumerate(record.qa_pairs):
             if pair.is_valid is None:
                 unjudged += 1  # never judged; cannot be canonically approved
@@ -155,27 +168,64 @@ def run_emic_judge_batch(
             if scope == "approved" and pair.is_valid is not True:
                 skipped += 1
                 continue
+            in_scope.append((idx, pair))
 
-            selected += 1
-            result = criterion.evaluate(
-                context=pair.context,
-                question=pair.question,
-                answer=pair.answer,
-            )
-            if result.ordinal_score is None:
+        selected += len(in_scope)
+        # Workers only run `_score_pair`; the checkpoint write and the source
+        # file save stay on this thread, so no locking is needed (same split as
+        # judge-answers). Concurrency is per source rather than across the whole
+        # corpus because a source's scores are persisted as one file: the loop
+        # drains before writing, which costs a short tail per source but keeps
+        # the per-source checkpoint honest.
+        by_index: dict[int, EmicScore] = {}
+        #
+        # No `rate_limit_of`: it would be dead code here. The adaptive throttle
+        # only sees exceptions that escape `fn`, but `JudgeCriterion.evaluate`
+        # catches every exception and returns an error score
+        # (judge/criterion.py), so an exhausted 429 budget never reaches this
+        # layer. Passing the predicate would build a throttle that can only ever
+        # record successes. The consequence is real and worth knowing before
+        # raising workers against a metered provider: a rate-limited pair
+        # becomes `emic_score=None` with the error recorded, counted in
+        # `failed_pairs` and warned about, rather than being backed off and
+        # retried.
+        for (idx, pair), evaluation, error in map_concurrent(
+            _score_pair,
+            in_scope,
+            workers=resolved.workers,
+        ):
+            if error is not None:
+                # Defensive: JudgeCriterion.evaluate already converts failures
+                # into an error score, so this branch means something outside
+                # the criterion broke. Isolate the pair instead of losing the
+                # whole source.
+                logger.warning("Scoring pair %d of %s failed: %s", idx, path.name, error)
+                failed += 1
+                by_index[idx] = EmicScore(
+                    pair_index=idx,
+                    bloom_level=pair.bloom_level,
+                    emic_score=None,
+                    rationale="",
+                    error=str(error),
+                    is_valid=pair.is_valid,
+                )
+                continue
+            if evaluation.ordinal_score is None:
                 failed += 1
             else:
                 scored += 1
-            scores.append(
-                EmicScore(
-                    pair_index=idx,
-                    bloom_level=pair.bloom_level,
-                    emic_score=result.ordinal_score,
-                    rationale=result.rationale,
-                    error=result.error,
-                    is_valid=pair.is_valid,
-                )
+            by_index[idx] = EmicScore(
+                pair_index=idx,
+                bloom_level=pair.bloom_level,
+                emic_score=evaluation.ordinal_score,
+                rationale=evaluation.rationale,
+                error=evaluation.error,
+                is_valid=pair.is_valid,
             )
+
+        # map_concurrent yields in completion order once workers > 1; restore
+        # pair order so the output file is stable across worker counts.
+        scores = [by_index[i] for i in sorted(by_index)]
 
         EmicSourceScores(
             source_file_id=record.source_file_id,

--- a/src/arandu/shared/emic/schemas.py
+++ b/src/arandu/shared/emic/schemas.py
@@ -3,12 +3,21 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Literal
 
 from pydantic import BaseModel, Field
 
+EmicScope = Literal["all", "approved"]
+"""Which CEP pairs the emic judge scores.
+
+``all`` scores every pair regardless of the ``judge-qa`` verdict, so emic
+validity can be cross-tabulated against approval. ``approved`` scores only
+canonically-approved pairs (``is_valid`` true).
+"""
+
 
 class EmicScore(BaseModel):
-    """One ordinal emic-validity score for a canonical-approved QA pair.
+    """One ordinal emic-validity score for a QA pair.
 
     Attributes:
         pair_index: Index of the pair within its source ``QARecordCEP``
@@ -18,6 +27,11 @@ class EmicScore(BaseModel):
             errored for this pair.
         rationale: The judge's short justification.
         error: Error message when ``emic_score`` is ``None``.
+        is_valid: The pair's ``judge-qa`` verdict at scoring time — ``True``
+            approved, ``False`` rejected, ``None`` never judged. Carried so
+            emic validity can be cross-tabulated against approval without
+            re-joining the CEP records, and so the sample builder can restrict
+            its frame to approved pairs even when the run scored everything.
     """
 
     pair_index: int = Field(..., ge=0)
@@ -25,10 +39,11 @@ class EmicScore(BaseModel):
     emic_score: int | None
     rationale: str
     error: str | None = None
+    is_valid: bool | None = None
 
 
 class EmicSourceScores(BaseModel):
-    """Emic-validity scores for one source interview's approved pairs."""
+    """Emic-validity scores for the in-scope pairs of one source interview."""
 
     source_file_id: str
     source_filename: str
@@ -49,31 +64,52 @@ class EmicJudgeResult(BaseModel):
 
     Source-level counters (``completed_sources``/``resumed_sources``/
     ``failed_sources``) account for *this* invocation; ``sources`` is the total
-    number of CEP source files seen. Pair-level counters
-    (``approved_pairs``/``scored_pairs``/``failed_pairs``/``unjudged_pairs``)
-    likewise reflect only the sources processed this run (resumed sources are
-    not re-counted), so a no-op ``--resume`` legitimately reports zero pairs.
+    number of CEP source files seen. Pair-level counters likewise reflect only
+    the sources processed this run (resumed sources are not re-counted), so a
+    no-op ``--resume`` legitimately reports zero pairs.
+
+    ``selected_pairs`` is the scope-dependent denominator: under ``all`` every
+    pair of a processed source is selected, under ``approved`` only the
+    canonically-approved ones. It always equals
+    ``scored_pairs + failed_pairs``, and
+    ``selected_pairs + skipped_pairs`` always equals
+    ``approved_pairs + rejected_pairs + unjudged_pairs``.
 
     Attributes:
         pipeline_id: Run identifier.
+        scope: Which pairs this run scored (see :data:`EmicScope`).
         sources: Total CEP source files discovered.
         completed_sources: Sources scored and persisted this invocation.
         resumed_sources: Sources skipped because already checkpointed.
         failed_sources: Sources that failed to load (skipped, no output).
-        approved_pairs: Canonical-approved pairs encountered this run.
-        scored_pairs: Approved pairs that received an ordinal score.
-        failed_pairs: Approved pairs whose LLM call errored.
-        unjudged_pairs: Pairs skipped because the run was never judged
-            (``is_valid is None``); a non-zero value signals a missing
+        selected_pairs: Pairs the scope selected for scoring this run.
+        scored_pairs: Selected pairs that received an ordinal score.
+        failed_pairs: Selected pairs whose LLM call errored.
+        skipped_pairs: Pairs excluded by the scope (always 0 under ``all``).
+        approved_pairs: Pairs encountered whose ``judge-qa`` verdict was
+            approve. Corpus composition, not a selection count: under
+            ``approved`` it equals ``selected_pairs``, under ``all`` it is a
+            subset of it.
+        rejected_pairs: Pairs encountered whose ``judge-qa`` verdict was
+            reject. Counted under both scopes (under ``approved`` they are
+            counted and then skipped), so the corpus split stays visible
+            whichever scope ran.
+        unjudged_pairs: Pairs encountered with no ``judge-qa`` verdict
+            (``is_valid is None``). Scored under ``all``, skipped under
+            ``approved``. A non-zero value signals a missing or partial
             ``arandu judge-qa`` step.
     """
 
     pipeline_id: str
+    scope: EmicScope
     sources: int
     completed_sources: int = 0
     resumed_sources: int = 0
     failed_sources: int = 0
-    approved_pairs: int
+    selected_pairs: int
     scored_pairs: int
     failed_pairs: int
+    skipped_pairs: int = 0
+    approved_pairs: int = 0
+    rejected_pairs: int = 0
     unjudged_pairs: int = 0

--- a/src/arandu/shared/emic/schemas.py
+++ b/src/arandu/shared/emic/schemas.py
@@ -7,6 +7,8 @@ from typing import Literal
 
 from pydantic import BaseModel, Field
 
+from arandu.shared.emic.settings import EmicJudgeSettings  # noqa: TC001 (Pydantic field type)
+
 EmicScope = Literal["all", "approved"]
 """Which CEP pairs the emic judge scores.
 
@@ -27,7 +29,7 @@ class EmicScore(BaseModel):
             errored for this pair.
         rationale: The judge's short justification.
         error: Error message when ``emic_score`` is ``None``.
-        is_valid: The pair's ``judge-qa`` verdict at scoring time — ``True``
+        is_valid: The pair's ``judge-qa`` verdict at scoring time: ``True``
             approved, ``False`` rejected, ``None`` never judged. Carried so
             emic validity can be cross-tabulated against approval without
             re-joining the CEP records, and so the sample builder can restrict
@@ -43,10 +45,24 @@ class EmicScore(BaseModel):
 
 
 class EmicSourceScores(BaseModel):
-    """Emic-validity scores for the in-scope pairs of one source interview."""
+    """Emic-validity scores for the in-scope pairs of one source interview.
+
+    Attributes:
+        source_file_id: Source interview id.
+        source_filename: Original media filename.
+        scope: The scope this file was produced under. Persisted because an
+            ``approved``-scope file is otherwise byte-indistinguishable from an
+            ``all``-scope one in which the judge approved everything, which
+            would make a downstream emic-validity x approval cross-tabulation
+            silently report 0 rejected pairs instead of "rejected pairs were
+            never scored". Defaults to ``None`` for files written before the
+            field existed.
+        scores: Per-pair ordinal scores.
+    """
 
     source_file_id: str
     source_filename: str
+    scope: EmicScope | None = None
     scores: list[EmicScore]
 
     def save(self, path: str | Path) -> None:
@@ -57,6 +73,21 @@ class EmicSourceScores(BaseModel):
     def load(cls, path: str | Path) -> EmicSourceScores:
         """Load per-source scores from JSON."""
         return cls.model_validate_json(Path(path).read_text(encoding="utf-8"))
+
+
+class EmicJudgeRunConfig(BaseModel):
+    """Config snapshotted into ``run_metadata.json`` for an emic-judge run.
+
+    Wraps the LLM settings together with the ``scope``, which is a CLI argument
+    rather than a settings field and would otherwise never reach any artifact.
+
+    Attributes:
+        scope: Which pairs the run scored (see :data:`EmicScope`).
+        llm: The resolved LLM settings for the run.
+    """
+
+    scope: EmicScope
+    llm: EmicJudgeSettings
 
 
 class EmicJudgeResult(BaseModel):
@@ -81,7 +112,11 @@ class EmicJudgeResult(BaseModel):
         sources: Total CEP source files discovered.
         completed_sources: Sources scored and persisted this invocation.
         resumed_sources: Sources skipped because already checkpointed.
-        failed_sources: Sources that failed to load (skipped, no output).
+        failed_sources: Sources that failed to load, or whose every selected
+            pair errored. The second case matters: a dead LLM sidecar produces
+            a full set of null scores rather than an exception, so without it a
+            total outage would be checkpointed as a successful run that
+            ``--resume`` never retries.
         selected_pairs: Pairs the scope selected for scoring this run.
         scored_pairs: Selected pairs that received an ordinal score.
         failed_pairs: Selected pairs whose LLM call errored.

--- a/src/arandu/shared/emic/schemas.py
+++ b/src/arandu/shared/emic/schemas.py
@@ -1,4 +1,4 @@
-"""Schemas for the emic-validity pre-pass artifacts (spec §5)."""
+"""Schemas for the emic-validity judge artifacts (spec §5)."""
 
 from __future__ import annotations
 
@@ -28,7 +28,7 @@ class EmicScore(BaseModel):
 
 
 class EmicSourceScores(BaseModel):
-    """Emic pre-pass scores for one source interview's approved pairs."""
+    """Emic-validity scores for one source interview's approved pairs."""
 
     source_file_id: str
     source_filename: str
@@ -44,8 +44,8 @@ class EmicSourceScores(BaseModel):
         return cls.model_validate_json(Path(path).read_text(encoding="utf-8"))
 
 
-class EmicPrepassResult(BaseModel):
-    """Summary of an emic pre-pass run.
+class EmicJudgeResult(BaseModel):
+    """Summary of an emic-validity judge run.
 
     Source-level counters (``completed_sources``/``resumed_sources``/
     ``failed_sources``) account for *this* invocation; ``sources`` is the total

--- a/src/arandu/shared/emic/settings.py
+++ b/src/arandu/shared/emic/settings.py
@@ -1,4 +1,4 @@
-"""Settings for ``arandu emic-prepass`` (env prefix ``ARANDU_EMIC_PREPASS_``)."""
+"""Settings for ``arandu emic-judge`` (env prefix ``ARANDU_EMIC_JUDGE_``)."""
 
 from __future__ import annotations
 
@@ -10,21 +10,25 @@ from pydantic_settings import SettingsConfigDict
 from arandu.shared.llm_settings import LLMSettings
 
 
-class EmicPrepassSettings(LLMSettings):
-    """LLM settings for the ordinal emic-validity pre-pass (spec §5).
+class EmicJudgeSettings(LLMSettings):
+    """LLM settings for the ordinal emic-validity judge (spec §5).
 
     A thin subclass of :class:`LLMSettings` (same pattern as the answerer /
     judge / non-answerable stages): inherits the canonical LLM fields and the
-    provider normalizer, pins the ``ARANDU_EMIC_PREPASS_`` env prefix, and
-    overrides only the two defaults the pre-pass deliberately changes. The
-    score is a sampling aid, **not** ground truth (the human annotators are the
-    reference), so a modest model is fine and the pre-pass can run a cheaper
-    model than the judge via ``ARANDU_EMIC_PREPASS_MODEL_ID``.
+    provider normalizer, pins the ``ARANDU_EMIC_JUDGE_`` env prefix, and
+    overrides only the two defaults the emic judgment deliberately changes.
+
+    Model choice is a **methodological** decision here, not a budget one: the
+    scores this stage produces are the measurement the study reports, and the
+    human annotation validates them (it does not replace them). Changing
+    ``ARANDU_EMIC_JUDGE_MODEL_ID`` changes the instrument under test, so a run
+    used for the agreement study must pin the same model as the one the thesis
+    describes.
 
     Attributes:
         temperature: Sampling temperature. Default 0.1: the emic judgment is
             structural, not creative (spec §4.2 principle 8). Still
-            env-overridable via ``ARANDU_EMIC_PREPASS_TEMPERATURE``.
+            env-overridable via ``ARANDU_EMIC_JUDGE_TEMPERATURE``.
         language: Prompt language. Narrowed to ``"pt"`` only (that is the only
             ``emic_validity`` prompt template that ships today).
     """
@@ -32,4 +36,4 @@ class EmicPrepassSettings(LLMSettings):
     temperature: float = Field(default=0.1, ge=0.0, le=2.0)
     language: Literal["pt"] = Field(default="pt")
 
-    model_config = SettingsConfigDict(env_prefix="ARANDU_EMIC_PREPASS_")
+    model_config = SettingsConfigDict(env_prefix="ARANDU_EMIC_JUDGE_")

--- a/src/arandu/shared/emic/settings.py
+++ b/src/arandu/shared/emic/settings.py
@@ -25,6 +25,10 @@ class EmicJudgeSettings(LLMSettings):
     used for the agreement study must pin the same model as the one the thesis
     describes.
 
+    Concurrency comes from the inherited ``workers`` field
+    (``ARANDU_EMIC_JUDGE_WORKERS``), which this stage honours via
+    :func:`arandu.utils.concurrency.map_concurrent`.
+
     Attributes:
         temperature: Sampling temperature. Default 0.1: the emic judgment is
             structural, not creative (spec §4.2 principle 8). Still

--- a/src/arandu/shared/human_eval/batch.py
+++ b/src/arandu/shared/human_eval/batch.py
@@ -1,6 +1,6 @@
 """Batch orchestrator for ``arandu build-human-eval-sample`` (spec §5).
 
-Builds the in-frame pool from the emic pre-pass outputs (dropping null-score
+Builds the in-frame pool from the emic-judge outputs (dropping null-score
 and out-of-frame-Bloom pairs), joins each pair's CEP payload (segment +
 question + answer), runs the deterministic stratified sampler, and persists the
 80-pair sample + a provenance manifest under
@@ -59,7 +59,7 @@ def run_build_sample_batch(
     """Build the stratified human-comparison sample for ``pipeline_id``.
 
     Args:
-        pipeline_id: Run identifier. Both the ``emic_prepass`` and ``cep``
+        pipeline_id: Run identifier. Both the ``emic_judge`` and ``cep``
             stages must be populated.
         seed: RNG seed for the deterministic selection (recorded in the run
             metadata and the manifest).
@@ -70,17 +70,17 @@ def run_build_sample_batch(
         The :class:`SampleManifest` describing the build.
 
     Raises:
-        FileNotFoundError: If the emic_prepass or cep stage outputs are absent.
+        FileNotFoundError: If the emic_judge or cep stage outputs are absent.
         ValueError: If a stratification cell has fewer than ``per_cell`` pairs,
             or a referenced CEP pair cannot be resolved.
     """
     base = base_dir if base_dir is not None else ResultsConfig().base_dir
-    emic_outputs = base / pipeline_id / PipelineType.EMIC_PREPASS.value / "outputs"
+    emic_outputs = base / pipeline_id / PipelineType.EMIC_JUDGE.value / "outputs"
     cep_outputs = base / pipeline_id / PipelineType.CEP.value / "outputs"
     if not emic_outputs.exists():
         raise FileNotFoundError(
-            f"Emic pre-pass outputs not found for pipeline_id {pipeline_id!r}: {emic_outputs}. "
-            f"Run `arandu emic-prepass --id {pipeline_id}` first."
+            f"Emic-judge outputs not found for pipeline_id {pipeline_id!r}: {emic_outputs}. "
+            f"Run `arandu emic-judge --id {pipeline_id}` first."
         )
     if not cep_outputs.exists():
         raise FileNotFoundError(
@@ -117,8 +117,8 @@ def run_build_sample_batch(
             if pair_id in seen_pair_ids:
                 raise ValueError(
                     f"Duplicate pair_id {pair_id!r} while pooling {emic_path.name}; the "
-                    f"emic_prepass outputs likely contain a stale or duplicate file for this "
-                    f"source. Clean results/{pipeline_id}/emic_prepass/outputs/ and re-run."
+                    f"emic_judge outputs likely contain a stale or duplicate file for this "
+                    f"source. Clean results/{pipeline_id}/emic_judge/outputs/ and re-run."
                 )
             seen_pair_ids.add(pair_id)
             pair = record.qa_pairs[score.pair_index]
@@ -139,7 +139,7 @@ def run_build_sample_batch(
         raise ValueError(
             f"No in-frame approved pairs found for {pipeline_id!r} "
             f"({excluded_none} null-score, {sum(excluded_bloom.values())} out-of-frame-Bloom "
-            f"excluded). Check that `arandu judge-qa` + `arandu emic-prepass` ran and produced "
+            f"excluded). Check that `arandu judge-qa` + `arandu emic-judge` ran and produced "
             f"scored, in-frame ({', '.join(FRAME_BLOOM_LEVELS)}) pairs."
         )
 

--- a/src/arandu/shared/human_eval/batch.py
+++ b/src/arandu/shared/human_eval/batch.py
@@ -103,11 +103,26 @@ def run_build_sample_batch(
             )
         record = QARecordCEP.load(cep_path)
         for score in scores.scores:
+            if score.pair_index >= len(record.qa_pairs):
+                raise ValueError(
+                    f"pair_index {score.pair_index} out of range for {cep_path.name} "
+                    f"({len(record.qa_pairs)} pairs); emic/cep stages are out of sync."
+                )
+            pair = record.qa_pairs[score.pair_index]
+
             # An `emic-judge --scope all` run scores rejected and never-judged
             # pairs too, so the emic outputs are NOT a pool of approved pairs.
             # The agreement study's frame is the approved corpus (spec §5), so
             # drop anything the judge did not approve before banding.
-            if score.is_valid is not True:
+            #
+            # Read the verdict off the CEP record, not off `score.is_valid`:
+            # that field is a snapshot taken when the emic judge ran, so a
+            # `judge-qa` re-run (e.g. a threshold change) would leave the frame
+            # pinned to the old verdicts, sampling pairs the corpus now rejects
+            # and excluding ones it now approves. The record loaded above is the
+            # authoritative copy. `score.is_valid` remains the provenance record
+            # of what the emic run saw.
+            if pair.is_valid is not True:
                 excluded_not_approved += 1
                 continue
             if score.emic_score is None:
@@ -116,11 +131,6 @@ def run_build_sample_batch(
             if score.bloom_level not in FRAME_BLOOM_LEVELS:
                 excluded_bloom[score.bloom_level] = excluded_bloom.get(score.bloom_level, 0) + 1
                 continue
-            if score.pair_index >= len(record.qa_pairs):
-                raise ValueError(
-                    f"pair_index {score.pair_index} out of range for {cep_path.name} "
-                    f"({len(record.qa_pairs)} pairs); emic/cep stages are out of sync."
-                )
             pair_id = f"{scores.source_file_id}:{score.pair_index}"
             if pair_id in seen_pair_ids:
                 raise ValueError(
@@ -129,7 +139,6 @@ def run_build_sample_batch(
                     f"source. Clean results/{pipeline_id}/emic_judge/outputs/ and re-run."
                 )
             seen_pair_ids.add(pair_id)
-            pair = record.qa_pairs[score.pair_index]
             pool.append(
                 PoolEntry(
                     pair_id=pair_id,
@@ -188,10 +197,12 @@ def run_build_sample_batch(
     results_mgr.complete_run(success=True)
 
     logger.info(
-        "Built human-eval sample: %d items across %d cells (pool=%d, excluded none=%d, bloom=%d).",
+        "Built human-eval sample: %d items across %d cells (pool=%d, excluded "
+        "not-approved=%d, none=%d, bloom=%d).",
         len(items),
         len(manifest.cell_counts),
         len(pool),
+        excluded_not_approved,
         excluded_none,
         sum(excluded_bloom.values()),
     )

--- a/src/arandu/shared/human_eval/batch.py
+++ b/src/arandu/shared/human_eval/batch.py
@@ -91,6 +91,7 @@ def run_build_sample_batch(
     pool: list[PoolEntry] = []
     seen_pair_ids: set[str] = set()
     excluded_none = 0
+    excluded_not_approved = 0
     excluded_bloom: dict[str, int] = {}
     for emic_path in sorted(emic_outputs.glob("*_cep_qa.json")):
         scores = EmicSourceScores.load(emic_path)
@@ -102,6 +103,13 @@ def run_build_sample_batch(
             )
         record = QARecordCEP.load(cep_path)
         for score in scores.scores:
+            # An `emic-judge --scope all` run scores rejected and never-judged
+            # pairs too, so the emic outputs are NOT a pool of approved pairs.
+            # The agreement study's frame is the approved corpus (spec §5), so
+            # drop anything the judge did not approve before banding.
+            if score.is_valid is not True:
+                excluded_not_approved += 1
+                continue
             if score.emic_score is None:
                 excluded_none += 1
                 continue
@@ -138,9 +146,10 @@ def run_build_sample_batch(
     if not pool:
         raise ValueError(
             f"No in-frame approved pairs found for {pipeline_id!r} "
-            f"({excluded_none} null-score, {sum(excluded_bloom.values())} out-of-frame-Bloom "
-            f"excluded). Check that `arandu judge-qa` + `arandu emic-judge` ran and produced "
-            f"scored, in-frame ({', '.join(FRAME_BLOOM_LEVELS)}) pairs."
+            f"({excluded_not_approved} not judge-approved, {excluded_none} null-score, "
+            f"{sum(excluded_bloom.values())} out-of-frame-Bloom excluded). Check that "
+            f"`arandu judge-qa` + `arandu emic-judge` ran and produced approved, scored, "
+            f"in-frame ({', '.join(FRAME_BLOOM_LEVELS)}) pairs."
         )
 
     population = population_by_cell(pool)
@@ -169,6 +178,7 @@ def run_build_sample_batch(
         cell_counts=dict.fromkeys(all_cell_ids(), per_cell),
         population_by_cell=population,
         excluded_none_score=excluded_none,
+        excluded_not_approved=excluded_not_approved,
         excluded_bloom=excluded_bloom,
         pool_sha256=pool_hash,
     )

--- a/src/arandu/shared/human_eval/sampling.py
+++ b/src/arandu/shared/human_eval/sampling.py
@@ -1,7 +1,7 @@
 """Deterministic stratified sampler for the human-comparison study (spec §5).
 
 Pure selection logic with no I/O: given an in-frame pool of approved pairs
-(each carrying its emic pre-pass ordinal score and annotation payload), build
+(each carrying its emic-judge ordinal score and annotation payload), build
 the 80-pair sample stratified as 4 Bloom levels x 2 emic bands x 10 pairs.
 Frame construction (dropping null-score and out-of-frame-Bloom pairs, joining
 the CEP payload) happens upstream in ``batch.py``.
@@ -143,7 +143,7 @@ def build_sample(pool: list[PoolEntry], seed: int, *, per_cell: int = PER_CELL) 
                     question=entry.question,
                     answer=entry.answer,
                     bloom_level=entry.bloom_level,
-                    emic_prepass_score=entry.emic_score,
+                    emic_score=entry.emic_score,
                     cell_id=cell_id,
                     slot_id=slot_id,
                 )

--- a/src/arandu/shared/human_eval/schemas.py
+++ b/src/arandu/shared/human_eval/schemas.py
@@ -66,6 +66,10 @@ class SampleManifest(BaseModel):
         population_by_cell: In-frame available count per ``cell_id`` (the pool
             each cell was sampled from).
         excluded_none_score: Approved pairs dropped for a null emic score.
+        excluded_not_approved: Scored pairs dropped because ``judge-qa`` did
+            not approve them (rejected or never judged). Non-zero whenever the
+            emic judge ran with ``--scope all``; the study's frame is the
+            approved corpus.
         excluded_bloom: Approved pairs dropped per out-of-frame Bloom level
             (``apply`` / ``create``), keyed by level.
         pool_sha256: Hash of the in-frame pool keys + scores (provenance).
@@ -78,6 +82,7 @@ class SampleManifest(BaseModel):
     cell_counts: dict[str, int]
     population_by_cell: dict[str, int]
     excluded_none_score: int = 0
+    excluded_not_approved: int = 0
     excluded_bloom: dict[str, int] = Field(default_factory=dict)
     pool_sha256: str
 

--- a/src/arandu/shared/human_eval/schemas.py
+++ b/src/arandu/shared/human_eval/schemas.py
@@ -25,7 +25,7 @@ class SampleItem(BaseModel):
     Carries the blinded annotation payload (segment + question + answer) plus
     the stratification bookkeeping. Deliberately excludes ``tacit_inference``
     and the canonical judge scores; further blinding (hiding ``bloom_level`` /
-    ``emic_prepass_score`` from the annotator) is the annotation instrument's
+    ``emic_score`` from the annotator) is the annotation instrument's
     responsibility, not this artifact's.
 
     Attributes:
@@ -36,7 +36,8 @@ class SampleItem(BaseModel):
         question: The generated question.
         answer: The generated answer.
         bloom_level: Bloom level (stratification dimension).
-        emic_prepass_score: Ordinal emic band hint {1..5} from the pre-pass.
+        emic_score: Ordinal emic-validity score {1..5} from the emic judge
+            (the measurement the annotators' ratings are compared against).
         cell_id: ``"{bloom_level}:{band}"`` stratification cell.
         slot_id: 0-based slot within the cell (0..9).
     """
@@ -48,7 +49,7 @@ class SampleItem(BaseModel):
     question: str
     answer: str
     bloom_level: str
-    emic_prepass_score: int = Field(..., ge=1, le=5)
+    emic_score: int = Field(..., ge=1, le=5)
     cell_id: str
     slot_id: int = Field(..., ge=0)
 

--- a/src/arandu/shared/llm_settings.py
+++ b/src/arandu/shared/llm_settings.py
@@ -48,9 +48,10 @@ class LLMSettings(BaseSettings):
         language: Prompt language; selects the per-stage prompt template.
         workers: Client-side concurrent LLM requests for batch runners
             wired through :func:`arandu.utils.concurrency.map_concurrent`
-            (answer, judge-answers); other stages ignore it. Pair with
-            matching server slots (``OLLAMA_NUM_PARALLEL``) and the
-            per-slot context VRAM budget (``scripts/slurm/rag/*.slurm``).
+            (answer, judge-answers, emic-judge); stages not on that list
+            ignore it. Pair with matching server slots
+            (``OLLAMA_NUM_PARALLEL``) and the per-slot context VRAM budget
+            (``scripts/slurm/rag/*.slurm``).
     """
 
     provider: str = Field(default="ollama")

--- a/src/arandu/shared/schemas.py
+++ b/src/arandu/shared/schemas.py
@@ -200,7 +200,7 @@ class PipelineType(StrEnum):
     JUDGE_ANSWERS = "judge_answers"
     ANALYSIS = "analysis"
     NON_ANSWERABLE = "non_answerable"
-    EMIC_PREPASS = "emic_prepass"
+    EMIC_JUDGE = "emic_judge"
     HUMAN_EVAL = "human_eval"
     EVALUATION = "evaluation"
 

--- a/tests/shared/emic/test_batch.py
+++ b/tests/shared/emic/test_batch.py
@@ -80,9 +80,14 @@ class TestEmicJudgeBatch:
             ],
         )
 
-        result = run_emic_judge_batch("run1", settings=settings, base_dir=tmp_path)
+        result = run_emic_judge_batch(
+            "run1", settings=settings, base_dir=tmp_path, scope="approved"
+        )
 
-        assert result.approved_pairs == 2  # the rejected pair is skipped
+        assert result.approved_pairs == 2
+        assert result.rejected_pairs == 1
+        assert result.selected_pairs == 2  # the rejected pair is skipped
+        assert result.skipped_pairs == 1
         assert result.scored_pairs == 2
         assert result.failed_pairs == 0
         assert result.sources == 1
@@ -97,6 +102,65 @@ class TestEmicJudgeBatch:
         assert [s.pair_index for s in out.scores] == [0, 2]  # original indices preserved
         assert all(s.emic_score == 2 for s in out.scores)
         assert {s.bloom_level for s in out.scores} == {"analyze", "evaluate"}
+
+    def test_scope_all_scores_every_pair_and_records_the_verdict(
+        self, tmp_path: Path, mock_emic_client: Any, settings: EmicJudgeSettings
+    ) -> None:
+        # The default scope. Every pair is scored regardless of the judge-qa
+        # verdict, and the verdict rides along on each score so emic validity
+        # can be cross-tabulated against approval downstream.
+        cep_outputs = tmp_path / "run_all" / "cep" / "outputs"
+        _write_cep_record(
+            cep_outputs,
+            "src1",
+            [
+                _pair("Q approved", approved=True),
+                _pair("Q rejected", approved=False),
+                _pair("Q unjudged", approved=False, judged=False),
+            ],
+        )
+
+        result = run_emic_judge_batch("run_all", settings=settings, base_dir=tmp_path)
+
+        assert result.scope == "all"
+        assert result.selected_pairs == 3
+        assert result.scored_pairs == 3
+        assert result.skipped_pairs == 0
+        assert result.approved_pairs == 1
+        assert result.rejected_pairs == 1
+        assert result.unjudged_pairs == 1
+        assert mock_emic_client.generate_structured.call_count == 3
+
+        out = EmicSourceScores.load(
+            tmp_path / "run_all" / "emic_judge" / "outputs" / "src1_cep_qa.json"
+        )
+        assert [s.pair_index for s in out.scores] == [0, 1, 2]
+        assert [s.is_valid for s in out.scores] == [True, False, None]
+
+    def test_scope_counters_reconcile(
+        self, tmp_path: Path, mock_emic_client: Any, settings: EmicJudgeSettings
+    ) -> None:
+        # The invariants the result docstring promises, asserted under both
+        # scopes so a future counter change cannot drift from the docs.
+        pairs = [
+            _pair("A", approved=True),
+            _pair("B", approved=True),
+            _pair("C", approved=False),
+            _pair("D", approved=False, judged=False),
+        ]
+        for idx, scope in enumerate(("all", "approved")):
+            run_id = f"run_rec{idx}"
+            _write_cep_record(tmp_path / run_id / "cep" / "outputs", "src1", list(pairs))
+
+            result = run_emic_judge_batch(run_id, settings=settings, base_dir=tmp_path, scope=scope)
+
+            assert result.selected_pairs == result.scored_pairs + result.failed_pairs
+            assert result.selected_pairs + result.skipped_pairs == (
+                result.approved_pairs + result.rejected_pairs + result.unjudged_pairs
+            )
+            assert result.approved_pairs == 2
+            assert result.rejected_pairs == 1
+            assert result.unjudged_pairs == 1
 
     def test_missing_cep_stage_raises(
         self, tmp_path: Path, mock_emic_client: Any, settings: EmicJudgeSettings
@@ -165,10 +229,14 @@ class TestEmicJudgeBatch:
             [_pair("Q1", approved=False, judged=False), _pair("Q2", approved=False, judged=False)],
         )
 
-        result = run_emic_judge_batch("run5", settings=settings, base_dir=tmp_path)
+        result = run_emic_judge_batch(
+            "run5", settings=settings, base_dir=tmp_path, scope="approved"
+        )
 
         assert result.unjudged_pairs == 2
         assert result.approved_pairs == 0
+        assert result.selected_pairs == 0
+        assert result.skipped_pairs == 2
         assert result.scored_pairs == 0
         assert mock_emic_client.generate_structured.call_count == 0  # nothing scored
         assert result.completed_sources == 1  # source still processed (empty scores)

--- a/tests/shared/emic/test_batch.py
+++ b/tests/shared/emic/test_batch.py
@@ -12,7 +12,7 @@ from arandu.shared.emic.batch import run_emic_judge_batch
 from arandu.shared.emic.schemas import EmicSourceScores
 from arandu.shared.emic.settings import EmicJudgeSettings
 from arandu.shared.judge.criterion import OrdinalCriterionResponse
-from arandu.shared.judge.schemas import JudgePipelineResult
+from arandu.shared.judge.schemas import CriterionScore, JudgePipelineResult
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -161,6 +161,85 @@ class TestEmicJudgeBatch:
             assert result.approved_pairs == 2
             assert result.rejected_pairs == 1
             assert result.unjudged_pairs == 1
+
+    @pytest.mark.parametrize("workers", [1, 4])
+    def test_output_order_is_stable_across_worker_counts(
+        self, tmp_path: Path, mocker: MockerFixture, workers: int
+    ) -> None:
+        # map_concurrent yields in completion order once workers > 1, so the
+        # batch must restore pair order before persisting. A per-pair score
+        # keyed off the question proves the score rides with the right pair and
+        # not merely that the indices are sorted.
+        client = mocker.MagicMock()
+        client.generate_structured.side_effect = lambda prompt, **_: OrdinalCriterionResponse(
+            score=int(prompt.split("MARK")[1][0]), rationale="r"
+        )
+        mocker.patch("arandu.shared.emic.batch.build_llm_client_from_settings", return_value=client)
+
+        run_id = f"run_order{workers}"
+        _write_cep_record(
+            tmp_path / run_id / "cep" / "outputs",
+            "src1",
+            [_pair(f"MARK{n} pergunta", approved=True) for n in (1, 2, 3, 4, 5)],
+        )
+
+        result = run_emic_judge_batch(
+            run_id,
+            settings=EmicJudgeSettings(provider="ollama", model_id="m", workers=workers),
+            base_dir=tmp_path,
+        )
+
+        assert result.scored_pairs == 5
+        out = EmicSourceScores.load(
+            tmp_path / run_id / "emic_judge" / "outputs" / "src1_cep_qa.json"
+        )
+        assert [s.pair_index for s in out.scores] == [0, 1, 2, 3, 4]
+        assert [s.emic_score for s in out.scores] == [1, 2, 3, 4, 5]
+
+    def test_worker_exception_isolates_the_pair(
+        self, tmp_path: Path, mocker: MockerFixture
+    ) -> None:
+        # JudgeCriterion.evaluate normally swallows failures into an error
+        # score, so this covers the defensive branch: anything escaping the
+        # criterion must fail one pair, not the whole source.
+        mocker.patch(
+            "arandu.shared.emic.batch.build_llm_client_from_settings",
+            return_value=mocker.MagicMock(),
+        )
+        calls = {"n": 0}
+
+        def _flaky(**_: Any) -> CriterionScore:
+            calls["n"] += 1
+            if calls["n"] == 2:
+                raise RuntimeError("boom outside the criterion")
+            return CriterionScore(ordinal_score=4, scale="ordinal", threshold=0.0, rationale="r")
+
+        mocker.patch(
+            "arandu.shared.judge.criterion.OrdinalLLMCriterion.evaluate", side_effect=_flaky
+        )
+
+        _write_cep_record(
+            tmp_path / "run_iso" / "cep" / "outputs",
+            "src1",
+            [_pair(f"Q{n}", approved=True) for n in range(3)],
+        )
+
+        result = run_emic_judge_batch(
+            "run_iso",
+            settings=EmicJudgeSettings(provider="ollama", model_id="m", workers=1),
+            base_dir=tmp_path,
+        )
+
+        assert result.selected_pairs == 3
+        assert result.failed_pairs == 1
+        assert result.completed_sources == 1  # the source still got persisted
+        out = EmicSourceScores.load(
+            tmp_path / "run_iso" / "emic_judge" / "outputs" / "src1_cep_qa.json"
+        )
+        assert len(out.scores) == 3
+        failed = [s for s in out.scores if s.emic_score is None]
+        assert len(failed) == 1
+        assert "boom outside the criterion" in (failed[0].error or "")
 
     def test_missing_cep_stage_raises(
         self, tmp_path: Path, mock_emic_client: Any, settings: EmicJudgeSettings

--- a/tests/shared/emic/test_batch.py
+++ b/tests/shared/emic/test_batch.py
@@ -295,12 +295,14 @@ class TestEmicJudgeBatch:
         assert out.scores[0].emic_score is None
         assert out.scores[0].error is not None
 
-    def test_unjudged_pairs_are_skipped_and_flagged(
+    def test_wholly_unjudged_corpus_aborts_before_any_llm_call(
         self, tmp_path: Path, mock_emic_client: Any, settings: EmicJudgeSettings
     ) -> None:
-        # A run that was CEP-populated but never judge-qa'd: is_valid is None
-        # for every pair, so nothing is scored and the result flags the gap
-        # instead of reporting a clean 0/0 success.
+        # A CEP-populated but never judge-qa'd run. Under the default scope
+        # every pair is in scope, so without a preflight this would spend a full
+        # GPU allocation producing scores whose verdicts are all null -- and the
+        # sample builder discards every one of them, since its frame is the
+        # approved corpus. Abort before the client is even built.
         cep_outputs = tmp_path / "run5" / "cep" / "outputs"
         _write_cep_record(
             cep_outputs,
@@ -308,21 +310,109 @@ class TestEmicJudgeBatch:
             [_pair("Q1", approved=False, judged=False), _pair("Q2", approved=False, judged=False)],
         )
 
-        result = run_emic_judge_batch(
-            "run5", settings=settings, base_dir=tmp_path, scope="approved"
+        with pytest.raises(ValueError, match="carries a judge-qa verdict"):
+            run_emic_judge_batch("run5", settings=settings, base_dir=tmp_path)
+
+        assert mock_emic_client.generate_structured.call_count == 0
+        # No run dir left behind in IN_PROGRESS.
+        assert not (tmp_path / "run5" / "emic_judge").exists()
+
+    def test_partially_unjudged_corpus_still_runs(
+        self, tmp_path: Path, mock_emic_client: Any, settings: EmicJudgeSettings
+    ) -> None:
+        # The preflight only guards the wholly-unjudged case; a run with some
+        # judged pairs proceeds and records the null verdicts.
+        _write_cep_record(
+            tmp_path / "run5b" / "cep" / "outputs",
+            "src1",
+            [_pair("Q1", approved=True), _pair("Q2", approved=False, judged=False)],
         )
 
-        assert result.unjudged_pairs == 2
-        assert result.approved_pairs == 0
-        assert result.selected_pairs == 0
-        assert result.skipped_pairs == 2
-        assert result.scored_pairs == 0
-        assert mock_emic_client.generate_structured.call_count == 0  # nothing scored
-        assert result.completed_sources == 1  # source still processed (empty scores)
+        result = run_emic_judge_batch("run5b", settings=settings, base_dir=tmp_path)
+
+        assert result.selected_pairs == 2
+        assert result.unjudged_pairs == 1
         out = EmicSourceScores.load(
-            tmp_path / "run5" / "emic_judge" / "outputs" / "src1_cep_qa.json"
+            tmp_path / "run5b" / "emic_judge" / "outputs" / "src1_cep_qa.json"
         )
-        assert out.scores == []
+        assert [s.is_valid for s in out.scores] == [True, None]
+
+    def test_source_with_every_pair_failing_is_marked_failed_not_completed(
+        self, tmp_path: Path, mocker: MockerFixture
+    ) -> None:
+        # A dead LLM endpoint does not raise: JudgeCriterion.evaluate turns it
+        # into an error score. Without this guard the source would be
+        # checkpointed as done, the run reported successful, and `--resume`
+        # would never retry it.
+        mocker.patch(
+            "arandu.shared.emic.batch.build_llm_client_from_settings",
+            return_value=mocker.MagicMock(),
+        )
+        mocker.patch(
+            "arandu.shared.judge.criterion.OrdinalLLMCriterion.evaluate",
+            return_value=CriterionScore(
+                ordinal_score=None,
+                scale="ordinal",
+                threshold=0.0,
+                rationale="",
+                error="connection refused",
+            ),
+        )
+        _write_cep_record(
+            tmp_path / "run_dead" / "cep" / "outputs",
+            "src1",
+            [_pair(f"Q{n}", approved=True) for n in range(3)],
+        )
+
+        result = run_emic_judge_batch(
+            "run_dead",
+            settings=EmicJudgeSettings(provider="ollama", model_id="m"),
+            base_dir=tmp_path,
+        )
+
+        assert result.failed_pairs == 3
+        assert result.scored_pairs == 0
+        assert result.failed_sources == 1
+        assert result.completed_sources == 0
+
+        meta = json.loads(
+            (tmp_path / "run_dead" / "emic_judge" / "run_metadata.json").read_text(encoding="utf-8")
+        )
+        assert meta["status"] != "completed"
+
+        # And a resume must retry it rather than skip it.
+        again = run_emic_judge_batch(
+            "run_dead",
+            settings=EmicJudgeSettings(provider="ollama", model_id="m"),
+            base_dir=tmp_path,
+        )
+        assert again.resumed_sources == 0
+        assert again.selected_pairs == 3
+
+    def test_scope_is_part_of_the_resume_identity(
+        self, tmp_path: Path, mock_emic_client: Any, settings: EmicJudgeSettings
+    ) -> None:
+        # Switching scope must re-score, not silently reuse the narrower corpus.
+        _write_cep_record(
+            tmp_path / "run_sc" / "cep" / "outputs",
+            "src1",
+            [_pair("A", approved=True), _pair("B", approved=False)],
+        )
+
+        first = run_emic_judge_batch(
+            "run_sc", settings=settings, base_dir=tmp_path, scope="approved"
+        )
+        assert first.selected_pairs == 1
+
+        second = run_emic_judge_batch("run_sc", settings=settings, base_dir=tmp_path, scope="all")
+        assert second.resumed_sources == 0  # not skipped
+        assert second.selected_pairs == 2
+
+        out = EmicSourceScores.load(
+            tmp_path / "run_sc" / "emic_judge" / "outputs" / "src1_cep_qa.json"
+        )
+        assert out.scope == "all"
+        assert [s.is_valid for s in out.scores] == [True, False]
 
     def test_load_failure_counts_failed_source_and_marks_run_failed(
         self, tmp_path: Path, mock_emic_client: Any, settings: EmicJudgeSettings

--- a/tests/shared/emic/test_batch.py
+++ b/tests/shared/emic/test_batch.py
@@ -1,4 +1,4 @@
-"""Tests for the emic-validity pre-pass batch (spec §5)."""
+"""Tests for the emic-validity judge batch (spec §5)."""
 
 from __future__ import annotations
 
@@ -8,9 +8,9 @@ from typing import TYPE_CHECKING, Any
 import pytest
 
 from arandu.qa.schemas import QAPairCEP, QARecordCEP
-from arandu.shared.emic.batch import run_emic_prepass_batch
+from arandu.shared.emic.batch import run_emic_judge_batch
 from arandu.shared.emic.schemas import EmicSourceScores
-from arandu.shared.emic.settings import EmicPrepassSettings
+from arandu.shared.emic.settings import EmicJudgeSettings
 from arandu.shared.judge.criterion import OrdinalCriterionResponse
 from arandu.shared.judge.schemas import JudgePipelineResult
 
@@ -61,13 +61,13 @@ def mock_emic_client(mocker: MockerFixture) -> Any:
 
 
 @pytest.fixture
-def settings() -> EmicPrepassSettings:
-    return EmicPrepassSettings(provider="ollama", model_id="test-model")
+def settings() -> EmicJudgeSettings:
+    return EmicJudgeSettings(provider="ollama", model_id="test-model")
 
 
-class TestEmicPrepassBatch:
+class TestEmicJudgeBatch:
     def test_scores_only_approved_pairs(
-        self, tmp_path: Path, mock_emic_client: Any, settings: EmicPrepassSettings
+        self, tmp_path: Path, mock_emic_client: Any, settings: EmicJudgeSettings
     ) -> None:
         cep_outputs = tmp_path / "run1" / "cep" / "outputs"
         _write_cep_record(
@@ -80,7 +80,7 @@ class TestEmicPrepassBatch:
             ],
         )
 
-        result = run_emic_prepass_batch("run1", settings=settings, base_dir=tmp_path)
+        result = run_emic_judge_batch("run1", settings=settings, base_dir=tmp_path)
 
         assert result.approved_pairs == 2  # the rejected pair is skipped
         assert result.scored_pairs == 2
@@ -92,30 +92,30 @@ class TestEmicPrepassBatch:
         assert result.unjudged_pairs == 0
 
         out = EmicSourceScores.load(
-            tmp_path / "run1" / "emic_prepass" / "outputs" / "src1_cep_qa.json"
+            tmp_path / "run1" / "emic_judge" / "outputs" / "src1_cep_qa.json"
         )
         assert [s.pair_index for s in out.scores] == [0, 2]  # original indices preserved
         assert all(s.emic_score == 2 for s in out.scores)
         assert {s.bloom_level for s in out.scores} == {"analyze", "evaluate"}
 
     def test_missing_cep_stage_raises(
-        self, tmp_path: Path, mock_emic_client: Any, settings: EmicPrepassSettings
+        self, tmp_path: Path, mock_emic_client: Any, settings: EmicJudgeSettings
     ) -> None:
         with pytest.raises(FileNotFoundError, match="CEP outputs not found"):
-            run_emic_prepass_batch("absent", settings=settings, base_dir=tmp_path)
+            run_emic_judge_batch("absent", settings=settings, base_dir=tmp_path)
 
     def test_resume_skips_completed_sources(
-        self, tmp_path: Path, mock_emic_client: Any, settings: EmicPrepassSettings
+        self, tmp_path: Path, mock_emic_client: Any, settings: EmicJudgeSettings
     ) -> None:
         cep_outputs = tmp_path / "run2" / "cep" / "outputs"
         _write_cep_record(cep_outputs, "src1", [_pair("Q", approved=True)])
 
-        run_emic_prepass_batch("run2", settings=settings, base_dir=tmp_path)
+        run_emic_judge_batch("run2", settings=settings, base_dir=tmp_path)
         calls_after_first = mock_emic_client.generate_structured.call_count
         assert calls_after_first == 1
 
         # Second run resumes: the source is already checkpointed, no new calls.
-        second = run_emic_prepass_batch("run2", settings=settings, base_dir=tmp_path)
+        second = run_emic_judge_batch("run2", settings=settings, base_dir=tmp_path)
         assert mock_emic_client.generate_structured.call_count == calls_after_first
         assert second.scored_pairs == 0  # nothing re-scored on resume
         assert second.approved_pairs == 0  # resumed sources are not re-counted
@@ -124,17 +124,17 @@ class TestEmicPrepassBatch:
         assert second.sources == 1
 
     def test_rerun_rescores(
-        self, tmp_path: Path, mock_emic_client: Any, settings: EmicPrepassSettings
+        self, tmp_path: Path, mock_emic_client: Any, settings: EmicJudgeSettings
     ) -> None:
         cep_outputs = tmp_path / "run3" / "cep" / "outputs"
         _write_cep_record(cep_outputs, "src1", [_pair("Q", approved=True)])
 
-        run_emic_prepass_batch("run3", settings=settings, base_dir=tmp_path)
-        run_emic_prepass_batch("run3", settings=settings, base_dir=tmp_path, rerun=True)
+        run_emic_judge_batch("run3", settings=settings, base_dir=tmp_path)
+        run_emic_judge_batch("run3", settings=settings, base_dir=tmp_path, rerun=True)
         assert mock_emic_client.generate_structured.call_count == 2
 
     def test_llm_error_records_failed_pair(
-        self, tmp_path: Path, mocker: MockerFixture, settings: EmicPrepassSettings
+        self, tmp_path: Path, mocker: MockerFixture, settings: EmicJudgeSettings
     ) -> None:
         client = mocker.MagicMock()
         client.generate_structured.side_effect = RuntimeError("llm down")
@@ -143,17 +143,17 @@ class TestEmicPrepassBatch:
         cep_outputs = tmp_path / "run4" / "cep" / "outputs"
         _write_cep_record(cep_outputs, "src1", [_pair("Q", approved=True)])
 
-        result = run_emic_prepass_batch("run4", settings=settings, base_dir=tmp_path)
+        result = run_emic_judge_batch("run4", settings=settings, base_dir=tmp_path)
         assert result.failed_pairs == 1
         assert result.scored_pairs == 0
         out = EmicSourceScores.load(
-            tmp_path / "run4" / "emic_prepass" / "outputs" / "src1_cep_qa.json"
+            tmp_path / "run4" / "emic_judge" / "outputs" / "src1_cep_qa.json"
         )
         assert out.scores[0].emic_score is None
         assert out.scores[0].error is not None
 
     def test_unjudged_pairs_are_skipped_and_flagged(
-        self, tmp_path: Path, mock_emic_client: Any, settings: EmicPrepassSettings
+        self, tmp_path: Path, mock_emic_client: Any, settings: EmicJudgeSettings
     ) -> None:
         # A run that was CEP-populated but never judge-qa'd: is_valid is None
         # for every pair, so nothing is scored and the result flags the gap
@@ -165,7 +165,7 @@ class TestEmicPrepassBatch:
             [_pair("Q1", approved=False, judged=False), _pair("Q2", approved=False, judged=False)],
         )
 
-        result = run_emic_prepass_batch("run5", settings=settings, base_dir=tmp_path)
+        result = run_emic_judge_batch("run5", settings=settings, base_dir=tmp_path)
 
         assert result.unjudged_pairs == 2
         assert result.approved_pairs == 0
@@ -173,12 +173,12 @@ class TestEmicPrepassBatch:
         assert mock_emic_client.generate_structured.call_count == 0  # nothing scored
         assert result.completed_sources == 1  # source still processed (empty scores)
         out = EmicSourceScores.load(
-            tmp_path / "run5" / "emic_prepass" / "outputs" / "src1_cep_qa.json"
+            tmp_path / "run5" / "emic_judge" / "outputs" / "src1_cep_qa.json"
         )
         assert out.scores == []
 
     def test_load_failure_counts_failed_source_and_marks_run_failed(
-        self, tmp_path: Path, mock_emic_client: Any, settings: EmicPrepassSettings
+        self, tmp_path: Path, mock_emic_client: Any, settings: EmicJudgeSettings
     ) -> None:
 
         cep_outputs = tmp_path / "run6" / "cep" / "outputs"
@@ -186,46 +186,46 @@ class TestEmicPrepassBatch:
         # A corrupt CEP artifact must be counted, not silently dropped.
         (cep_outputs / "broken_cep_qa.json").write_text("{not valid json", encoding="utf-8")
 
-        result = run_emic_prepass_batch("run6", settings=settings, base_dir=tmp_path)
+        result = run_emic_judge_batch("run6", settings=settings, base_dir=tmp_path)
 
         assert result.sources == 2
         assert result.completed_sources == 1
         assert result.failed_sources == 1
-        assert not (tmp_path / "run6" / "emic_prepass" / "outputs" / "broken_cep_qa.json").exists()
+        assert not (tmp_path / "run6" / "emic_judge" / "outputs" / "broken_cep_qa.json").exists()
 
         metadata = json.loads(
-            (tmp_path / "run6" / "emic_prepass" / "run_metadata.json").read_text(encoding="utf-8")
+            (tmp_path / "run6" / "emic_judge" / "run_metadata.json").read_text(encoding="utf-8")
         )
         assert metadata["status"] == "failed"  # a failed source marks the run FAILED
 
     def test_run_marked_completed_on_success(
-        self, tmp_path: Path, mock_emic_client: Any, settings: EmicPrepassSettings
+        self, tmp_path: Path, mock_emic_client: Any, settings: EmicJudgeSettings
     ) -> None:
 
         cep_outputs = tmp_path / "run7" / "cep" / "outputs"
         _write_cep_record(cep_outputs, "src1", [_pair("Q", approved=True)])
 
-        run_emic_prepass_batch("run7", settings=settings, base_dir=tmp_path)
+        run_emic_judge_batch("run7", settings=settings, base_dir=tmp_path)
 
         metadata = json.loads(
-            (tmp_path / "run7" / "emic_prepass" / "run_metadata.json").read_text(encoding="utf-8")
+            (tmp_path / "run7" / "emic_judge" / "run_metadata.json").read_text(encoding="utf-8")
         )
         assert metadata["status"] == "completed"  # no longer stuck IN_PROGRESS
 
     def test_rerun_clears_stale_outputs(
-        self, tmp_path: Path, mock_emic_client: Any, settings: EmicPrepassSettings
+        self, tmp_path: Path, mock_emic_client: Any, settings: EmicJudgeSettings
     ) -> None:
         cep_outputs = tmp_path / "run8" / "cep" / "outputs"
         _write_cep_record(cep_outputs, "src1", [_pair("Q", approved=True)])
-        run_emic_prepass_batch("run8", settings=settings, base_dir=tmp_path)
+        run_emic_judge_batch("run8", settings=settings, base_dir=tmp_path)
 
         # Simulate a stale output from a prior, larger corpus that is no longer
         # present in cep/outputs.
-        outputs_dir = tmp_path / "run8" / "emic_prepass" / "outputs"
+        outputs_dir = tmp_path / "run8" / "emic_judge" / "outputs"
         stale = outputs_dir / "removed_source_cep_qa.json"
         stale.write_text("{}", encoding="utf-8")
 
-        run_emic_prepass_batch("run8", settings=settings, base_dir=tmp_path, rerun=True)
+        run_emic_judge_batch("run8", settings=settings, base_dir=tmp_path, rerun=True)
 
         assert not stale.exists()  # --rerun purged the orphaned scores
         assert (outputs_dir / "src1_cep_qa.json").exists()  # live source re-scored

--- a/tests/shared/human_eval/test_batch.py
+++ b/tests/shared/human_eval/test_batch.py
@@ -57,7 +57,7 @@ def _write_source(
     ).save(cep_outputs / f"{source_id}_cep_qa.json")
 
     scores = [
-        EmicScore(pair_index=i, bloom_level=bloom, emic_score=score, rationale="r")
+        EmicScore(pair_index=i, bloom_level=bloom, emic_score=score, rationale="r", is_valid=True)
         for i, (bloom, score) in enumerate(specs)
     ]
     EmicSourceScores(
@@ -99,6 +99,35 @@ class TestRunBuildSampleBatch:
         assert manifest.total_items == 16  # exclusions don't change the sample size
         assert manifest.excluded_none_score == 1
         assert manifest.excluded_bloom == {"apply": 1, "create": 1}
+
+    def test_excludes_pairs_the_judge_did_not_approve(self, tmp_path: Path) -> None:
+        # An `emic-judge --scope all` run writes rejected and never-judged
+        # pairs into the emic outputs too. The agreement study's frame is the
+        # approved corpus, so those must never reach the pool -- otherwise the
+        # bands would be built over material the pipeline already discarded.
+        specs = _frame_specs(2)
+        _write_source(tmp_path, "run_scope", "s1", specs)
+
+        emic_path = tmp_path / "run_scope" / "emic_judge" / "outputs" / "s1_cep_qa.json"
+        scores = EmicSourceScores.load(emic_path)
+        scores.scores[0].is_valid = False  # judged and rejected
+        scores.scores[1].is_valid = None  # never judged
+        scores.save(emic_path)
+
+        with pytest.raises(ValueError, match="has only"):
+            run_build_sample_batch("run_scope", seed=1, base_dir=tmp_path, per_cell=2)
+
+        # And with enough approved material left, they are counted, not silent.
+        specs2 = _frame_specs(3)
+        _write_source(tmp_path, "run_scope2", "s1", specs2)
+        emic_path2 = tmp_path / "run_scope2" / "emic_judge" / "outputs" / "s1_cep_qa.json"
+        scores2 = EmicSourceScores.load(emic_path2)
+        scores2.scores[0].is_valid = False
+        scores2.save(emic_path2)
+
+        manifest = run_build_sample_batch("run_scope2", seed=1, base_dir=tmp_path, per_cell=2)
+        assert manifest.excluded_not_approved == 1
+        assert manifest.total_items == 16
 
     def test_payload_is_blinded(self, tmp_path: Path) -> None:
         _write_source(tmp_path, "run3", "s1", _frame_specs(2))
@@ -144,7 +173,11 @@ class TestRunBuildSampleBatch:
         EmicSourceScores(
             source_file_id="s1",
             source_filename="s1.mp4",
-            scores=[EmicScore(pair_index=0, bloom_level="remember", emic_score=2, rationale="r")],
+            scores=[
+                EmicScore(
+                    pair_index=0, bloom_level="remember", emic_score=2, rationale="r", is_valid=True
+                )
+            ],
         ).save(emic_outputs / "s1_cep_qa.json")
 
         with pytest.raises(FileNotFoundError, match="CEP outputs not found"):
@@ -186,7 +219,13 @@ class TestRunBuildSampleBatch:
                 source_file_id="dup",
                 source_filename="dup.mp4",
                 scores=[
-                    EmicScore(pair_index=0, bloom_level="remember", emic_score=2, rationale="r")
+                    EmicScore(
+                        pair_index=0,
+                        bloom_level="remember",
+                        emic_score=2,
+                        rationale="r",
+                        is_valid=True,
+                    )
                 ],
             ).save(emic_outputs / f"{name}_cep_qa.json")
 

--- a/tests/shared/human_eval/test_batch.py
+++ b/tests/shared/human_eval/test_batch.py
@@ -11,6 +11,7 @@ from arandu.qa.schemas import QAPairCEP, QARecordCEP
 from arandu.shared.emic.schemas import EmicScore, EmicSourceScores
 from arandu.shared.human_eval.batch import run_build_sample_batch
 from arandu.shared.human_eval.schemas import SampleItem, SampleManifest
+from arandu.shared.judge.schemas import JudgePipelineResult
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -35,6 +36,8 @@ def _write_source(
     cep_outputs.mkdir(parents=True, exist_ok=True)
     emic_outputs.mkdir(parents=True, exist_ok=True)
 
+    # The CEP record carries the authoritative judge-qa verdict; the frame is
+    # filtered on it, not on the snapshot in the emic outputs.
     pairs = [
         QAPairCEP(
             question=f"q{i}",
@@ -43,6 +46,7 @@ def _write_source(
             question_type="conceptual",
             confidence=0.9,
             bloom_level=bloom,
+            validation=JudgePipelineResult(stage_results={}, passed=True),
         )
         for i, (bloom, _score) in enumerate(specs)
     ]
@@ -100,34 +104,47 @@ class TestRunBuildSampleBatch:
         assert manifest.excluded_none_score == 1
         assert manifest.excluded_bloom == {"apply": 1, "create": 1}
 
-    def test_excludes_pairs_the_judge_did_not_approve(self, tmp_path: Path) -> None:
-        # An `emic-judge --scope all` run writes rejected and never-judged
-        # pairs into the emic outputs too. The agreement study's frame is the
-        # approved corpus, so those must never reach the pool -- otherwise the
-        # bands would be built over material the pipeline already discarded.
-        specs = _frame_specs(2)
-        _write_source(tmp_path, "run_scope", "s1", specs)
+    def test_frame_follows_the_live_cep_verdict_not_the_emic_snapshot(self, tmp_path: Path) -> None:
+        # An `emic-judge --scope all` run scores rejected pairs too, so the emic
+        # outputs are not a pool of approved pairs. The frame must come from the
+        # CEP record (the authoritative verdict), NOT from the is_valid snapshot
+        # frozen into the emic outputs -- otherwise a judge-qa re-run silently
+        # leaves the sample pinned to stale verdicts.
+        _write_source(tmp_path, "run_live", "s1", _frame_specs(3))
+        cep_path = next((tmp_path / "run_live" / "cep" / "outputs").glob("*_cep_qa.json"))
+        emic_path = next((tmp_path / "run_live" / "emic_judge" / "outputs").glob("*.json"))
 
-        emic_path = tmp_path / "run_scope" / "emic_judge" / "outputs" / "s1_cep_qa.json"
+        # The corpus rejects pair 0 while the emic snapshot still says approved.
+        record = QARecordCEP.load(cep_path)
+        record.qa_pairs[0].validation = JudgePipelineResult(stage_results={}, passed=False)
+        record.save(cep_path)
+
+        manifest = run_build_sample_batch("run_live", seed=1, base_dir=tmp_path, per_cell=2)
+        assert manifest.excluded_not_approved == 1  # live verdict wins
+        assert manifest.total_items == 16
+
+        # And the converse: mutating only the emic snapshot must change nothing,
+        # because it is provenance, not the frame.
         scores = EmicSourceScores.load(emic_path)
-        scores.scores[0].is_valid = False  # judged and rejected
-        scores.scores[1].is_valid = None  # never judged
+        for score in scores.scores:
+            score.is_valid = False
         scores.save(emic_path)
+
+        again = run_build_sample_batch("run_live", seed=1, base_dir=tmp_path, per_cell=2)
+        assert again.excluded_not_approved == 1
+        assert again.pool_sha256 == manifest.pool_sha256
+
+    def test_insufficient_approved_pairs_raises(self, tmp_path: Path) -> None:
+        # With too few approved pairs left in a cell the build fails loudly
+        # rather than silently shrinking the sample.
+        _write_source(tmp_path, "run_scope", "s1", _frame_specs(2))
+        cep_path = next((tmp_path / "run_scope" / "cep" / "outputs").glob("*_cep_qa.json"))
+        record = QARecordCEP.load(cep_path)
+        record.qa_pairs[0].validation = JudgePipelineResult(stage_results={}, passed=False)
+        record.save(cep_path)
 
         with pytest.raises(ValueError, match="has only"):
             run_build_sample_batch("run_scope", seed=1, base_dir=tmp_path, per_cell=2)
-
-        # And with enough approved material left, they are counted, not silent.
-        specs2 = _frame_specs(3)
-        _write_source(tmp_path, "run_scope2", "s1", specs2)
-        emic_path2 = tmp_path / "run_scope2" / "emic_judge" / "outputs" / "s1_cep_qa.json"
-        scores2 = EmicSourceScores.load(emic_path2)
-        scores2.scores[0].is_valid = False
-        scores2.save(emic_path2)
-
-        manifest = run_build_sample_batch("run_scope2", seed=1, base_dir=tmp_path, per_cell=2)
-        assert manifest.excluded_not_approved == 1
-        assert manifest.total_items == 16
 
     def test_payload_is_blinded(self, tmp_path: Path) -> None:
         _write_source(tmp_path, "run3", "s1", _frame_specs(2))
@@ -209,6 +226,7 @@ class TestRunBuildSampleBatch:
                         question_type="conceptual",
                         confidence=0.9,
                         bloom_level="remember",
+                        validation=JudgePipelineResult(stage_results={}, passed=True),
                     )
                 ],
                 model_id="m",

--- a/tests/shared/human_eval/test_batch.py
+++ b/tests/shared/human_eval/test_batch.py
@@ -31,7 +31,7 @@ def _write_source(
     base: Path, pipeline_id: str, source_id: str, specs: list[tuple[str, int | None]]
 ) -> None:
     cep_outputs = base / pipeline_id / "cep" / "outputs"
-    emic_outputs = base / pipeline_id / "emic_prepass" / "outputs"
+    emic_outputs = base / pipeline_id / "emic_judge" / "outputs"
     cep_outputs.mkdir(parents=True, exist_ok=True)
     emic_outputs.mkdir(parents=True, exist_ok=True)
 
@@ -134,12 +134,12 @@ class TestRunBuildSampleBatch:
         assert first == second
 
     def test_missing_emic_stage_raises(self, tmp_path: Path) -> None:
-        with pytest.raises(FileNotFoundError, match="Emic pre-pass outputs not found"):
+        with pytest.raises(FileNotFoundError, match="Emic-judge outputs not found"):
             run_build_sample_batch("absent", seed=1, base_dir=tmp_path, per_cell=2)
 
     def test_missing_cep_stage_raises(self, tmp_path: Path) -> None:
         # emic outputs present, cep dir absent.
-        emic_outputs = tmp_path / "run6" / "emic_prepass" / "outputs"
+        emic_outputs = tmp_path / "run6" / "emic_judge" / "outputs"
         emic_outputs.mkdir(parents=True)
         EmicSourceScores(
             source_file_id="s1",
@@ -159,7 +159,7 @@ class TestRunBuildSampleBatch:
     def test_duplicate_pair_id_raises(self, tmp_path: Path) -> None:
         # Two emic files whose EmicSourceScores share the same source_file_id +
         # pair_index collide on pair_id (e.g. a stale duplicate emic output).
-        emic_outputs = tmp_path / "run9" / "emic_prepass" / "outputs"
+        emic_outputs = tmp_path / "run9" / "emic_judge" / "outputs"
         cep_outputs = tmp_path / "run9" / "cep" / "outputs"
         emic_outputs.mkdir(parents=True)
         cep_outputs.mkdir(parents=True)

--- a/tests/shared/test_results_manager.py
+++ b/tests/shared/test_results_manager.py
@@ -781,7 +781,7 @@ class TestPipelineType:
             "judge_answers",
             "analysis",
             "non_answerable",
-            "emic_prepass",
+            "emic_judge",
             "human_eval",
             "evaluation",
         }


### PR DESCRIPTION
Makes `emic-judge` (Phase D, spec §5) actually runnable on the cluster. It was
merged as code in #123 but had never been run: no deploy existed, the batch
ignored its own concurrency setting, and the stage was named and documented as
something it is not.

Four commits, sequentially dependent (the later ones assume the new names), so
they are kept in one PR rather than a stack.

## ⚠️ Breaking change

`798153d` removes `ARANDU_EMIC_PREPASS_*` and the `arandu emic-prepass`
command. Use `ARANDU_EMIC_JUDGE_*` and `arandu emic-judge`.

**No stored results are affected because none were ever produced** — `results/`
has no `emic_prepass/` output anywhere. That is precisely why the rename is in
this PR: doing it after the ~hours-long run and the frozen sample would have
made it a results-directory migration with provenance hashes in the way.

## Commits

### `798153d` refactor(emic)!: rename emic-prepass to emic-judge and fix its framing

The stage was named and documented as a preliminary sampling aid: *"the score
is a sampling aid, not ground truth — the human annotators are the reference"*.
That inverts the method. The ordinal `emic_validity` score **is** the study's
measurement; the human annotation round measures agreement with it
(Krippendorff α over raters, weighted Cohen κ of the judge against each
annotator). It validates the instrument, it does not replace it.

Renames `PipelineType.EMIC_PREPASS` → `EMIC_JUDGE`, the settings class, the
result schema, the batch entrypoint, the checkpoint, `SampleItem`'s score
field, and the CLI module — and rewrites every docstring that asserted the old
framing. Also documents that the model id is a methodological parameter here
rather than a budget knob: it defines the instrument under test, so a run
feeding the agreement study must pin the model the dissertation describes. The
previous docstring actively invited the opposite (*"a modest model is fine"*).

### `4df0af3` feat(emic): score the whole corpus, not only judge-approved pairs

Adds `--scope all|approved`, defaulting to `all`. Restricting the judge to
approved pairs threw away the comparison that makes the measure interesting:
whether pairs `judge-qa` rejected are systematically less emic, or whether the
two axes are orthogonal. Each `EmicScore` now carries the pair's `judge-qa`
verdict (`is_valid`: true/false/None) so the cross-tabulation needs no re-join
with the CEP records. Never-judged pairs are scored with a null verdict instead
of being dropped silently.

`EmicJudgeResult` separates the scope-dependent denominator (`selected_pairs`,
`skipped_pairs`) from corpus composition (`approved_pairs`, `rejected_pairs`,
`unjudged_pairs`), with two invariants asserted in tests so the docstring
cannot drift from the code.

**Latent bug fixed here:** with `--scope all` the emic outputs stop being a pool
of approved pairs. `run_build_sample_batch` would have banded and sampled
material the pipeline already discarded, contaminating the human-eval frame
*silently* — nothing in `sample.jsonl` would have shown it. It now drops
anything with `is_valid is not True` and reports the count as
`SampleManifest.excluded_not_approved`. The study's frame stays the approved
corpus; only the measurement widened.

### `94aa78f` perf(emic): honour the inherited workers setting via map_concurrent

The emic judge was the only LLM-heavy batch runner still scoring pairs in a
plain sequential loop — while already inheriting a `workers` field from
`LLMSettings` and silently ignoring it. Setting `ARANDU_EMIC_JUDGE_WORKERS` did
nothing and said nothing.

Reuses `arandu.utils.concurrency.map_concurrent` (the helper behind `answer`
and `judge-answers`) with the same split: workers only run the LLM call;
checkpoint writes and file saves stay on the main thread, so no locking.
Concurrency is per source rather than across the corpus because a source's
scores are persisted as one file, so the loop must drain before writing.

`map_concurrent` yields in completion order once workers > 1, so results are
re-sorted by pair index before persisting. A test asserts the output is
identical between `workers=1` and `workers=4`, keyed per pair, proving scores
ride with the right pair rather than merely that indices are sorted.

### `0979abc` build(emic): add cluster deploy (compose service + SLURM)

Adds the `arandu-emic` service (profiles `emic` / `emic-gpu`) and
`scripts/slurm/emic/`. A separate service rather than reusing `arandu-judge`,
which forwards `ARANDU_JUDGE_*` only — running emic through it would leave
every emic setting silently at its default (`extra="ignore"`). The `emic`
profiles are also added to the ollama sidecars; without that, `--profile emic`
would bring up the stage with no LLM behind it.

Extracts the #152 orphan-container trap into a shared
`scripts/slurm/container_teardown.sh` instead of copying it a second time.

Concurrency sizing is derived, not guessed: template (~2k tokens pt) + one
`cep_4k` segment (≤4k) + Q&A ≈ 6.5k input against an 8192 response budget, so
16384 context with headroom. `4 × 16384 ≈ 9.8 GB KV + 9.3 GB weights ≈ 19 GB`
fits the 24 GB card, inside the envelope `judge-answers` already runs at. Emic
gets twice its concurrency because its prompts carry no retrieved passages.
`OLLAMA_NUM_PARALLEL` derives from the worker count so client and server cannot
drift on a plain submit.

## Docs

`scripts/slurm/AGENTS.md` (cross-layer map, layout, submit table, new
orphan-container section), a new `EmicJudgeSettings` section in
`configuration.md`, a new Phase D section in `cli-reference.md` (`emic-judge`
and `build-human-eval-sample` were misfiled under Phase C), the compose header
map, and `README.md`.

## Two findings surfaced, not fixed here

1. **The 429 throttle is inert whenever a call goes through a criterion.**
   `JudgeCriterion.evaluate` catches every exception and returns an error
   score, so a `RateLimitError` never escapes to `map_concurrent`'s
   `AdaptiveThrottle`. `judge-answers` passes `rate_limit_of=is_rate_limit_error`
   but its path also descends through `criterion.evaluate` (confirmed by code
   reading, not by execution), so its adaptation is inert too. This PR
   deliberately does **not** pass the predicate for emic rather than ship code
   that looks like protection without protecting; the consequence is documented
   at the call site. Fixing it touches three stages and the deliberate
   "criterion never breaks the batch" contract, so it is tracked separately.

2. **`judge/`, `cep/` and `kg/` have no teardown trap at all.** #152 fixed only
   `rag_common.sh`. `judge_common.sh` runs its container in the foreground and
   tears down afterwards, so on a TIMEOUT the teardown never executes — which is
   exactly the `judge-answers 799024` incident that needed admin intervention.
   The shared helper this PR adds is the fix; adopting it is tracked separately
   because those scripts run in production and deploy via rsync without git.

## Verification

- Full suite: **1702 passed**, 0 failures.
- `ruff check` + `ruff format` clean; `shellcheck` clean on all three new shell
  scripts; `docker compose config` validates and profile resolution verified.
- `arandu emic-judge --help` renders the new text and `--scope [all|approved]`.
- Repo-wide grep for `emic_prepass|emic-prepass|EmicPrepass|pre-pass|sampling
  aid` returns empty.

**Not verified:** none of this has run on the cluster. Compose validation covers
syntax and profile resolution, but the image build, model pull, and the trap's
real behaviour under TIMEOUT only prove out on a submit. The rsync deploy to
pcad has not been done.