### PR TITLE
feat(emic)!: make the emic-validity ruler a signed-off single source

### DIFF
--- a/docs/emic/annotator-instructions.pt.md
+++ b/docs/emic/annotator-instructions.pt.md
@@ -1,0 +1,206 @@
+# Anotação de validade êmica: instruções
+
+Obrigado por aceitar participar. São 120 pares pergunta-resposta, gerados
+automaticamente a partir de trechos de entrevistas. Sua tarefa é dar a cada par
+uma nota de 1 a 5 de validade êmica, com uma justificativa opcional.
+
+Você pode parar e retomar quando quiser: o sistema grava cada anotação
+individualmente, então nada se perde se você fechar a página.
+
+Não há comunicação entre os três anotadores durante a anotação, e isso é
+deliberado: a medida de interesse é o quanto vocês concordam de forma
+independente. Suas respostas individuais não serão publicadas. Apenas os
+coeficientes agregados entram no texto da pesquisa.
+
+> Este texto define a régua. O juiz automático que será comparado com vocês recebe
+> exatamente as mesmas definições, a mesma escala e o mesmo guia, palavra por
+> palavra. É isso que torna a comparação válida.
+
+## Êmico e não-êmico
+
+Êmico é descrever nos termos de quem vive a situação: as categorias, as medidas e
+as razões que a própria pessoa usa para explicar o mundo dela.
+
+Não-êmico é descrever nos termos de quem observa: as categorias do pesquisador, do
+técnico ou da teoria, aplicadas de fora sobre o que a pessoa disse.
+
+Os dois não são opostos absolutos, e nenhum é errado em geral. Um par se afasta do
+registro êmico por graus, e é esse afastamento que a escala de 1 a 5 mede. O que se
+quer registrar é o conhecimento da pessoa, não a tradução dele para o vocabulário
+de quem a estuda.
+
+O par é gerado a partir de um trecho de entrevista. A pergunta a responder: a
+própria pessoa reconheceria este par como fiel ao que quis dizer e a como ela
+entende o mundo?
+
+Isto não é fidelidade ao texto. Um par pode citar corretamente o que foi dito e
+ainda deslocar o sentido ao reenquadrá-lo.
+
+## A escala
+
+- **5**: Preserva o sentido, a perspectiva e quem sabe ou decide.
+- **4**: Preserva o sentido, mas apaga um elemento situado ou a postura da pessoa.
+- **3**: Acrescenta algo que a pessoa não disse, e o núcleo do que ela disse continua reconhecível.
+- **2**: Acrescenta algo que a pessoa não disse e troca o motivo que ela deu.
+- **1**: Contradiz o que a pessoa disse, ou substitui a perspectiva dela por clichê.
+
+## Tipos de perda êmica
+
+- **Sentido alterado**: a reformulação muda o que está sendo dito. (nota 1)
+- **Clichê sobre populações tradicionais**: uma fórmula pronta ocupa o lugar do
+  conhecimento da pessoa: sabedoria ancestral, harmonia com a natureza, vínculo
+  imemorial com o território. (nota 1)
+- **Informação de fora adicionada**: o par afirma algo que a pessoa não disse: uma
+  explicação, um diagnóstico ou uma categoria de análise. (nota 2 ou 3, ver o guia)
+- **Lacuna preenchida**: o que a pessoa não disse é completado com aquilo que
+  normalmente seria o caso. (nota 2 ou 3, ver o guia)
+- **Elemento situado apagado**: o sentido se preserva, mas desaparece quem sabe,
+  decide ou age, ou o sinal concreto que a pessoa usa. (nota 4)
+- **Postura apagada**: o conteúdo se preserva, mas desaparece como a pessoa se
+  posiciona: a dúvida vira certeza, ou a avaliação dela vira descrição neutra.
+  (nota 4)
+
+## Disposições gerais
+
+O objeto de avaliação é o par. Avalia-se a pergunta e a resposta juntas, e a perda
+pode estar em qualquer uma das duas. Uma pergunta que pressupõe o que a pessoa não
+disse, ou que arranca a fala do contexto em que ela foi dita, basta para derrubar o
+par, ainda que a resposta seja sóbria.
+
+A pergunta define o que conta como perda. Um detalhe que a pergunta não punha em
+jogo pode desaparecer sem custo. O que carrega o conhecimento que a pergunta pede,
+não. Se a pergunta trata de como algo é feito, perder o nome de quem emprestou o
+dinheiro não é perda, desde que a lógica que a pessoa deu continue inteira; se a
+pergunta trata de como se sabe algo, perder quem sabe é perda. A pergunta calibra a
+expectativa de detalhe e nada além disso.
+
+**Não são perda êmica:**
+
+- Generalizar ou abstrair preservando o sentido. Alguma generalização é esperada.
+- Trocar uma palavra por outra sem apagar nada: dizer embarcação onde a pessoa
+  disse barco não custa ponto.
+- Perder um nome próprio ou um objeto específico quando a pergunta não pedia aquele
+  detalhe e a lógica que a pessoa enunciou continua inteira.
+- Responder de forma curta, ou menos detalhada que o trecho.
+
+Fora deste escopo: se o par está bem escrito, se a resposta está correta, completa
+ou bem fundamentada no trecho. Aqui se julga apenas se a perspectiva da pessoa foi
+preservada.
+
+## Guia de avaliação
+
+**1.** Localize no trecho as passagens de que o par trata. Julgue o par contra
+essas passagens, não contra o trecho inteiro.
+
+**2.** Nessas passagens, identifique quatro coisas: o que a pessoa afirma; as
+palavras e medidas que ela usa; quem sabe, decide ou age; e o que a pergunta põe em
+jogo.
+
+**3.** Percorra as condições em ordem e pare na primeira que se aplicar. A nota é a
+dessa condição.
+
+- O par contradiz o que a pessoa afirma, ou substitui a perspectiva dela por clichê
+  sobre populações tradicionais: **nota 1**
+- O par afirma algo que ela não disse, e essa adição troca o motivo que ela deu por
+  outro, fazendo a fala servir de exemplo de uma ideia que não é dela: **nota 2**
+- O par afirma algo que ela não disse, mas o núcleo do que ela disse continua
+  reconhecível: **nota 3**
+- O par preserva o sentido, mas apaga um elemento situado que carrega o conhecimento
+  em jogo (quem sabe, decide ou age; o sinal concreto), ou apaga a postura com que
+  ela disse (a dúvida virou certeza, a avaliação virou descrição neutra): **nota 4**
+- Nenhuma das anteriores: **nota 5**
+
+**4.** Não reduzem a nota, por si sós: generalizar ou abstrair; usar vocabulário
+mais formal; responder de forma curta; omitir um detalhe que a pergunta não pedia.
+Só reduzem quando uma das condições acima se aplica.
+
+**5.** Na justificativa, nomeie a condição que decidiu a nota.
+
+## Sobre as fronteiras entre notas
+
+As fronteiras são finas de propósito. 5 e 4 se separam por uma única coisa: se o
+elemento situado (quem sabe, decide ou age, o sinal usado) continua no par. 3 e 2 se
+separam por saber se o que foi acrescentado convive com o que a pessoa disse ou
+troca o motivo que ela deu. Hesitar entre notas vizinhas é esperado e não é erro
+seu. Quando hesitar, volte ao guia e percorra as condições na ordem: a primeira que
+se aplicar decide. Se a dúvida persistir, registre na justificativa qual foi.
+
+Use 1 apenas se você puder apontar uma das duas coisas: uma afirmação que contraria
+o que a pessoa disse, ou um clichê sobre populações tradicionais ocupando o lugar da
+perspectiva dela. Não é 1: achar a resposta vaga, achar o vocabulário formal demais,
+ou discordar da leitura sem conseguir apontar uma dessas duas. Esses casos são 3 ou
+4.
+
+## Exemplos
+
+Casos construídos para ilustrar a escala. Nenhum vem de entrevista real.
+
+### Nota 5
+
+- **Trecho:** "a gente não sai antes de ver a marca d'água no galpão do seu Ari; a rádio às vezes fala, mas é a marca que decide."
+- **Pergunta:** "Que critérios orientam a decisão de sair de casa durante uma cheia?"
+- **Resposta:** "Os moradores só saem depois de conferir a marca d'água no galpão de um vizinho; quando o aviso da rádio diverge desse sinal, eles seguem a marca."
+- **Por quê:** nenhuma condição se aplica. O par abstrai ("um vizinho", "esse sinal") e organiza os critérios em hierarquia, mas a hierarquia é a que a pessoa formulou e quem decide continua na frase. Se estivesse escrito "a decisão se apoia em um sinal local verificável", cairia para 4, porque o sujeito que decide desapareceria.
+
+### Nota 4, elemento situado apagado
+
+- **Trecho:** "quando o vento vira pra baixo a gente já sabe que não dá pra atravessar."
+- **Pergunta:** "O que indica que a travessia não deve ser feita?"
+- **Resposta:** "A mudança na direção do vento indica que a travessia se torna inviável."
+- **Por quê:** o sentido está intacto e o vocabulário é aceitável. O que se perde é o "a gente já sabe": um saber coletivo passa a ser apresentado como propriedade do mundo, e não como algo que aquelas pessoas sabem ler.
+
+### Nota 4, postura apagada
+
+- **Trecho:** "eu acho que dessa vez a água subiu mais rápido que na outra cheia, mas não sei dizer, foi de noite. Foi terrível, a gente perdeu tudo o que tinha embaixo."
+- **Pergunta:** "Como ela compara essa cheia com a anterior?"
+- **Resposta:** "A elevação do nível da água foi mais rápida do que na cheia anterior, resultando em perdas materiais nos pertences armazenados na parte inferior da casa."
+- **Por quê:** o conteúdo está todo lá e nada de fora foi acrescentado. O que desaparece é a postura: "eu acho que, não sei dizer" vira afirmação segura, e "foi terrível" vira "perdas materiais". Ela não afirmou com essa certeza nem descreveu aquilo com essa neutralidade.
+
+### Nota 3, informação de fora adicionada
+
+- **Trecho:** "faz dois anos que eu peço o cadastro e até hoje nada; cada vez que eu vou lá falta um papel."
+- **Pergunta:** "Qual a experiência dela com o cadastro?"
+- **Resposta:** "As exigências documentais repetidas configuram uma barreira burocrática de acesso ao cadastro."
+- **Por quê:** o núcleo continua reconhecível (pediu, não saiu, sempre falta papel), mas "barreira burocrática de acesso" é uma explicação que ela não deu. Nada do que ela disse é contradito.
+
+### Nota 3, lacuna preenchida
+
+- **Trecho:** "esse ano eu plantei mais pra baixo, perto da sanga."
+- **Pergunta:** "O que ela fez em relação ao plantio deste ano?"
+- **Resposta:** "Neste ano plantou em área mais baixa, próxima à sanga, buscando solo mais úmido."
+- **Por quê:** a parte factual está correta, mas "buscando solo mais úmido" é um motivo que ela não deu, completado com o que normalmente seria o caso. O núcleo continua reconhecível e nada é contradito, então é 3. Não é 2 porque ela não deu motivo nenhum: não há motivo trocado, há motivo inventado onde não havia.
+
+### Nota 2
+
+- **Trecho:** "depois da enchente muita gente foi embora, foi pra cidade, pra casa de parente. Meu genro foi. Eu fiquei. Não é que eu não pudesse ir, o meu cunhado tinha lugar lá. É que aqui eu sei viver: eu sei a hora que o rio sobe, sei onde botar as coisas, sei com quem contar."
+- **Pergunta:** "Por que parte dos moradores permaneceu na área afetada após a enchente?"
+- **Resposta:** "A permanência evidencia um processo de desterritorialização seletiva, em que os moradores sem alternativa habitacional permaneceram expostos ao risco."
+- **Por quê:** o motivo que ela deu foi saber viver ali, e o par o substitui por falta de alternativa, contradizendo o "não é que eu não pudesse ir". Ela reconheceria os fatos e não a explicação. Não é 3 porque a adição não convive com o que foi dito: troca o motivo. Não é 1 porque os fatos continuam corretos e não há clichê.
+
+### Nota 1, sentido alterado
+
+- **Trecho:** "eu não vendo pra atravessador, prefiro vender na porta mesmo, ganho menos mas recebo na hora."
+- **Pergunta:** "Como ela comercializa o pescado?"
+- **Resposta:** "Vende para atravessadores porque precisa receber o pagamento imediatamente."
+- **Por quê:** a resposta afirma o contrário do que foi dito. Ela disse que não vende para atravessador. Não há clichê nem informação de fora acrescentada: o que ela disse foi invertido, e isso basta para a nota 1.
+
+### Nota 1, pelo clichê
+
+- **Trecho:** "eu pesco desde os nove anos, aprendi vendo meu pai; hoje tem dia que não paga nem o diesel."
+- **Pergunta:** "Como ele descreve sua relação com a pesca?"
+- **Resposta:** "O pescador mantém uma relação ancestral de harmonia com o rio, guiada por uma sabedoria tradicional transmitida entre gerações."
+- **Por quê:** entra o clichê ("ancestral", "harmonia", "sabedoria tradicional") e desaparece o que ele colocou, que é a pesca não pagar o próprio custo. Ele não reconheceria nem os fatos nem a explicação.
+
+### Nota 1, pela pergunta
+
+- **Trecho:** "eu pesco desde os nove anos, aprendi vendo meu pai; hoje tem dia que não paga nem o diesel."
+- **Pergunta:** "Como a sabedoria ancestral dos pescadores é transmitida entre gerações?"
+- **Resposta:** "O aprendizado ocorre pela observação do trabalho dos mais velhos, desde os nove anos de idade."
+- **Por quê:** a resposta é sóbria e fiel ao trecho. A perda está na pergunta, que insere "sabedoria ancestral", um clichê que a pessoa não usou, e faz o par inteiro afirmar isso. A condição dispara pela pergunta, não pela resposta.
+
+## O que você vê e o que você não vê
+
+Cada tarefa mostra apenas três coisas: o trecho da entrevista, a pergunta e a
+resposta. Você não vê o nível cognitivo atribuído ao par, nem as notas dadas pelos
+juízes automáticos, nem qualquer outro dado gerado junto com o par. Isso é
+proposital: qualquer um desses campos ancoraria a sua leitura.

--- a/docs/user-guide/cli-reference.md
+++ b/docs/user-guide/cli-reference.md
@@ -414,6 +414,16 @@ parameter (it defines the instrument under test), so a run feeding the
 agreement study must pin the model the dissertation describes. See
 [EmicJudgeSettings](configuration.md#emicjudgesettings).
 
+**The ruler is a signed-off single source.** The construct, the 1-5 scale, the
+loss types and the decision guide live in
+`prompts/judge/criteria/emic_validity/ruler.pt.yaml`, and both the judge prompt
+and the annotator sheet ([docs/emic/annotator-instructions.pt.md](../emic/annotator-instructions.pt.md))
+render it. The weighted kappa between the judge and each annotator only measures
+agreement if both score on the same ruler, so `tests/shared/judge/test_emic_ruler.py`
+fails if either artifact drifts. The `signed_off` field records the
+anthropologist gate; the annotation instrument refuses to build while it is
+false.
+
 **`emic-judge` options**:
 
 | Option | Default | Description |

--- a/prompts/judge/criteria/emic_validity/pt/prompt.md
+++ b/prompts/judge/criteria/emic_validity/pt/prompt.md
@@ -1,90 +1,140 @@
-Você avalia da posição de um antropólogo treinado em trabalho de campo etnográfico, não da posição de um modelo de linguagem de propósito geral. O domínio são comunidades ribeirinhas do sul do Brasil afetadas por eventos climáticos críticos.
+Você é um avaliador rigoroso de pares pergunta-resposta gerados a partir de entrevistas. Sua tarefa é avaliar a VALIDADE ÊMICA do par, com o rigor de um antropólogo.
 
-Sua tarefa é atribuir a VALIDADE ÊMICA de um par pergunta-resposta gerado a partir de uma entrevista.
+Êmico e não-êmico
 
-O construto: validade êmica
+Êmico é descrever nos termos de quem vive a situação: as categorias, as medidas e as razões que a própria pessoa usa para explicar o mundo dela.
 
-Um par tem validade êmica quando preserva o sentido e a perspectiva do interlocutor (perspectiva êmica), em vez de impor a moldura do analista externo (ética), estereótipo, romantização ou senso comum.
+Não-êmico é descrever nos termos de quem observa: as categorias do pesquisador, do técnico ou da teoria, aplicadas de fora sobre o que a pessoa disse.
 
-Generalizar e abstrair é desejável, não um defeito. O par não precisa reproduzir literalmente o que cada pessoa disse; o propósito do grafo é justamente generalizar e conectar conhecimento. O que importa é que a generalização preserve o sentido e fique em registros que a comunidade reconheceria. A nota só cai quando o sentido é deslocado ou uma moldura externa é imposta.
+Os dois não são opostos absolutos, e nenhum é errado em geral. Um par se afasta do registro êmico por graus, e é esse afastamento que a escala de 1 a 5 mede. O que se quer registrar é o conhecimento da pessoa, não a tradução dele para o vocabulário de quem a estuda.
 
-A pergunta que você responde: o interlocutor (ou um membro da comunidade) reconheceria este par como fiel ao que quis dizer e a como entende o mundo? Ou o sentido foi alterado / uma interpretação de fora foi atribuída a ele?
+O par é gerado a partir de um trecho de entrevista. A pergunta a responder: a própria pessoa reconheceria este par como fiel ao que quis dizer e a como ela entende o mundo?
 
-Isto não é fidelidade textual. Um par pode citar fielmente o que foi dito e ainda assim distorcer o sentido ao reenquadrá-lo. Fidelidade pergunta "está no texto?"; validade êmica pergunta "respeita a perspectiva do interlocutor?".
+Isto não é fidelidade ao texto. Um par pode citar corretamente o que foi dito e ainda deslocar o sentido ao reenquadrá-lo.
 
-Aviso sobre o seu próprio viés
+Escala:
 
-Modelos de linguagem como você tendem a elevar queixas e descrições situadas a diagnósticos analítico-institucionais (ex.: transformar "eles te prejudicam" em "negligência sistêmica dos órgãos"). Isso não é generalizar: é adicionar uma afirmação que o interlocutor não fez. Essa é exatamente a falha que você deve detectar no par, e que não deve cometer na sua justificativa.
+- 5: Preserva o sentido, a perspectiva e quem sabe ou decide.
+- 4: Preserva o sentido, mas apaga um elemento situado ou a postura da pessoa.
+- 3: Acrescenta algo que a pessoa não disse, e o núcleo do que ela disse continua reconhecível.
+- 2: Acrescenta algo que a pessoa não disse e troca o motivo que ela deu.
+- 1: Contradiz o que a pessoa disse, ou substitui a perspectiva dela por clichê.
 
-Marcadores de violação (em ordem de gravidade):
+Tipos de perda êmica:
 
-Violações fortes (derrubam a nota para 1-2):
+- Sentido alterado: a reformulação muda o que está sendo dito. (nota 1)
+- Clichê sobre populações tradicionais: uma fórmula pronta ocupa o lugar do conhecimento da pessoa: sabedoria ancestral, harmonia com a natureza, vínculo imemorial com o território. (nota 1)
+- Informação de fora adicionada: o par afirma algo que a pessoa não disse: uma explicação, um diagnóstico ou uma categoria de análise. (nota 2 ou 3, ver o guia)
+- Lacuna preenchida: o que a pessoa não disse é completado com aquilo que normalmente seria o caso. (nota 2 ou 3, ver o guia)
+- Elemento situado apagado: o sentido se preserva, mas desaparece quem sabe, decide ou age, ou o sinal concreto que a pessoa usa. (nota 4)
+- Postura apagada: o conteúdo se preserva, mas desaparece como a pessoa se posiciona: a dúvida vira certeza, ou a avaliação dela vira descrição neutra. (nota 4)
 
-1. Distorção de sentido: a reformulação muda o que está sendo dito.
-2. Claim/diagnóstico externo adicionado: atribui ao interlocutor uma afirmação ou interpretação que ele não fez (ex.: "te prejudicam" → "negligência sistêmica", elevando uma queixa pessoal a um diagnóstico estrutural).
-3. Estereótipo ou romantização ("sabedoria ancestral", "harmonia com a natureza") no lugar do conhecimento situado e específico.
-4. Senso comum do modelo preenchendo lacunas que o interlocutor não preencheu.
+Disposições gerais
 
-Violação leve (derruba de 5 para 3-4):
+O objeto de avaliação é o par. Avalia-se a pergunta e a resposta juntas, e a perda pode estar em qualquer uma das duas. Uma pergunta que pressupõe o que a pessoa não disse, ou que arranca a fala do contexto em que ela foi dita, basta para derrubar o par, ainda que a resposta seja sóbria.
 
-5. Troca de categoria/registro situado por técnico-externo, ainda que o sentido se preserve (ex.: "a água subiu rápido" → "taxa de elevação do nível hidrométrico"). A categoria nativa carrega sentido; substituí-la por um registro que a comunidade não usaria é uma perda êmica leve.
+A pergunta define o que conta como perda. Um detalhe que a pergunta não punha em jogo pode desaparecer sem custo. O que carrega o conhecimento que a pergunta pede, não. Se a pergunta trata de como algo é feito, perder o nome de quem emprestou o dinheiro não é perda, desde que a lógica que a pessoa deu continue inteira; se a pergunta trata de como se sabe algo, perder quem sabe é perda. A pergunta calibra a expectativa de detalhe e nada além disso.
 
-Não é violação: generalização/abstração que preserva o sentido e fica em registros reconhecíveis (ex.: abstrair objetos específicos em "objetos domésticos adquiridos por doação e por crédito").
+Não são perda êmica:
 
-Escala (1 a 5):
+- Generalizar ou abstrair preservando o sentido. Alguma generalização é esperada.
+- Trocar uma palavra por outra sem apagar nada: dizer embarcação onde a pessoa disse barco não custa ponto.
+- Perder um nome próprio ou um objeto específico quando a pergunta não pedia aquele detalhe e a lógica que a pessoa enunciou continua inteira.
+- Responder de forma curta, ou menos detalhada que o trecho.
 
-- 5: Plenamente êmico. Preserva sentido e perspectiva; generalização, se houver, fica nos registros do interlocutor. Nenhum marcador.
-- 4: Predominantemente êmico. Leve troca de registro/categoria, sem distorcer o sentido (marcador 5 brando).
-- 3: Misto. Troca de registro relevante ou início de moldura externa; sentido parcialmente deslocado.
-- 2: Predominantemente ético. Adiciona claim/diagnóstico externo ou impõe moldura analítica; o interlocutor hesitaria em reconhecer como sua.
-- 1: Distorção. Muda o sentido, ou estereótipo/senso comum substitui a perspectiva.
+Fora deste escopo: se o par está bem escrito, se a resposta está correta, completa ou bem fundamentada no trecho. Aqui se julga apenas se a perspectiva da pessoa foi preservada.
 
-Exemplos (provisórios; pendentes de validação por especialista):
+Guia de avaliação
 
-Cada exemplo traz os mesmos três campos que você vê na avaliação (segmento, pergunta, resposta).
+1. Localize no trecho as passagens de que o par trata. Julgue o par contra essas passagens, não contra o trecho inteiro.
 
-Nota 5 (generalização que preserva o sentido).
-- Segmento: "ganhei o açucareiro de presente; o fogão eu comprei com um dinheiro que o Maikinho emprestou, que veio pelo Jô, porque tava caro e eu não tinha."
-- Pergunta: "Como Dona Gilda adquiriu seus objetos domésticos?"
-- Resposta: "Dona Gilda adquiriu objetos domésticos por vias distintas: alguns recebidos como presente, outros comprados com dinheiro emprestado, conforme o custo e os recursos disponíveis."
-- Por quê: abstrai os objetos específicos (açucareiro, fogão) numa generalização que preserva o sentido e a lógica da interlocutora (doação vs crédito). Generalizar aqui é bom. Nenhum marcador.
+2. Nessas passagens, identifique quatro coisas: o que a pessoa afirma; as palavras e medidas que ela usa; quem sabe, decide ou age; e o que a pergunta põe em jogo.
 
-Nota 4 (troca leve de registro).
-- Segmento: "quando a água começa a subir rápido a gente já sabe que tem que tirar o barco."
-- Pergunta: "Como o pescador sabe que é hora de retirar o barco?"
-- Resposta: "Uma subida acelerada do nível do rio sinaliza a necessidade de retirar a embarcação."
-- Por quê: o sentido se mantém, mas "embarcação"/"subida acelerada do nível do rio" troca o registro situado ("barco", "a água subiu rápido") por um mais formal. Marcador 5 brando.
+3. Percorra as condições em ordem e pare na primeira que se aplicar. A nota é a dessa condição.
 
-Nota 3 (misto: troca de registro com início de moldura externa).
-- Segmento: "quando o rio tá daquele jeito, barrento e revolto, a gente nem bota o pé na água, espera baixar."
-- Pergunta: "Como os moradores decidem se entram no rio?"
-- Resposta: "Os moradores avaliam indicadores de turbidez e correnteza para determinar o risco antes de acessar o rio."
-- Por quê: o sentido geral se mantém (ler o rio antes de entrar), mas troca o registro situado ("barrento e revolto", "espera baixar") por um técnico-analítico ("indicadores de turbidez e correnteza") e começa a enquadrar uma leitura experiencial como avaliação técnica. Marcador 5 somado ao início de uma moldura externa: misto.
+- O par contradiz o que a pessoa afirma, ou substitui a perspectiva dela por clichê sobre populações tradicionais: nota 1
+- O par afirma algo que ela não disse, e essa adição troca o motivo que ela deu por outro, fazendo a fala servir de exemplo de uma ideia que não é dela: nota 2
+- O par afirma algo que ela não disse, mas o núcleo do que ela disse continua reconhecível: nota 3
+- O par preserva o sentido, mas apaga um elemento situado que carrega o conhecimento em jogo (quem sabe, decide ou age; o sinal concreto), ou apaga a postura com que ela disse (a dúvida virou certeza, a avaliação virou descrição neutra): nota 4
+- Nenhuma das anteriores: nota 5
 
-Nota 2 (claim externo adicionado).
-- Segmento: "o pescador vive oprimido pelo IBAMA, pela PATRAM (...) em vez de te proteger e te ajudar, eles te prejudicam."
-- Pergunta: "Como o pescador descreve a atuação dos órgãos ambientais?"
-- Resposta: "A falta de apoio à família reflete a negligência sistêmica dos órgãos ambientais, criando desconfiança e abandonando casos sociais."
-- Por quê: não é apenas vocabulário diferente; eleva uma queixa pessoal ("te prejudicam") a um diagnóstico estrutural ("negligência sistêmica", "casos sociais") que o interlocutor não afirmou. Marcador 2 (claim externo adicionado).
+4. Não reduzem a nota, por si sós: generalizar ou abstrair; usar vocabulário mais formal; responder de forma curta; omitir um detalhe que a pergunta não pedia. Só reduzem quando uma das condições acima se aplica.
 
-Nota 1 (distorção: estereótipo substitui a perspectiva).
-- Segmento: "a gente vai pescando onde dá, às vezes mais pra cima, às vezes mais pra baixo, depende do dia."
-- Pergunta: "Como o pescador escolhe o local de pesca?"
-- Resposta: "Guiado por uma sabedoria ancestral em harmonia com a natureza, o pescador sente intuitivamente onde os peixes estão."
-- Por quê: substitui uma descrição pragmática e variável ("onde dá", "depende do dia") por um estereótipo romantizado ("sabedoria ancestral", "harmonia com a natureza"), distorcendo o sentido. Marcador 3 (estereótipo/romantização) somado ao marcador 1 (distorção).
+5. Na justificativa, nomeie a condição que decidiu a nota.
 
-Avalie o par abaixo. Você vê apenas o segmento de origem, a pergunta e a resposta.
+Exemplos
 
-Segmento de origem:
+Casos construídos para ilustrar a escala. Nenhum vem de entrevista real.
+
+Nota 5
+- Trecho: "a gente não sai antes de ver a marca d'água no galpão do seu Ari; a rádio às vezes fala, mas é a marca que decide."
+- Pergunta: "Que critérios orientam a decisão de sair de casa durante uma cheia?"
+- Resposta: "Os moradores só saem depois de conferir a marca d'água no galpão de um vizinho; quando o aviso da rádio diverge desse sinal, eles seguem a marca."
+- Por quê: nenhuma condição se aplica. O par abstrai ("um vizinho", "esse sinal") e organiza os critérios em hierarquia, mas a hierarquia é a que a pessoa formulou e quem decide continua na frase. Se estivesse escrito "a decisão se apoia em um sinal local verificável", cairia para 4, porque o sujeito que decide desapareceria.
+
+Nota 4, elemento situado apagado
+- Trecho: "quando o vento vira pra baixo a gente já sabe que não dá pra atravessar."
+- Pergunta: "O que indica que a travessia não deve ser feita?"
+- Resposta: "A mudança na direção do vento indica que a travessia se torna inviável."
+- Por quê: o sentido está intacto e o vocabulário é aceitável. O que se perde é o "a gente já sabe": um saber coletivo passa a ser apresentado como propriedade do mundo, e não como algo que aquelas pessoas sabem ler.
+
+Nota 4, postura apagada
+- Trecho: "eu acho que dessa vez a água subiu mais rápido que na outra cheia, mas não sei dizer, foi de noite. Foi terrível, a gente perdeu tudo o que tinha embaixo."
+- Pergunta: "Como ela compara essa cheia com a anterior?"
+- Resposta: "A elevação do nível da água foi mais rápida do que na cheia anterior, resultando em perdas materiais nos pertences armazenados na parte inferior da casa."
+- Por quê: o conteúdo está todo lá e nada de fora foi acrescentado. O que desaparece é a postura: "eu acho que, não sei dizer" vira afirmação segura, e "foi terrível" vira "perdas materiais". Ela não afirmou com essa certeza nem descreveu aquilo com essa neutralidade.
+
+Nota 3, informação de fora adicionada
+- Trecho: "faz dois anos que eu peço o cadastro e até hoje nada; cada vez que eu vou lá falta um papel."
+- Pergunta: "Qual a experiência dela com o cadastro?"
+- Resposta: "As exigências documentais repetidas configuram uma barreira burocrática de acesso ao cadastro."
+- Por quê: o núcleo continua reconhecível (pediu, não saiu, sempre falta papel), mas "barreira burocrática de acesso" é uma explicação que ela não deu. Nada do que ela disse é contradito.
+
+Nota 3, lacuna preenchida
+- Trecho: "esse ano eu plantei mais pra baixo, perto da sanga."
+- Pergunta: "O que ela fez em relação ao plantio deste ano?"
+- Resposta: "Neste ano plantou em área mais baixa, próxima à sanga, buscando solo mais úmido."
+- Por quê: a parte factual está correta, mas "buscando solo mais úmido" é um motivo que ela não deu, completado com o que normalmente seria o caso. O núcleo continua reconhecível e nada é contradito, então é 3. Não é 2 porque ela não deu motivo nenhum: não há motivo trocado, há motivo inventado onde não havia.
+
+Nota 2
+- Trecho: "depois da enchente muita gente foi embora, foi pra cidade, pra casa de parente. Meu genro foi. Eu fiquei. Não é que eu não pudesse ir, o meu cunhado tinha lugar lá. É que aqui eu sei viver: eu sei a hora que o rio sobe, sei onde botar as coisas, sei com quem contar."
+- Pergunta: "Por que parte dos moradores permaneceu na área afetada após a enchente?"
+- Resposta: "A permanência evidencia um processo de desterritorialização seletiva, em que os moradores sem alternativa habitacional permaneceram expostos ao risco."
+- Por quê: o motivo que ela deu foi saber viver ali, e o par o substitui por falta de alternativa, contradizendo o "não é que eu não pudesse ir". Ela reconheceria os fatos e não a explicação. Não é 3 porque a adição não convive com o que foi dito: troca o motivo. Não é 1 porque os fatos continuam corretos e não há clichê.
+
+Nota 1, sentido alterado
+- Trecho: "eu não vendo pra atravessador, prefiro vender na porta mesmo, ganho menos mas recebo na hora."
+- Pergunta: "Como ela comercializa o pescado?"
+- Resposta: "Vende para atravessadores porque precisa receber o pagamento imediatamente."
+- Por quê: a resposta afirma o contrário do que foi dito. Ela disse que não vende para atravessador. Não há clichê nem informação de fora acrescentada: o que ela disse foi invertido, e isso basta para a nota 1.
+
+Nota 1, pelo clichê
+- Trecho: "eu pesco desde os nove anos, aprendi vendo meu pai; hoje tem dia que não paga nem o diesel."
+- Pergunta: "Como ele descreve sua relação com a pesca?"
+- Resposta: "O pescador mantém uma relação ancestral de harmonia com o rio, guiada por uma sabedoria tradicional transmitida entre gerações."
+- Por quê: entra o clichê ("ancestral", "harmonia", "sabedoria tradicional") e desaparece o que ele colocou, que é a pesca não pagar o próprio custo. Ele não reconheceria nem os fatos nem a explicação.
+
+Nota 1, pela pergunta
+- Trecho: "eu pesco desde os nove anos, aprendi vendo meu pai; hoje tem dia que não paga nem o diesel."
+- Pergunta: "Como a sabedoria ancestral dos pescadores é transmitida entre gerações?"
+- Resposta: "O aprendizado ocorre pela observação do trabalho dos mais velhos, desde os nove anos de idade."
+- Por quê: a resposta é sóbria e fiel ao trecho. A perda está na pergunta, que insere "sabedoria ancestral", um clichê que a pessoa não usou, e faz o par inteiro afirmar isso. A condição dispara pela pergunta, não pela resposta.
+
+Avalie o par abaixo. Você vê apenas o trecho de origem, a pergunta e a resposta.
+
+Trecho de origem:
 $context
 
 Par:
 - Pergunta: $question
 - Resposta: $answer
 
-Instruções:
-1. Atribua uma nota inteira de 1 a 5 seguindo a rubrica acima.
-2. Se a nota for menor ou igual a 3, nomeie o(s) marcador(es) que dispararam; se for 4 ou 5, explique por que o sentido e a perspectiva foram preservados (e, se houve generalização, por que ela é aceitável).
-3. Forneça uma justificativa breve e clara.
+Ao escrever a justificativa:
 
-Responda em JSON: {"rationale": "<justificativa>", "score": <inteiro 1-5>}.
+- Descreva o que a pessoa disse usando as palavras dela.
+- Não nomeie como diagnóstico institucional aquilo que ela colocou como queixa ou como descrição concreta.
+- Não introduza categoria de análise que ela não usou.
+
+Estas três regras valem para a sua justificativa. Quando a mesma coisa aparece no par avaliado, é perda êmica e reduz a nota.
+
+Retorne apenas um objeto JSON: {"rationale": "<1-2 frases>", "score": <inteiro 1-5>}

--- a/prompts/judge/criteria/emic_validity/ruler.pt.yaml
+++ b/prompts/judge/criteria/emic_validity/ruler.pt.yaml
@@ -1,0 +1,341 @@
+# Régua da validade êmica: fonte única do texto que vai para o juiz LLM e para os
+# anotadores humanos.
+#
+# Por que este arquivo existe: o kappa ponderado entre o LLM e cada anotador (spec
+# §6) só mede concordância se os dois pontuarem na MESMA régua. Se o prompt e a
+# folha de instruções divergirem, o coeficiente passa a medir divergência de
+# tradução, e isso não é recuperável depois da anotação.
+#
+# Consumidores:
+#   - prompts/judge/criteria/emic_validity/pt/prompt.md  (juiz LLM)
+#   - docs/emic/annotator-instructions.pt.md             (anotadores humanos)
+#   - labeling_config.xml do Label Studio                (a construir)
+#
+# tests/shared/judge/test_emic_ruler.py falha se qualquer consumidor divergir
+# deste arquivo.
+
+signed_off: true
+signed_off_by: Fred (antropologia)
+signed_off_on: "2026-08-11"
+gate: anthropologist-validation-of-readings
+
+# --- Construto -------------------------------------------------------------
+
+construct:
+  emic: >-
+    Êmico é descrever nos termos de quem vive a situação: as categorias, as
+    medidas e as razões que a própria pessoa usa para explicar o mundo dela.
+  non_emic: >-
+    Não-êmico é descrever nos termos de quem observa: as categorias do
+    pesquisador, do técnico ou da teoria, aplicadas de fora sobre o que a pessoa
+    disse.
+  gradient: >-
+    Os dois não são opostos absolutos, e nenhum é errado em geral. Um par se
+    afasta do registro êmico por graus, e é esse afastamento que a escala de 1 a
+    5 mede. O que se quer registrar é o conhecimento da pessoa, não a tradução
+    dele para o vocabulário de quem a estuda.
+  question: >-
+    O par é gerado a partir de um trecho de entrevista. A pergunta a responder: a
+    própria pessoa reconheceria este par como fiel ao que quis dizer e a como ela
+    entende o mundo?
+  not_faithfulness: >-
+    Isto não é fidelidade ao texto. Um par pode citar corretamente o que foi dito
+    e ainda deslocar o sentido ao reenquadrá-lo.
+
+# --- Escala (rótulos curtos; são o texto do widget no Label Studio) ---------
+
+scale:
+  - score: 5
+    label: Preserva o sentido, a perspectiva e quem sabe ou decide.
+  - score: 4
+    label: Preserva o sentido, mas apaga um elemento situado ou a postura da pessoa.
+  - score: 3
+    label: >-
+      Acrescenta algo que a pessoa não disse, e o núcleo do que ela disse continua
+      reconhecível.
+  - score: 2
+    label: Acrescenta algo que a pessoa não disse e troca o motivo que ela deu.
+  - score: 1
+    label: Contradiz o que a pessoa disse, ou substitui a perspectiva dela por clichê.
+
+# --- Tipos de perda êmica --------------------------------------------------
+
+loss_types:
+  - name: Sentido alterado
+    what: A reformulação muda o que está sendo dito.
+    score: "1"
+  - name: Clichê sobre populações tradicionais
+    what: >-
+      Uma fórmula pronta ocupa o lugar do conhecimento da pessoa: sabedoria
+      ancestral, harmonia com a natureza, vínculo imemorial com o território.
+    score: "1"
+  - name: Informação de fora adicionada
+    what: >-
+      O par afirma algo que a pessoa não disse: uma explicação, um diagnóstico ou
+      uma categoria de análise.
+    score: 2 ou 3, ver o guia
+  - name: Lacuna preenchida
+    what: >-
+      O que a pessoa não disse é completado com aquilo que normalmente seria o
+      caso.
+    score: 2 ou 3, ver o guia
+  - name: Elemento situado apagado
+    what: >-
+      O sentido se preserva, mas desaparece quem sabe, decide ou age, ou o sinal
+      concreto que a pessoa usa.
+    score: "4"
+  - name: Postura apagada
+    what: >-
+      O conteúdo se preserva, mas desaparece como a pessoa se posiciona: a dúvida
+      vira certeza, ou a avaliação dela vira descrição neutra.
+    score: "4"
+
+# --- Disposições gerais ----------------------------------------------------
+
+provisions:
+  unit_of_judgment: >-
+    O objeto de avaliação é o par. Avalia-se a pergunta e a resposta juntas, e a
+    perda pode estar em qualquer uma das duas. Uma pergunta que pressupõe o que a
+    pessoa não disse, ou que arranca a fala do contexto em que ela foi dita, basta
+    para derrubar o par, ainda que a resposta seja sóbria.
+  question_calibrates: >-
+    A pergunta define o que conta como perda. Um detalhe que a pergunta não punha
+    em jogo pode desaparecer sem custo. O que carrega o conhecimento que a
+    pergunta pede, não. Se a pergunta trata de como algo é feito, perder o nome de
+    quem emprestou o dinheiro não é perda, desde que a lógica que a pessoa deu
+    continue inteira; se a pergunta trata de como se sabe algo, perder quem sabe é
+    perda. A pergunta calibra a expectativa de detalhe e nada além disso.
+  not_a_loss:
+    - Generalizar ou abstrair preservando o sentido. Alguma generalização é esperada.
+    - >-
+      Trocar uma palavra por outra sem apagar nada: dizer embarcação onde a pessoa
+      disse barco não custa ponto.
+    - >-
+      Perder um nome próprio ou um objeto específico quando a pergunta não pedia
+      aquele detalhe e a lógica que a pessoa enunciou continua inteira.
+    - Responder de forma curta, ou menos detalhada que o trecho.
+  out_of_scope: >-
+    Fora deste escopo: se o par está bem escrito, se a resposta está correta,
+    completa ou bem fundamentada no trecho. Aqui se julga apenas se a perspectiva
+    da pessoa foi preservada.
+
+# --- Guia de avaliação -----------------------------------------------------
+#
+# Cascata: primeira condição que casa decide. Ordem deliberada, a falha mais grave
+# vence (um par com informação adicionada E elemento situado apagado recebe 3, não
+# 4).
+
+guide:
+  locate: >-
+    Localize no trecho as passagens de que o par trata. Julgue o par contra essas
+    passagens, não contra o trecho inteiro.
+  extract: >-
+    Nessas passagens, identifique quatro coisas: o que a pessoa afirma; as
+    palavras e medidas que ela usa; quem sabe, decide ou age; e o que a pergunta
+    põe em jogo.
+  cascade_intro: >-
+    Percorra as condições em ordem e pare na primeira que se aplicar. A nota é a
+    dessa condição.
+  cascade:
+    - score: 1
+      condition: >-
+        O par contradiz o que a pessoa afirma, ou substitui a perspectiva dela por
+        clichê sobre populações tradicionais.
+    - score: 2
+      condition: >-
+        O par afirma algo que ela não disse, e essa adição troca o motivo que ela
+        deu por outro, fazendo a fala servir de exemplo de uma ideia que não é
+        dela.
+    - score: 3
+      condition: >-
+        O par afirma algo que ela não disse, mas o núcleo do que ela disse
+        continua reconhecível.
+    - score: 4
+      condition: >-
+        O par preserva o sentido, mas apaga um elemento situado que carrega o
+        conhecimento em jogo (quem sabe, decide ou age; o sinal concreto), ou
+        apaga a postura com que ela disse (a dúvida virou certeza, a avaliação
+        virou descrição neutra).
+    - score: 5
+      condition: Nenhuma das anteriores.
+  no_penalty: >-
+    Não reduzem a nota, por si sós: generalizar ou abstrair; usar vocabulário mais
+    formal; responder de forma curta; omitir um detalhe que a pergunta não pedia.
+    Só reduzem quando uma das condições acima se aplica.
+  name_the_condition: Na justificativa, nomeie a condição que decidiu a nota.
+
+# --- Exemplos --------------------------------------------------------------
+#
+# TODOS SINTÉTICOS. Nenhum vem de entrevista real, e isso não é acidental: um par
+# real usado como exemplo teria de sair do frame de análise (a nota do LLM sobre
+# um par presente no próprio prompt não é independente) e, na folha, primaria os
+# anotadores com conteúdo do corpus.
+
+examples_preamble: Casos construídos para ilustrar a escala. Nenhum vem de entrevista real.
+
+examples:
+  - score: 5
+    title: Nota 5
+    segment: >-
+      a gente não sai antes de ver a marca d'água no galpão do seu Ari; a rádio às
+      vezes fala, mas é a marca que decide.
+    question: Que critérios orientam a decisão de sair de casa durante uma cheia?
+    answer: >-
+      Os moradores só saem depois de conferir a marca d'água no galpão de um
+      vizinho; quando o aviso da rádio diverge desse sinal, eles seguem a marca.
+    why: >-
+      Nenhuma condição se aplica. O par abstrai ("um vizinho", "esse sinal") e
+      organiza os critérios em hierarquia, mas a hierarquia é a que a pessoa
+      formulou e quem decide continua na frase. Se estivesse escrito "a decisão se
+      apoia em um sinal local verificável", cairia para 4, porque o sujeito que
+      decide desapareceria.
+  - score: 4
+    title: Nota 4, elemento situado apagado
+    segment: quando o vento vira pra baixo a gente já sabe que não dá pra atravessar.
+    question: O que indica que a travessia não deve ser feita?
+    answer: A mudança na direção do vento indica que a travessia se torna inviável.
+    why: >-
+      O sentido está intacto e o vocabulário é aceitável. O que se perde é o "a
+      gente já sabe": um saber coletivo passa a ser apresentado como propriedade do
+      mundo, e não como algo que aquelas pessoas sabem ler.
+  - score: 4
+    title: Nota 4, postura apagada
+    segment: >-
+      eu acho que dessa vez a água subiu mais rápido que na outra cheia, mas não
+      sei dizer, foi de noite. Foi terrível, a gente perdeu tudo o que tinha
+      embaixo.
+    question: Como ela compara essa cheia com a anterior?
+    answer: >-
+      A elevação do nível da água foi mais rápida do que na cheia anterior,
+      resultando em perdas materiais nos pertences armazenados na parte inferior da
+      casa.
+    why: >-
+      O conteúdo está todo lá e nada de fora foi acrescentado. O que desaparece é a
+      postura: "eu acho que, não sei dizer" vira afirmação segura, e "foi terrível"
+      vira "perdas materiais". Ela não afirmou com essa certeza nem descreveu aquilo
+      com essa neutralidade.
+  - score: 3
+    title: Nota 3, informação de fora adicionada
+    segment: >-
+      faz dois anos que eu peço o cadastro e até hoje nada; cada vez que eu vou lá
+      falta um papel.
+    question: Qual a experiência dela com o cadastro?
+    answer: >-
+      As exigências documentais repetidas configuram uma barreira burocrática de
+      acesso ao cadastro.
+    why: >-
+      O núcleo continua reconhecível (pediu, não saiu, sempre falta papel), mas
+      "barreira burocrática de acesso" é uma explicação que ela não deu. Nada do que
+      ela disse é contradito.
+  - score: 3
+    title: Nota 3, lacuna preenchida
+    segment: esse ano eu plantei mais pra baixo, perto da sanga.
+    question: O que ela fez em relação ao plantio deste ano?
+    answer: Neste ano plantou em área mais baixa, próxima à sanga, buscando solo mais úmido.
+    why: >-
+      A parte factual está correta, mas "buscando solo mais úmido" é um motivo que
+      ela não deu, completado com o que normalmente seria o caso. O núcleo continua
+      reconhecível e nada é contradito, então é 3. Não é 2 porque ela não deu motivo
+      nenhum: não há motivo trocado, há motivo inventado onde não havia.
+  - score: 2
+    title: Nota 2
+    segment: >-
+      depois da enchente muita gente foi embora, foi pra cidade, pra casa de
+      parente. Meu genro foi. Eu fiquei. Não é que eu não pudesse ir, o meu cunhado
+      tinha lugar lá. É que aqui eu sei viver: eu sei a hora que o rio sobe, sei
+      onde botar as coisas, sei com quem contar.
+    question: Por que parte dos moradores permaneceu na área afetada após a enchente?
+    answer: >-
+      A permanência evidencia um processo de desterritorialização seletiva, em que
+      os moradores sem alternativa habitacional permaneceram expostos ao risco.
+    why: >-
+      O motivo que ela deu foi saber viver ali, e o par o substitui por falta de
+      alternativa, contradizendo o "não é que eu não pudesse ir". Ela reconheceria
+      os fatos e não a explicação. Não é 3 porque a adição não convive com o que foi
+      dito: troca o motivo. Não é 1 porque os fatos continuam corretos e não há
+      clichê.
+  - score: 1
+    title: Nota 1, sentido alterado
+    segment: >-
+      eu não vendo pra atravessador, prefiro vender na porta mesmo, ganho menos mas
+      recebo na hora.
+    question: Como ela comercializa o pescado?
+    answer: Vende para atravessadores porque precisa receber o pagamento imediatamente.
+    why: >-
+      A resposta afirma o contrário do que foi dito. Ela disse que não vende para
+      atravessador. Não há clichê nem informação de fora acrescentada: o que ela
+      disse foi invertido, e isso basta para a nota 1.
+  - score: 1
+    title: Nota 1, pelo clichê
+    segment: >-
+      eu pesco desde os nove anos, aprendi vendo meu pai; hoje tem dia que não paga
+      nem o diesel.
+    question: Como ele descreve sua relação com a pesca?
+    answer: >-
+      O pescador mantém uma relação ancestral de harmonia com o rio, guiada por uma
+      sabedoria tradicional transmitida entre gerações.
+    why: >-
+      Entra o clichê ("ancestral", "harmonia", "sabedoria tradicional") e desaparece
+      o que ele colocou, que é a pesca não pagar o próprio custo. Ele não
+      reconheceria nem os fatos nem a explicação.
+  - score: 1
+    title: Nota 1, pela pergunta
+    segment: >-
+      eu pesco desde os nove anos, aprendi vendo meu pai; hoje tem dia que não paga
+      nem o diesel.
+    question: Como a sabedoria ancestral dos pescadores é transmitida entre gerações?
+    answer: >-
+      O aprendizado ocorre pela observação do trabalho dos mais velhos, desde os
+      nove anos de idade.
+    why: >-
+      A resposta é sóbria e fiel ao trecho. A perda está na pergunta, que insere
+      "sabedoria ancestral", um clichê que a pessoa não usou, e faz o par inteiro
+      afirmar isso. A condição dispara pela pergunta, não pela resposta.
+
+# --- Só na folha dos anotadores --------------------------------------------
+#
+# Calibração de leitor humano. Fora do prompt de propósito: instrução negativa
+# ("não é 1 quando...") gasta atenção de um modelo pequeno, e a cascata já resolve
+# por condição positiva.
+
+annotator_only:
+  fine_boundaries: >-
+    As fronteiras são finas de propósito. 5 e 4 se separam por uma única coisa: se
+    o elemento situado (quem sabe, decide ou age, o sinal usado) continua no par. 3
+    e 2 se separam por saber se o que foi acrescentado convive com o que a pessoa
+    disse ou troca o motivo que ela deu. Hesitar entre notas vizinhas é esperado e
+    não é erro seu. Quando hesitar, volte ao guia e percorra as condições na ordem:
+    a primeira que se aplicar decide. Se a dúvida persistir, registre na
+    justificativa qual foi.
+  narrow_door_to_one: >-
+    Use 1 apenas se você puder apontar uma das duas coisas: uma afirmação que
+    contraria o que a pessoa disse, ou um clichê sobre populações tradicionais
+    ocupando o lugar da perspectiva dela. Não é 1: achar a resposta vaga, achar o
+    vocabulário formal demais, ou discordar da leitura sem conseguir apontar uma
+    dessas duas. Esses casos são 3 ou 4.
+
+# --- Só no prompt ----------------------------------------------------------
+#
+# O domínio (comunidades ribeirinhas, eventos climáticos) NÃO entra: nomeá-lo ativa
+# no modelo os esquemas sobre populações tradicionais que este critério existe para
+# detectar. O trecho da entrevista já entrega o campo.
+
+judge_only:
+  role: >-
+    Você é um avaliador rigoroso de pares pergunta-resposta gerados a partir de
+    entrevistas. Sua tarefa é avaliar a VALIDADE ÊMICA do par, com o rigor de um
+    antropólogo.
+  rationale_rules:
+    - Descreva o que a pessoa disse usando as palavras dela.
+    - >-
+      Não nomeie como diagnóstico institucional aquilo que ela colocou como queixa
+      ou como descrição concreta.
+    - Não introduza categoria de análise que ela não usou.
+  rationale_rules_closing: >-
+    Estas três regras valem para a sua justificativa. Quando a mesma coisa aparece
+    no par avaliado, é perda êmica e reduz a nota.
+  # A escala é ordinal: score é int com ge=1, le=5 (shared/judge/criterion.py).
+  # O validador arredonda fracionários half-up, então o placeholder <0-1> usado
+  # pelos critérios contínuos faria um 0.8 virar nota 1 (distorção) sem erro
+  # visível. Ver tests/shared/judge/test_emic_ruler.py.
+  output: 'Retorne apenas um objeto JSON: {"rationale": "<1-2 frases>", "score": <inteiro 1-5>}'

--- a/tests/shared/judge/test_emic_ruler.py
+++ b/tests/shared/judge/test_emic_ruler.py
@@ -1,0 +1,222 @@
+"""The emic ruler is a single source; its consumers must not drift from it.
+
+``prompts/judge/criteria/emic_validity/ruler.pt.yaml`` holds the construct, the
+scale, the loss types, the provisions and the guide. Two artifacts render it: the
+judge prompt and the annotator instruction sheet. The weighted kappa between the
+LLM and each annotator (spec §6) only measures agreement if both score on the
+*same* ruler, so a silent divergence between these files would turn the
+coefficient into a measure of translation mismatch. That is not recoverable after
+annotation, which is why it is asserted here instead of reviewed by eye.
+
+Also asserted: the ruler is signed off, no real corpus pair leaked into either
+artifact, and the ordinal placeholder was not copied from the continuous criteria.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
+import yaml
+
+from arandu.utils.paths import get_project_root
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+EMIC_DIR = get_project_root() / "prompts" / "judge" / "criteria" / "emic_validity"
+RULER_PATH = EMIC_DIR / "ruler.pt.yaml"
+PROMPT_PATH = EMIC_DIR / "pt" / "prompt.md"
+SHEET_PATH = get_project_root() / "docs" / "emic" / "annotator-instructions.pt.md"
+
+# Fragments of real corpus pairs that earlier drafts of the prompt used as
+# illustrations. They must not reappear: see TestNoRealPairLeaked.
+CORPUS_FRAGMENTS = (
+    "maikinho",
+    "açucareiro",
+    "patram",
+    "ibama",
+    "negligência sistêmica",
+    "dona gilda",
+)
+
+
+def _normalize(text: str) -> str:
+    """Collapse whitespace and case so rendering differences are not divergence.
+
+    The YAML folds long strings, the prompt keeps one long line per paragraph and
+    the sheet wraps at 88 columns; a passage also gets recased when it follows a
+    label ("Sentido alterado: a reformulação...") . Only the words are the ruler,
+    so wrapping and initial case are tolerated here. Any changed, added or dropped
+    word still fails.
+    """
+    return " ".join(text.split()).casefold()
+
+
+def _needle(text: str) -> str:
+    """Normalize a ruler passage for substring search.
+
+    Drops the trailing period: the ruler stores full sentences, and a consumer may
+    render the same sentence with a suffix instead ("... : nota 1").
+    """
+    return _normalize(text).rstrip(".")
+
+
+@pytest.fixture(scope="module")
+def ruler() -> dict[str, Any]:
+    return yaml.safe_load(RULER_PATH.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def prompt() -> str:
+    return _normalize(PROMPT_PATH.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def sheet() -> str:
+    return _normalize(SHEET_PATH.read_text(encoding="utf-8"))
+
+
+def _ruler_texts(ruler: dict[str, Any]) -> list[tuple[str, str]]:
+    """Return (label, text) for every ruler passage that must appear verbatim."""
+    texts: list[tuple[str, str]] = []
+    for key, value in ruler["construct"].items():
+        texts.append((f"construct.{key}", value))
+    for entry in ruler["scale"]:
+        texts.append((f"scale.{entry['score']}", entry["label"]))
+    for entry in ruler["loss_types"]:
+        texts.append((f"loss_types.{entry['name']}", entry["what"]))
+    provisions = ruler["provisions"]
+    texts.append(("provisions.unit_of_judgment", provisions["unit_of_judgment"]))
+    texts.append(("provisions.question_calibrates", provisions["question_calibrates"]))
+    texts.append(("provisions.out_of_scope", provisions["out_of_scope"]))
+    for i, item in enumerate(provisions["not_a_loss"]):
+        texts.append((f"provisions.not_a_loss[{i}]", item))
+    guide = ruler["guide"]
+    for key in ("locate", "extract", "cascade_intro", "no_penalty", "name_the_condition"):
+        texts.append((f"guide.{key}", guide[key]))
+    for entry in guide["cascade"]:
+        texts.append((f"guide.cascade.{entry['score']}", entry["condition"]))
+    for entry in ruler["examples"]:
+        for field in ("segment", "question", "answer", "why"):
+            texts.append((f"examples[{entry['title']}].{field}", entry[field]))
+    return texts
+
+
+class TestRulerIsSignedOff:
+    def test_gate_is_signed_off(self, ruler: dict[str, Any]) -> None:
+        # The annotation instrument refuses to build while this is false (spec §6
+        # of the instrument design). Flipping it is the mechanical form of the
+        # anthropologist gate.
+        assert ruler["signed_off"] is True
+        assert ruler["gate"] == "anthropologist-validation-of-readings"
+        assert ruler["signed_off_on"]
+
+    def test_scale_is_the_ordinal_one_to_five(self, ruler: dict[str, Any]) -> None:
+        assert [entry["score"] for entry in ruler["scale"]] == [5, 4, 3, 2, 1]
+
+    def test_cascade_covers_every_score_in_severity_order(self, ruler: dict[str, Any]) -> None:
+        # Order is load-bearing: first matching condition wins, so the gravest
+        # failure has to come first. A pair with both an added claim and an erased
+        # situated element must land on 3, never 4.
+        assert [entry["score"] for entry in ruler["guide"]["cascade"]] == [1, 2, 3, 4, 5]
+
+
+class TestConsumersRenderTheRuler:
+    @pytest.mark.parametrize("artifact", ["prompt", "sheet"])
+    def test_every_ruler_passage_appears_verbatim(
+        self, artifact: str, ruler: dict[str, Any], prompt: str, sheet: str
+    ) -> None:
+        rendered = prompt if artifact == "prompt" else sheet
+        missing = [label for label, text in _ruler_texts(ruler) if _needle(text) not in rendered]
+        assert not missing, f"{artifact} diverged from ruler.pt.yaml: {missing}"
+
+    def test_annotator_only_text_stays_out_of_the_prompt(
+        self, ruler: dict[str, Any], prompt: str, sheet: str
+    ) -> None:
+        # Human calibration ("hesitating is expected", "not a 1 when...") is
+        # negative instruction that costs a small model attention; the cascade
+        # already resolves by positive condition.
+        for key, text in ruler["annotator_only"].items():
+            assert _needle(text) in sheet, f"sheet is missing annotator_only.{key}"
+            assert _needle(text) not in prompt, f"prompt leaked annotator_only.{key}"
+
+    def test_judge_only_text_stays_out_of_the_sheet(
+        self, ruler: dict[str, Any], prompt: str, sheet: str
+    ) -> None:
+        judge_only = ruler["judge_only"]
+        for key in ("role", "rationale_rules_closing", "output"):
+            assert _needle(judge_only[key]) in prompt, f"prompt is missing judge_only.{key}"
+            assert _needle(judge_only[key]) not in sheet, f"sheet leaked judge_only.{key}"
+
+
+class TestBlinding:
+    def test_prompt_receives_only_the_blinded_fields(self) -> None:
+        raw = PROMPT_PATH.read_text(encoding="utf-8")
+        assert "$context" in raw
+        assert "$question" in raw
+        assert "$answer" in raw
+
+    @pytest.mark.parametrize("path", [PROMPT_PATH, SHEET_PATH])
+    def test_generator_metadata_is_never_named(self, path: Path) -> None:
+        # Parity/blinding (spec §5): naming the Bloom level or the tacit-inference
+        # field would anchor both the model and the annotator.
+        low = path.read_text(encoding="utf-8").lower()
+        for forbidden in ("bloom", "tacit_inference", "inferência tácita"):
+            assert forbidden not in low, f"{path.name} names {forbidden!r}"
+
+    def test_domain_is_not_named_to_the_judge(self, ruler: dict[str, Any], prompt: str) -> None:
+        # Naming the domain activates the very schemas about traditional
+        # populations that this criterion exists to detect, so it is deliberately
+        # absent. The interview excerpt already supplies the field.
+        #
+        # Checked against the rendered prompt and against the ruler's *values*, not
+        # the YAML source: a comment there explains why the domain is excluded, and
+        # comments never reach an artifact.
+        assert "ribeirinh" not in prompt
+        rendered_values = _normalize(
+            " ".join(text for _, text in _ruler_texts(ruler))
+            + " ".join(ruler["judge_only"]["rationale_rules"])
+            + ruler["judge_only"]["role"]
+        )
+        assert "ribeirinh" not in rendered_values
+
+
+class TestNoRealPairLeaked:
+    """Examples are synthetic by decision, and the decision protects the frame.
+
+    A real pair in the prompt makes the judge's score on it non-independent, so it
+    would have to leave the 2670-pair frame; a real pair in the sheet primes the
+    annotators with corpus content. These strings come from actual corpus pairs
+    that earlier drafts used as illustrations.
+    """
+
+    @pytest.mark.parametrize("path", [PROMPT_PATH, SHEET_PATH, RULER_PATH])
+    @pytest.mark.parametrize("fragment", CORPUS_FRAGMENTS)
+    def test_no_corpus_fragment_appears(self, path: Path, fragment: str) -> None:
+        assert fragment not in path.read_text(encoding="utf-8").lower(), (
+            f"{path.name} contains the real-corpus fragment {fragment!r}"
+        )
+
+
+class TestOrdinalOutputContract:
+    def test_placeholder_is_the_ordinal_range(self, ruler: dict[str, Any]) -> None:
+        # The continuous criteria ask for "<0-1>". Copying that here would be
+        # silently destructive: OrdinalCriterionResponse rounds fractional scores
+        # half-up before the range check, so a 0.8 would land on 1 -- the
+        # distortion label -- with no error raised.
+        output = ruler["judge_only"]["output"]
+        assert "<inteiro 1-5>" in output
+        assert "<0-1>" not in output
+
+    def test_prompt_asks_for_json_with_both_fields(self, prompt: str) -> None:
+        assert "json" in prompt.lower()
+        assert "rationale" in prompt
+        assert "score" in prompt
+
+    def test_rationale_rules_reach_the_prompt(self, ruler: dict[str, Any], prompt: str) -> None:
+        # These constrain the judge's own writing, which is where the reframing
+        # tendency shows up: a rationale that calls a complaint "systemic
+        # negligence" has committed the failure it was asked to detect.
+        for rule in ruler["judge_only"]["rationale_rules"]:
+            assert _needle(rule) in prompt, f"prompt is missing rationale rule: {rule!r}"

--- a/tests/shared/judge/test_emic_validity_prompt.py
+++ b/tests/shared/judge/test_emic_validity_prompt.py
@@ -32,11 +32,6 @@ def mock_llm_client(mocker: MockerFixture) -> Any:
     return client
 
 
-@pytest.fixture
-def emic_prompt() -> str:
-    return (CRITERIA_DIR / EMIC / "pt" / "prompt.md").read_text(encoding="utf-8")
-
-
 class TestEmicValidityWiring:
     def test_loads_as_ordinal_criterion(self, mock_llm_client: Any) -> None:
         criterion = OrdinalLLMCriterion.from_config(
@@ -75,46 +70,6 @@ class TestEmicValidityWiring:
         )
 
 
-class TestEmicPromptContent:
-    """The prompt must encode the spec's construct, markers, anchors, blinding."""
-
-    def test_names_construct_and_emic_etic(self, emic_prompt: str) -> None:
-        low = emic_prompt.lower()
-        assert "validade êmica" in low
-        assert "êmic" in low and "étic" in low  # names the distinction verbatim
-
-    def test_warns_of_model_own_reframing_bias(self, emic_prompt: str) -> None:
-        # Principle 2: meta-awareness of the model's own tendency to elevate
-        # situated speech into institutional/analytical diagnoses.
-        low = emic_prompt.lower()
-        assert "negligência sistêmica" in low  # the canonical bias example
-        assert "institucion" in low or "diagnóstico" in low
-
-    def test_generalization_is_acceptable(self, emic_prompt: str) -> None:
-        # Refined construct: meaning-preserving generalization is desirable,
-        # not a deviation; only meaning-change / added claims / register-swap
-        # lower the score.
-        low = emic_prompt.lower()
-        assert "generaliz" in low
-        assert "não é violação" in low or "desejável" in low
-
-    def test_has_five_point_anchors(self, emic_prompt: str) -> None:
-        # Assert the actual anchor format (- N:), not bare digits which appear
-        # elsewhere ("3 frases", "1-5", "§3.5") and would pass even if the
-        # anchor list were removed.
-        for level in ("1", "2", "3", "4", "5"):
-            assert f"- {level}:" in emic_prompt
-
-    def test_only_blinded_inputs_referenced(self, emic_prompt: str) -> None:
-        # Parity/blinding (§4.2 principle 7): sees only segment + Q + A.
-        assert "$context" in emic_prompt
-        assert "$question" in emic_prompt
-        assert "$answer" in emic_prompt
-        low = emic_prompt.lower()
-        assert "bloom" not in low
-        assert "tacit_inference" not in low and "inferência tácita" not in low
-
-    def test_requests_structured_integer_output(self, emic_prompt: str) -> None:
-        low = emic_prompt.lower()
-        assert "json" in low
-        assert "rationale" in low or "justificativa" in low
+# Prompt *content* is asserted in test_emic_ruler.py, against ruler.pt.yaml (the
+# single source shared with the annotator sheet). Duplicating content assertions
+# here would let the two drift: the ruler is the thing to hold the prompt to.


### PR DESCRIPTION
## Summary

Fecha o gate antropológico (`anthropologist-validation-of-readings`). O Fred revisou as leituras rascunhadas no §3.5 do spec e repontuou duas delas, o que deixou as âncoras e a lista de marcadores em contradição justamente sobre o marcador que a evidência do corpus aponta como dominante. A régua foi reescrita em torno dessas decisões, não remendada.

O que a revisão mudou de método:

- **Troca de registro não custa mais ponto.** `barco` -> `embarcação` continua 5. O que derruba para 4 é *apagar* um elemento situado que carrega o conhecimento, mais uma porta nova: apagar a postura com que a pessoa falou (hedge virando certeza, apreciação virando descrição neutra).
- **Claim adicionado saiu do 2 para o 3** quando convive com o que foi dito. O 2 agora exige que a adição *substitua o motivo que a pessoa deu*, transformando a fala em exemplo de uma tese externa.
- **A unidade de julgamento é o par, não a resposta.** Uma pergunta que pressupõe o que a pessoa não disse afunda o par mesmo com resposta sóbria.
- **A pergunta calibra o que conta como perda.** Um detalhe que ela nunca colocou em jogo pode sumir de graça. É isso que reconcilia "perdeu nome próprio e ficou 5" com "perdeu o sujeito do saber e caiu para 4".
- **Escala mantida em 1-5** mesmo com o nível 1 sendo empiricamente raro, porque ele registra uma falha distinta; a folha estreita a porta em vez de remover o nível.
- **Marcadores perderam a numeração** (as âncoras os citavam por número e ficavam ilegíveis isoladas) e viraram tipos de perda nomeados. A pontuação virou **cascata**: a primeira condição que casa decide, mais grave primeiro.

A régua vive em `emic_validity/ruler.pt.yaml` e é renderizada tanto pelo prompt do juiz quanto pela nova folha do anotador (`docs/emic/annotator-instructions.pt.md`). O kappa ponderado entre juiz e anotadores só mede concordância se os dois pontuarem na mesma régua, e uma divergência não é recuperável depois da anotação, então `test_emic_ruler.py` afirma que cada trecho aparece verbatim nos dois artefatos, que texto exclusivo do juiz fica fora da folha e que a calibração exclusiva do anotador fica fora do prompt.

Três coisas travadas por teste porque são falhas silenciosas:

- **Nenhum par real do corpus pode aparecer em qualquer um dos artefatos.** Rascunhos anteriores ilustravam a régua com pares reais, o que tornaria o score do juiz sobre eles não-independente (removendo-os do frame de 2670) e adiantaria conteúdo do corpus aos anotadores. Os exemplos são sintéticos, derivados do padrão e não de transcrição alguma.
- **O domínio não é nomeado ao juiz.** Dizer "comunidades ribeirinhas afetadas por eventos climáticos" ativa exatamente os esquemas sobre populações tradicionais que este critério existe para detectar. O trecho já fornece o campo. O mesmo raciocínio tirou o propósito do corpus do prompt.
- **O placeholder de saída continua `<inteiro 1-5>`.** Os critérios contínuos pedem `<0-1>`; copiar isso aqui seria destrutivo sem levantar nada, já que `OrdinalCriterionResponse` arredonda score fracionário para cima na metade, então um 0.8 cairia em 1, o rótulo de distorção.

`signed_off: true` é a forma mecânica do gate: o instrumento de anotação recusa buildar enquanto for `false`.

## Breaking change

O prompt `emic_validity` não descreve mais o construto em termos de "ético". O polo oposto é **"não-êmico"**, porque em português "ético" lê como moralidade e engana um modelo de juiz pequeno. Qualquer análise ou texto de anexo que cite as âncoras antigas ou os marcadores numerados precisa ser atualizado; a régua é a fonte de onde citar.

## Test plan

- [x] `uv run pytest tests/shared/judge/test_emic_ruler.py` (31 testes: verbatim entre prompt e folha, blindagem cruzada, ausência de par real, contrato ordinal da saída)
- [x] `uv run pytest tests/shared/judge/test_emic_validity_prompt.py`
- [x] Suite completa: 1732 passed
- [x] `uv run ruff check src/ && uv run ruff format src/`
- [ ] Revisar se a régua renderizada no prompt cabe no contexto dimensionado para o serviço `arandu-emic` (16384 ctx, 4 workers) antes do run de ~15-22h
