### PR TITLE
feat(annotation): add the emic annotation instrument (build/push/pull)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -279,6 +279,16 @@ ARANDU_QUALITY_EXPECTED_LANGUAGE=pt
 # Base URL of the instance the three annotators use.
 ARANDU_LABEL_STUDIO_URL=https://label.emcorrespondencia.cloud
 # API token: Label Studio UI -> Account & Settings -> Access Token.
+# Both token types Label Studio issues are accepted, and you do not have to
+# declare which one you have: the token's own shape decides.
+#   * Personal access token (JWT, three dot-separated segments). What a current
+#     instance hands out. It is a *refresh* token and is rejected by the API
+#     endpoints directly, so the client exchanges it at POST /api/token/refresh
+#     for a short-lived access token and sends that as a Bearer credential.
+#     Renewal is automatic; you only re-copy it if it is revoked or expires.
+#   * Legacy API token (a single hex-ish string, no dots). Sent as-is. Older
+#     instances, and organizations with legacy tokens enabled, show this one on
+#     the same screen.
 # Never commit a real value and never place it in docker-compose.yml.
 # Read from this file or from the environment. The value is kept out of
 # results/: it is a SecretStr in the settings class, and the environment

--- a/.env.example
+++ b/.env.example
@@ -275,6 +275,16 @@ ARANDU_QUALITY_EXPECTED_LANGUAGE=pt
 # ARANDU_QUALITY_UNIFORM_INTERVAL_TOLERANCE=0.1
 
 
+# --- Label Studio (emic annotation instrument) ---
+# Base URL of the instance the three annotators use.
+ARANDU_LABEL_STUDIO_URL=https://label.emcorrespondencia.cloud
+# API token: Label Studio UI -> Account & Settings -> Access Token.
+# Never commit a real value and never place it in docker-compose.yml.
+ARANDU_LABEL_STUDIO_TOKEN=
+# Per-request timeout in seconds (a 120-task import is one request).
+ARANDU_LABEL_STUDIO_TIMEOUT=60
+
+
 # =============================================================================
 # SLURM / GPU / ROCm (set by job scripts, override only when needed)
 # =============================================================================

--- a/.env.example
+++ b/.env.example
@@ -280,6 +280,10 @@ ARANDU_QUALITY_EXPECTED_LANGUAGE=pt
 ARANDU_LABEL_STUDIO_URL=https://label.emcorrespondencia.cloud
 # API token: Label Studio UI -> Account & Settings -> Access Token.
 # Never commit a real value and never place it in docker-compose.yml.
+# Read from this file or from the environment. The value is kept out of
+# results/: it is a SecretStr in the settings class, and the environment
+# snapshot every run writes into run_metadata.json redacts any ARANDU_ variable
+# whose name contains TOKEN / SECRET / PASSWORD / KEY / CREDENTIAL.
 ARANDU_LABEL_STUDIO_TOKEN=
 # Per-request timeout in seconds (a 120-task import is one request).
 ARANDU_LABEL_STUDIO_TIMEOUT=60

--- a/docs/development/schemas.md
+++ b/docs/development/schemas.md
@@ -1148,9 +1148,17 @@ Captures configuration at the time of run execution.
 |-------|------|----------|-------------|
 | `config_type` | `str` | Yes | Configuration class name |
 | `config_values` | `dict` | Yes | Configuration values as dictionary |
-| `environment_variables` | `dict[str, str]` | Yes | Relevant environment variables (default: empty dict) |
+| `environment_variables` | `dict[str, str]` | Yes | Relevant environment variables, with credential values redacted (default: empty dict) |
 
 **Class Method**: `from_config(config, env_prefix="ARANDU_")` - Creates snapshot from a Pydantic config object
+
+**Credential redaction**: the captured environment is written verbatim into
+every run's `run_metadata.json` under `results/`, which is a durable artifact.
+Any captured variable whose name contains `TOKEN`, `SECRET`, `PASSWORD`, `KEY`
+or `CREDENTIAL` (case-insensitive) has its value replaced by `***REDACTED***`.
+The key is kept, so the snapshot still records that the variable was set.
+There is no allowlist: `ARANDU_*_API_KEY_ENV` holds a variable *name* rather
+than a secret and is redacted too, which is harmless.
 
 **Example**:
 ```json
@@ -1163,7 +1171,8 @@ Captures configuration at the time of run execution.
   },
   "environment_variables": {
     "ARANDU_MODEL_ID": "openai/whisper-large-v3",
-    "ARANDU_DEVICE": "cuda"
+    "ARANDU_DEVICE": "cuda",
+    "ARANDU_LABEL_STUDIO_TOKEN": "***REDACTED***"
   }
 }
 ```

--- a/docs/emic/annotator-instructions.pt.md
+++ b/docs/emic/annotator-instructions.pt.md
@@ -96,19 +96,21 @@ essas passagens, não contra o trecho inteiro.
 palavras e medidas que ela usa; quem sabe, decide ou age; e o que a pergunta põe em
 jogo.
 
-**3.** Percorra as condições em ordem e pare na primeira que se aplicar. A nota é a
-dessa condição.
+**3.** Percorra as frases abaixo em ordem e pare na primeira cuja condição se
+aplicar ao par. Ela diz a nota a atribuir.
 
-- O par contradiz o que a pessoa afirma, ou substitui a perspectiva dela por clichê
-  sobre populações tradicionais: **nota 1**
-- O par afirma algo que ela não disse, e essa adição troca o motivo que ela deu por
-  outro, fazendo a fala servir de exemplo de uma ideia que não é dela: **nota 2**
-- O par afirma algo que ela não disse, mas o núcleo do que ela disse continua
-  reconhecível: **nota 3**
-- O par preserva o sentido, mas apaga um elemento situado que carrega o conhecimento
-  em jogo (quem sabe, decide ou age; o sinal concreto), ou apaga a postura com que
-  ela disse (a dúvida virou certeza, a avaliação virou descrição neutra): **nota 4**
-- Nenhuma das anteriores: **nota 5**
+- Se o par contradiz o que a pessoa afirma, ou substitui a perspectiva dela por
+  clichê sobre populações tradicionais, atribua **nota 1**.
+- Se o par afirma algo que ela não disse, e essa adição troca o motivo que ela deu
+  por outro, fazendo a fala servir de exemplo de uma ideia que não é dela, atribua
+  **nota 2**.
+- Se o par afirma algo que ela não disse, mas o núcleo do que ela disse continua
+  reconhecível, atribua **nota 3**.
+- Se o par preserva o sentido, mas apaga um elemento situado que carrega o
+  conhecimento em jogo (quem sabe, decide ou age; o sinal concreto), ou apaga a
+  postura com que ela disse (a dúvida virou certeza, a avaliação virou descrição
+  neutra), atribua **nota 4**.
+- Se nenhuma das condições acima se aplica, atribua **nota 5**.
 
 **4.** Não reduzem a nota, por si sós: generalizar ou abstrair; usar vocabulário
 mais formal; responder de forma curta; omitir um detalhe que a pergunta não pedia.

--- a/docs/user-guide/cli-reference.md
+++ b/docs/user-guide/cli-reference.md
@@ -579,6 +579,13 @@ remaining tasks into the same project from the UI and leave the manifest alone
 re-push with `--force`, which records a second id and makes every later network
 pull require `--project-id <n>`. Building under a fresh run id avoids both.
 
+An import the instance accepts but does not *count* fails the same way, and for
+the same reason: the response carries no `task_count`, so nothing on this side
+can tell 120 from 118, and reading it as success is what would make the guard
+above unfireable in exactly the case it exists for. The message names the check
+(open the project, compare its task count with the number sent) and the same two
+recovery shapes.
+
 ### `arandu emic-annotation-pull`
 
 Fetches the annotations back and writes one JSONL per annotator.

--- a/docs/user-guide/cli-reference.md
+++ b/docs/user-guide/cli-reference.md
@@ -471,6 +471,9 @@ have to be the reviewed ones: a divergence from the judge prompt makes the
 weighted kappa measure translation drift instead of agreement, and it cannot be
 repaired after annotation.
 
+A ruler that parses but is missing a section the labeling config needs fails
+with a message naming the missing key and the ruler path, not a traceback.
+
 **Rebuilding after a push is refused.** It would rewrite the join while
 annotators work against the old one, silently mislabelling every pull.
 
@@ -491,6 +494,19 @@ export ARANDU_LABEL_STUDIO_TOKEN=...   # Account & Settings -> Access Token
 arandu emic-annotation-push --id thesis-run-01
 ```
 
+Both variables can equally live in `.env` at the project root; the settings
+class reads it like every other config in the project. `ARANDU_LABEL_STUDIO_TIMEOUT`
+(seconds, default `60`) is the third.
+
+**The token never lands under `results/`.** Two things keep it out. The settings
+field is a `SecretStr`, so it is masked in every repr and `model_dump()`. And
+every stage's `run_metadata.json` records the `ARANDU_*` environment as it was
+at run time, so any captured variable whose name contains `TOKEN`, `SECRET`,
+`PASSWORD`, `KEY` or `CREDENTIAL` is written as `***REDACTED***` instead of its
+value (the key is kept, so the snapshot still shows the variable was set). That
+redaction is repo-wide, not specific to this stage: the environment snapshot is
+captured by every pipeline step run from the same shell.
+
 Uploads only what `emic-annotation-build` wrote, so the annotators see exactly
 what was audited. The project id is recorded in `manifest.json` **before** the
 task import runs, so an import that fails or times out still leaves the project
@@ -506,7 +522,12 @@ blocks Submit, not Skip.
 
 If Label Studio accepts fewer tasks than were sent, the push fails naming both
 counts. Silently importing 118 of 120 would leave two pairs indistinguishable
-from ones nobody has rated yet, in every pull thereafter.
+from ones nobody has rated yet, in every pull thereafter. The project id is
+already recorded at that point, so the error also names the way out: import the
+remaining tasks into the same project from the UI and leave the manifest alone
+(cheapest, keeps one recorded project), or delete the project server-side and
+re-push with `--force`, which records a second id and makes every later network
+pull require `--project-id <n>`. Building under a fresh run id avoids both.
 
 ### `arandu emic-annotation-pull`
 
@@ -524,7 +545,10 @@ arandu emic-annotation-pull --id thesis-run-01 --project-id 42  # after a --forc
 |--------|---------|-------------|
 | `--id` | required | Pipeline ID with a built (and usually pushed) annotation stage |
 | `--file` / `-f` | none | Read a JSON export downloaded from the UI; no network and no token |
-| `--project-id` | from the manifest | Project to pull from. Required when a `--force` re-push recorded more than one |
+| `--project-id` | from the manifest | Project to pull from. Required when a `--force` re-push recorded more than one. Cannot be combined with `-f` |
+
+`-f` and `--project-id` name different sources, so passing both is refused
+rather than silently ignoring the project selection.
 
 Writes `results/<id>/annotation/outputs/labels/<annotator_id>.jsonl`, one object
 per line with `pair_id`, `annotator_id`, `score`, `rationale`, `timestamp`.
@@ -541,7 +565,20 @@ Only newly seen user ids get a new alias, appended in sorted order.
 
 Partial annotation is fine and is reported as a per-annotator count. Ratings the
 annotator skipped in Label Studio carry no score, so they are counted and
-reported separately rather than counted as done or aborting the pull.
+reported separately rather than counted as done or aborting the pull. An
+annotation that carries a rationale but no rating counts the same way: the
+`required` flag on the rating widget is enforced in the browser only, and
+annotations can also arrive through the API, so one of those must not abort
+everyone else's pull. A rating region that IS present but empty still aborts:
+that is the measurement going missing, not a task nobody rated.
+
+**`labels/` reflects exactly one pull.** A `*.jsonl` written by an earlier,
+wider pull that the current export does not cover is removed, and the count is
+reported. Otherwise a later `-f partial-export.json` (or a different
+`--project-id`) would leave the agreement analysis reading a mix of two pulls
+while the printed summary named only one. Nothing but `*.jsonl` inside
+`labels/` is touched, and `annotator_map.json` lives one level up, so the alias
+bindings survive.
 
 **Several recorded projects abort the pull.** If `--force` created more than one
 project, the command refuses and lists every recorded id: pulling one silently

--- a/docs/user-guide/cli-reference.md
+++ b/docs/user-guide/cli-reference.md
@@ -498,6 +498,23 @@ Both variables can equally live in `.env` at the project root; the settings
 class reads it like every other config in the project. `ARANDU_LABEL_STUDIO_TIMEOUT`
 (seconds, default `60`) is the third.
 
+**Either token type works, and you do not have to say which one you have.**
+Both come from the same screen (Account & Settings, Access Token), and the
+token's own shape selects the scheme:
+
+| What you copied | Looks like | What happens |
+| --------------- | ---------- | ------------ |
+| Personal access token (JWT) | three dot-separated segments, `eyJ...`-ish | It is a *refresh* token, which the API endpoints reject on their own. The client exchanges it at `POST /api/token/refresh` for a short-lived access token and sends `Authorization: Bearer <access>`. |
+| Legacy API token | one hex-ish string, no dots | Sent as `Authorization: Token <token>`. |
+
+Access tokens are short-lived, so the exchange is lazy, cached for the process,
+and redone once automatically if a request comes back 401 mid-run (a long
+import followed by an export can outlive one). A second 401 in a row is
+reported instead of retried: at that point the personal access token is expired
+or revoked, or `ARANDU_LABEL_STUDIO_URL` points at a different instance than
+the one that issued it. Neither the token you pasted nor the access token
+derived from it ever appears in an error message or a log line.
+
 **The token never lands under `results/`.** Two things keep it out. The settings
 field is a `SecretStr`, so it is masked in every repr and `model_dump()`. And
 every stage's `run_metadata.json` records the `ARANDU_*` environment as it was

--- a/docs/user-guide/cli-reference.md
+++ b/docs/user-guide/cli-reference.md
@@ -27,7 +27,7 @@ The Arandu CLI is built with [Typer](https://typer.tiangolo.com/) and provides r
 - **QA Generation**: `generate-cep-qa`, `generate-non-answerable`
 - **Judging**: `judge-transcription`, `judge-qa`, `judge-answers`
 - **Knowledge Graph & RAG (Phase C)**: `chunk`, `build-kg`, `kg-link-passages`, `kg-build-retriever-index`, `retrieve`, `answer`, `rag-analysis`
-- **Emic validity (Phase D)**: `emic-judge`, `build-human-eval-sample`, `emic-annotation-build`, `emic-annotation-push`
+- **Emic validity (Phase D)**: `emic-judge`, `build-human-eval-sample`, `emic-annotation-build`, `emic-annotation-push`, `emic-annotation-pull`
 - **Utilities**: `refresh-auth`, `enrich-metadata`, `replicate`, `info`, `list-runs`, `run-info`, `rebuild-index`, `report`, `serve-report`
 
 **Global Options**:
@@ -408,6 +408,7 @@ reported.
 | `build-human-eval-sample` | Build the stratified human-comparison sample for a run |
 | `emic-annotation-build` | Build the Label Studio artifacts (labeling config, blinded tasks, manifest) for a run's sample |
 | `emic-annotation-push` | Create the Label Studio project from the built artifacts and import the tasks |
+| `emic-annotation-pull` | Fetch the annotations back and write one JSONL per anonymized annotator |
 
 **The emic score is a measurement, not a filter.** It is what the study
 reports; the human annotation round validates it by agreement rather than
@@ -487,6 +488,31 @@ Uploads only what `emic-annotation-build` wrote, so the annotators see exactly
 what was audited. The project id is recorded in `manifest.json`; a second push
 is refused rather than silently creating a duplicate project that would split
 the annotators across two. `--force` overrides and records both ids.
+
+### `arandu emic-annotation-pull`
+
+Fetches the annotations back and writes one JSONL per annotator.
+
+```bash
+arandu emic-annotation-pull --id thesis-run-01
+arandu emic-annotation-pull --id thesis-run-01 -f export.json   # no network, no token
+```
+
+Writes `results/<id>/annotation/outputs/labels/<annotator_id>.jsonl`, one object
+per line with `pair_id`, `annotator_id`, `score`, `rationale`, `timestamp`.
+
+Annotators are anonymized to `A1` / `A2` / `A3` from the numeric Label Studio
+user id; no email is requested from the API or written anywhere. The
+id-to-alias map lands in `annotator_map.json` **beside** `labels/`, never inside
+it, so the directory feeding the agreement analysis holds nothing identifying.
+
+Partial annotation is fine and is reported as a per-annotator count. An export
+referencing an unknown `task_id` aborts the pull: the manifest and the project
+are out of sync, and no label from that project can be trusted.
+
+The individual labels are not a published artifact. Only the aggregate
+coefficients (Krippendorff alpha, weighted Cohen kappa, Gwet AC2, with the Bloom
+breakdown) go into the text.
 
 ---
 

--- a/docs/user-guide/cli-reference.md
+++ b/docs/user-guide/cli-reference.md
@@ -462,7 +462,7 @@ Writes to `results/<id>/annotation/outputs/`:
 | File | Contents |
 | --- | --- |
 | `labeling_config.xml` | The annotation canvas, with the 1-5 anchors rendered verbatim from `prompts/judge/criteria/emic_validity/ruler.pt.yaml`. |
-| `expert_instruction.html` | The full ruler, for the project's instructions modal. Plain semantic HTML, no external resource. |
+| `expert_instruction.html` | The full ruler, for the project's instructions modal. Semantic HTML with a scoped `<style>` block, no external resource; still readable if Label Studio strips the block. |
 | `tasks.json` | The blinded tasks. Each carries only `task_id`, `segment`, `question`, `answer`. |
 | `manifest.json` | Seed, provenance hashes, and the `task_id -> pair_id` join. Never uploaded. |
 
@@ -483,7 +483,11 @@ segment renders in a height-capped box with its own scrollbar, so a long chunk
 scrolls inside itself instead of pushing the rating off screen.
 
 The 1-5 anchor sentences stay on the options themselves in
-`labeling_config.xml`; that placement is the instrument. Judge-only material
+`labeling_config.xml`; that placement is the instrument. Each option also
+carries an explicit `hotkey` equal to its own score, so pressing `5` records a
+5. Left to Label Studio, hotkeys are assigned by position, and the options run
+5 down to 1: key `1` would record a 5 and key `5` would record a 1, silently and
+with no way to detect it afterwards. Judge-only material
 (the role framing, the JSON output contract, the rationale rules) appears in
 neither surface: it would prime the annotator with the machine's framing. Both
 are checked verbatim against the ruler by the test suite.

--- a/docs/user-guide/cli-reference.md
+++ b/docs/user-guide/cli-reference.md
@@ -27,7 +27,7 @@ The Arandu CLI is built with [Typer](https://typer.tiangolo.com/) and provides r
 - **QA Generation**: `generate-cep-qa`, `generate-non-answerable`
 - **Judging**: `judge-transcription`, `judge-qa`, `judge-answers`
 - **Knowledge Graph & RAG (Phase C)**: `chunk`, `build-kg`, `kg-link-passages`, `kg-build-retriever-index`, `retrieve`, `answer`, `rag-analysis`
-- **Emic validity (Phase D)**: `emic-judge`, `build-human-eval-sample`
+- **Emic validity (Phase D)**: `emic-judge`, `build-human-eval-sample`, `emic-annotation-build`
 - **Utilities**: `refresh-auth`, `enrich-metadata`, `replicate`, `info`, `list-runs`, `run-info`, `rebuild-index`, `report`, `serve-report`
 
 **Global Options**:
@@ -406,6 +406,7 @@ reported.
 |---------|-------------|
 | `emic-judge` | Score a run's CEP pairs for emic validity (ordinal 1-5) |
 | `build-human-eval-sample` | Build the stratified human-comparison sample for a run |
+| `emic-annotation-build` | Build the Label Studio artifacts (labeling config, blinded tasks, manifest) for a run's sample |
 
 **The emic score is a measurement, not a filter.** It is what the study
 reports; the human annotation round validates it by agreement rather than
@@ -444,6 +445,32 @@ arandu build-human-eval-sample --id project-001 --seed 42
 The sample builder keeps its frame on the judge-approved corpus even when
 `emic-judge` scored everything: pairs the judge rejected (or never judged) are
 dropped and counted in the manifest's `excluded_not_approved`.
+
+### `arandu emic-annotation-build`
+
+Turns a run's human-eval sample into Label Studio artifacts. Offline and
+deterministic: no network, no credential.
+
+```bash
+arandu emic-annotation-build --id thesis-run-01 --seed 20260817
+```
+
+Writes to `results/<id>/annotation/outputs/`:
+
+| File | Contents |
+| --- | --- |
+| `labeling_config.xml` | The annotation interface, with the 1-5 anchors rendered verbatim from `prompts/judge/criteria/emic_validity/ruler.pt.yaml`. |
+| `tasks.json` | The blinded tasks. Each carries only `task_id`, `segment`, `question`, `answer`. |
+| `manifest.json` | Seed, provenance hashes, and the `task_id -> pair_id` join. Never uploaded. |
+
+**The sign-off gate is mechanical.** While the ruler carries `signed_off: false`
+the command refuses to run and names the gate. The anchors the annotators read
+have to be the reviewed ones: a divergence from the judge prompt makes the
+weighted kappa measure translation drift instead of agreement, and it cannot be
+repaired after annotation.
+
+**Rebuilding after a push is refused.** It would rewrite the join while
+annotators work against the old one, silently mislabelling every pull.
 
 ---
 

--- a/docs/user-guide/cli-reference.md
+++ b/docs/user-guide/cli-reference.md
@@ -461,9 +461,32 @@ Writes to `results/<id>/annotation/outputs/`:
 
 | File | Contents |
 | --- | --- |
-| `labeling_config.xml` | The annotation interface, with the 1-5 anchors rendered verbatim from `prompts/judge/criteria/emic_validity/ruler.pt.yaml`. |
+| `labeling_config.xml` | The annotation canvas, with the 1-5 anchors rendered verbatim from `prompts/judge/criteria/emic_validity/ruler.pt.yaml`. |
+| `expert_instruction.html` | The full ruler, for the project's instructions modal. Plain semantic HTML, no external resource. |
 | `tasks.json` | The blinded tasks. Each carries only `task_id`, `segment`, `question`, `answer`. |
 | `manifest.json` | Seed, provenance hashes, and the `task_id -> pair_id` join. Never uploaded. |
+
+**The ruler reaches the annotator through two surfaces.** Rendering all of it on
+the canvas put roughly two screens of prose between the pair and the rating
+widget, so a 4000-character segment had scrolled out of view by the time the
+annotator reached the radio buttons, once per task and 120 times per annotator.
+The split:
+
+| Surface | Holds | Where it shows |
+| --- | --- | --- |
+| `expert_instruction.html` | The whole annotator-facing ruler: construct, scale, loss types, provisions, the full scoring guide, the calibration. | Behind the Label Studio help button, in a modal (`show_instruction` is turned on by the push). |
+| `labeling_config.xml` | A collapsed summary, **closed by default**: the scoring cascade, the "does not reduce the score" list, and the calibration about the fine boundaries and the narrow door to 1. | On the canvas, above the pair. |
+
+The canvas order is header, collapsed summary, the pair, then the rating widget
+and the rationale box. The pair sits immediately above the widget and the
+segment renders in a height-capped box with its own scrollbar, so a long chunk
+scrolls inside itself instead of pushing the rating off screen.
+
+The 1-5 anchor sentences stay on the options themselves in
+`labeling_config.xml`; that placement is the instrument. Judge-only material
+(the role framing, the JSON output contract, the rationale rules) appears in
+neither surface: it would prime the annotator with the machine's framing. Both
+are checked verbatim against the ruler by the test suite.
 
 **The sign-off gate is mechanical.** While the ruler carries `signed_off: false`
 the command refuses to run and names the gate. The anchors the annotators read
@@ -536,6 +559,12 @@ The project is created with the Label Studio Skip button turned off
 (`show_skip_button: false`). A skip writes an annotation with no rating in it,
 which occupies the slot of a real one; `required="true"` on the rating widget
 blocks Submit, not Skip.
+
+The create call also carries the project's instructions: `expert_instruction`
+is the contents of `expert_instruction.html` as the build wrote it, and
+`show_instruction: true` puts the help button that opens it in front of the
+annotator. Push renders nothing of its own here either, so the ruler the
+annotators read is still exactly the file an auditor reviewed.
 
 If Label Studio accepts fewer tasks than were sent, the push fails naming both
 counts. Silently importing 118 of 120 would leave two pairs indistinguishable

--- a/docs/user-guide/cli-reference.md
+++ b/docs/user-guide/cli-reference.md
@@ -474,6 +474,13 @@ repaired after annotation.
 **Rebuilding after a push is refused.** It would rewrite the join while
 annotators work against the old one, silently mislabelling every pull.
 
+**Rebuilding after a pull is refused too.** A non-empty `labels/` directory
+blocks the build even when no `project_id` was ever recorded (the file-mode
+`-f` path, where the project was created by hand in the UI). The pulled labels
+carry `pair_id`s resolved through the old `task_map`; a rebuild would replace
+that map and invalidate every one of them with nothing marking the divergence.
+Create a new run id instead.
+
 ### `arandu emic-annotation-push`
 
 Creates the Label Studio project from the built artifacts and imports the tasks.
@@ -485,9 +492,21 @@ arandu emic-annotation-push --id thesis-run-01
 ```
 
 Uploads only what `emic-annotation-build` wrote, so the annotators see exactly
-what was audited. The project id is recorded in `manifest.json`; a second push
-is refused rather than silently creating a duplicate project that would split
-the annotators across two. `--force` overrides and records both ids.
+what was audited. The project id is recorded in `manifest.json` **before** the
+task import runs, so an import that fails or times out still leaves the project
+recorded and the duplicate guard armed. A second push is refused rather than
+silently creating a duplicate project that would split the annotators across
+two. `--force` overrides and records both ids (and see `--project-id` on the
+pull side).
+
+The project is created with the Label Studio Skip button turned off
+(`show_skip_button: false`). A skip writes an annotation with no rating in it,
+which occupies the slot of a real one; `required="true"` on the rating widget
+blocks Submit, not Skip.
+
+If Label Studio accepts fewer tasks than were sent, the push fails naming both
+counts. Silently importing 118 of 120 would leave two pairs indistinguishable
+from ones nobody has rated yet, in every pull thereafter.
 
 ### `arandu emic-annotation-pull`
 
@@ -496,7 +515,16 @@ Fetches the annotations back and writes one JSONL per annotator.
 ```bash
 arandu emic-annotation-pull --id thesis-run-01
 arandu emic-annotation-pull --id thesis-run-01 -f export.json   # no network, no token
+arandu emic-annotation-pull --id thesis-run-01 --project-id 42  # after a --force re-push
 ```
+
+**Options**:
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--id` | required | Pipeline ID with a built (and usually pushed) annotation stage |
+| `--file` / `-f` | none | Read a JSON export downloaded from the UI; no network and no token |
+| `--project-id` | from the manifest | Project to pull from. Required when a `--force` re-push recorded more than one |
 
 Writes `results/<id>/annotation/outputs/labels/<annotator_id>.jsonl`, one object
 per line with `pair_id`, `annotator_id`, `score`, `rationale`, `timestamp`.
@@ -506,9 +534,25 @@ user id; no email is requested from the API or written anywhere. The
 id-to-alias map lands in `annotator_map.json` **beside** `labels/`, never inside
 it, so the directory feeding the agreement analysis holds nothing identifying.
 
-Partial annotation is fine and is reported as a per-annotator count. An export
-referencing an unknown `task_id` aborts the pull: the manifest and the project
-are out of sync, and no label from that project can be trusted.
+**Aliases are stable across pulls.** An existing `annotator_map.json` is read
+back and every binding in it kept, so pulling weekly for progress never
+reassigns `A1` to a different person when somebody submits their first rating.
+Only newly seen user ids get a new alias, appended in sorted order.
+
+Partial annotation is fine and is reported as a per-annotator count. Ratings the
+annotator skipped in Label Studio carry no score, so they are counted and
+reported separately rather than counted as done or aborting the pull.
+
+**Several recorded projects abort the pull.** If `--force` created more than one
+project, the command refuses and lists every recorded id: pulling one silently
+would lose the others' labels, and merging them would double-count anyone who
+annotated in more than one. Re-run with `--project-id <n>`.
+
+An export referencing an unknown `task_id` aborts the pull: the manifest and the
+project are out of sync, and no label from that project can be trusted. The same
+applies when one annotator rated the same pair twice, and when the downloaded
+file is a `JSON_MIN` export (only `exportType=JSON` carries the `task_id` the
+join needs).
 
 The individual labels are not a published artifact. Only the aggregate
 coefficients (Krippendorff alpha, weighted Cohen kappa, Gwet AC2, with the Bloom

--- a/docs/user-guide/cli-reference.md
+++ b/docs/user-guide/cli-reference.md
@@ -27,7 +27,7 @@ The Arandu CLI is built with [Typer](https://typer.tiangolo.com/) and provides r
 - **QA Generation**: `generate-cep-qa`, `generate-non-answerable`
 - **Judging**: `judge-transcription`, `judge-qa`, `judge-answers`
 - **Knowledge Graph & RAG (Phase C)**: `chunk`, `build-kg`, `kg-link-passages`, `kg-build-retriever-index`, `retrieve`, `answer`, `rag-analysis`
-- **Emic validity (Phase D)**: `emic-judge`, `build-human-eval-sample`, `emic-annotation-build`
+- **Emic validity (Phase D)**: `emic-judge`, `build-human-eval-sample`, `emic-annotation-build`, `emic-annotation-push`
 - **Utilities**: `refresh-auth`, `enrich-metadata`, `replicate`, `info`, `list-runs`, `run-info`, `rebuild-index`, `report`, `serve-report`
 
 **Global Options**:
@@ -407,6 +407,7 @@ reported.
 | `emic-judge` | Score a run's CEP pairs for emic validity (ordinal 1-5) |
 | `build-human-eval-sample` | Build the stratified human-comparison sample for a run |
 | `emic-annotation-build` | Build the Label Studio artifacts (labeling config, blinded tasks, manifest) for a run's sample |
+| `emic-annotation-push` | Create the Label Studio project from the built artifacts and import the tasks |
 
 **The emic score is a measurement, not a filter.** It is what the study
 reports; the human annotation round validates it by agreement rather than
@@ -471,6 +472,21 @@ repaired after annotation.
 
 **Rebuilding after a push is refused.** It would rewrite the join while
 annotators work against the old one, silently mislabelling every pull.
+
+### `arandu emic-annotation-push`
+
+Creates the Label Studio project from the built artifacts and imports the tasks.
+
+```bash
+export ARANDU_LABEL_STUDIO_URL=https://label.emcorrespondencia.cloud
+export ARANDU_LABEL_STUDIO_TOKEN=...   # Account & Settings -> Access Token
+arandu emic-annotation-push --id thesis-run-01
+```
+
+Uploads only what `emic-annotation-build` wrote, so the annotators see exactly
+what was audited. The project id is recorded in `manifest.json`; a second push
+is refused rather than silently creating a duplicate project that would split
+the annotators across two. `--force` overrides and records both ids.
 
 ---
 

--- a/prompts/judge/criteria/emic_validity/pt/prompt.md
+++ b/prompts/judge/criteria/emic_validity/pt/prompt.md
@@ -50,13 +50,13 @@ Guia de avaliação
 
 2. Nessas passagens, identifique quatro coisas: o que a pessoa afirma; as palavras e medidas que ela usa; quem sabe, decide ou age; e o que a pergunta põe em jogo.
 
-3. Percorra as condições em ordem e pare na primeira que se aplicar. A nota é a dessa condição.
+3. Percorra as frases abaixo em ordem e pare na primeira cuja condição se aplicar ao par. Ela diz a nota a atribuir.
 
-- O par contradiz o que a pessoa afirma, ou substitui a perspectiva dela por clichê sobre populações tradicionais: nota 1
-- O par afirma algo que ela não disse, e essa adição troca o motivo que ela deu por outro, fazendo a fala servir de exemplo de uma ideia que não é dela: nota 2
-- O par afirma algo que ela não disse, mas o núcleo do que ela disse continua reconhecível: nota 3
-- O par preserva o sentido, mas apaga um elemento situado que carrega o conhecimento em jogo (quem sabe, decide ou age; o sinal concreto), ou apaga a postura com que ela disse (a dúvida virou certeza, a avaliação virou descrição neutra): nota 4
-- Nenhuma das anteriores: nota 5
+- Se o par contradiz o que a pessoa afirma, ou substitui a perspectiva dela por clichê sobre populações tradicionais, atribua nota 1.
+- Se o par afirma algo que ela não disse, e essa adição troca o motivo que ela deu por outro, fazendo a fala servir de exemplo de uma ideia que não é dela, atribua nota 2.
+- Se o par afirma algo que ela não disse, mas o núcleo do que ela disse continua reconhecível, atribua nota 3.
+- Se o par preserva o sentido, mas apaga um elemento situado que carrega o conhecimento em jogo (quem sabe, decide ou age; o sinal concreto), ou apaga a postura com que ela disse (a dúvida virou certeza, a avaliação virou descrição neutra), atribua nota 4.
+- Se nenhuma das condições acima se aplica, atribua nota 5.
 
 4. Não reduzem a nota, por si sós: generalizar ou abstrair; usar vocabulário mais formal; responder de forma curta; omitir um detalhe que a pergunta não pedia. Só reduzem quando uma das condições acima se aplica.
 

--- a/prompts/judge/criteria/emic_validity/ruler.pt.yaml
+++ b/prompts/judge/criteria/emic_validity/ruler.pt.yaml
@@ -19,6 +19,14 @@ signed_off_by: Fred (antropologia)
 signed_off_on: "2026-08-11"
 gate: anthropologist-validation-of-readings
 
+# Revisão de forma, não de método. A assinatura de 2026-08-11 continua valendo, e
+# por isso signed_off_on não muda; o campo abaixo registra a única alteração
+# posterior ao texto, para que um auditor veja o que mudou e por quê.
+presentation_revision: >-
+  2026-08-17: a cascata passou a ser lida como frases ("Se <condição>, atribua
+  nota N.") em vez de lista numerada. As condições, a ordem delas e a escala
+  continuam as mesmas.
+
 # --- Construto -------------------------------------------------------------
 
 construct:
@@ -134,30 +142,33 @@ guide:
     palavras e medidas que ela usa; quem sabe, decide ou age; e o que a pergunta
     põe em jogo.
   cascade_intro: >-
-    Percorra as condições em ordem e pare na primeira que se aplicar. A nota é a
-    dessa condição.
+    Percorra as frases abaixo em ordem e pare na primeira cuja condição se
+    aplicar ao par. Ela diz a nota a atribuir.
+  # Cada condição é uma oração subordinada em minúscula, sem ponto final: os
+  # consumidores a montam como "Se <condição>, atribua nota N.". A moldura fica
+  # no renderizador de cada consumidor, não aqui.
   cascade:
     - score: 1
       condition: >-
-        O par contradiz o que a pessoa afirma, ou substitui a perspectiva dela por
-        clichê sobre populações tradicionais.
+        o par contradiz o que a pessoa afirma, ou substitui a perspectiva dela por
+        clichê sobre populações tradicionais
     - score: 2
       condition: >-
-        O par afirma algo que ela não disse, e essa adição troca o motivo que ela
+        o par afirma algo que ela não disse, e essa adição troca o motivo que ela
         deu por outro, fazendo a fala servir de exemplo de uma ideia que não é
-        dela.
+        dela
     - score: 3
       condition: >-
-        O par afirma algo que ela não disse, mas o núcleo do que ela disse
-        continua reconhecível.
+        o par afirma algo que ela não disse, mas o núcleo do que ela disse
+        continua reconhecível
     - score: 4
       condition: >-
-        O par preserva o sentido, mas apaga um elemento situado que carrega o
+        o par preserva o sentido, mas apaga um elemento situado que carrega o
         conhecimento em jogo (quem sabe, decide ou age; o sinal concreto), ou
         apaga a postura com que ela disse (a dúvida virou certeza, a avaliação
-        virou descrição neutra).
+        virou descrição neutra)
     - score: 5
-      condition: Nenhuma das anteriores.
+      condition: nenhuma das condições acima se aplica
   no_penalty: >-
     Não reduzem a nota, por si sós: generalizar ou abstrair; usar vocabulário mais
     formal; responder de forma curta; omitir um detalhe que a pergunta não pedia.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "google-auth-oauthlib>=1.0.0",
     "pydantic>=2.0.0",
     "pydantic-settings>=2.0.0",
+    "pyyaml>=6.0",
     "rich>=13.0.0",
     "sentencepiece>=0.2.1",
     "tenacity>=8.0.0",

--- a/src/arandu/cli/annotation.py
+++ b/src/arandu/cli/annotation.py
@@ -40,10 +40,11 @@ def emic_annotation_build(
     """Build the Label Studio artifacts for a run's human-eval sample.
 
     Offline and deterministic: reads ``sample.jsonl`` and the signed-off emic
-    ruler, and writes ``labeling_config.xml``, ``tasks.json`` and
-    ``manifest.json`` under ``results/<id>/annotation/outputs/``. No network and
-    no credential is involved, so the artifacts can be audited for blinding and
-    anchor fidelity before anything reaches an annotator.
+    ruler, and writes ``labeling_config.xml``, ``expert_instruction.html``,
+    ``tasks.json`` and ``manifest.json`` under
+    ``results/<id>/annotation/outputs/``. No network and no credential is
+    involved, so the artifacts can be audited for blinding and anchor fidelity
+    before anything reaches an annotator.
     """
     print_info(f"Run: {pipeline_id} | seed: {seed}")
 

--- a/src/arandu/cli/annotation.py
+++ b/src/arandu/cli/annotation.py
@@ -16,7 +16,10 @@ from typing import Annotated
 import typer
 
 from arandu.shared.annotation.build import run_build_annotation
+from arandu.shared.annotation.client import LabelStudioError, build_client_from_settings
+from arandu.shared.annotation.push import run_push_annotation
 from arandu.shared.annotation.ruler import RulerNotSignedOffError
+from arandu.shared.annotation.settings import LabelStudioSettings
 from arandu.utils.logger import print_error, print_info, print_success
 
 logger = logging.getLogger(__name__)
@@ -60,4 +63,59 @@ def emic_annotation_build(
     print_success(
         f"Built {manifest.total_items} blinded tasks (seed {manifest.seed}). "
         f"Artifacts under results/{pipeline_id}/annotation/outputs/."
+    )
+
+
+def emic_annotation_push(
+    pipeline_id: Annotated[
+        str,
+        typer.Option("--id", help="Pipeline ID with a built annotation stage."),
+    ],
+    title: Annotated[
+        str | None,
+        typer.Option("--title", help="Project title. Defaults to one naming the run."),
+    ] = None,
+    force: Annotated[
+        bool,
+        typer.Option("--force", help="Create another project even though one is recorded."),
+    ] = False,
+) -> None:
+    """Create the Label Studio project for a built annotation stage.
+
+    Uploads only what ``emic-annotation-build`` already wrote to disk, so the
+    annotators see exactly the artifacts an auditor can review. Reads the
+    instance URL and token from ``ARANDU_LABEL_STUDIO_URL`` and
+    ``ARANDU_LABEL_STUDIO_TOKEN``.
+    """
+    try:
+        settings = LabelStudioSettings()
+    except ValueError as exc:
+        print_error(
+            "Label Studio is not configured. Set ARANDU_LABEL_STUDIO_URL and "
+            f"ARANDU_LABEL_STUDIO_TOKEN in your environment or .env file. ({exc})"
+        )
+        raise typer.Exit(code=1) from exc
+
+    print_info(f"Run: {pipeline_id} | instance: {settings.url}")
+    client = build_client_from_settings(settings)
+
+    try:
+        project_id = run_push_annotation(
+            pipeline_id=pipeline_id, client=client, title=title, force=force
+        )
+    except FileNotFoundError as exc:
+        print_error(str(exc))
+        raise typer.Exit(code=1) from exc
+    except ValueError as exc:
+        print_error(f"Could not push the annotation project: {exc}")
+        raise typer.Exit(code=1) from exc
+    except LabelStudioError as exc:
+        print_error(f"Label Studio rejected the push: {exc}")
+        raise typer.Exit(code=1) from exc
+    finally:
+        client.close()
+
+    print_success(
+        f"Created project {project_id} at {settings.url}/projects/{project_id}. "
+        f"Invite the annotators and they can start."
     )

--- a/src/arandu/cli/annotation.py
+++ b/src/arandu/cli/annotation.py
@@ -11,12 +11,14 @@ Three flat commands, matching the project convention (the CLI has no
 from __future__ import annotations
 
 import logging
+from pathlib import Path  # noqa: TC003
 from typing import Annotated
 
 import typer
 
 from arandu.shared.annotation.build import run_build_annotation
 from arandu.shared.annotation.client import LabelStudioError, build_client_from_settings
+from arandu.shared.annotation.pull import run_pull_annotation
 from arandu.shared.annotation.push import run_push_annotation
 from arandu.shared.annotation.ruler import RulerNotSignedOffError
 from arandu.shared.annotation.settings import LabelStudioSettings
@@ -119,3 +121,71 @@ def emic_annotation_push(
         f"Created project {project_id} at {settings.url}/projects/{project_id}. "
         f"Invite the annotators and they can start."
     )
+
+
+def emic_annotation_pull(
+    pipeline_id: Annotated[
+        str,
+        typer.Option("--id", help="Pipeline ID with a pushed annotation stage."),
+    ],
+    export_file: Annotated[
+        Path | None,
+        typer.Option(
+            "--file",
+            "-f",
+            help="Read a JSON export downloaded from the UI instead of using the network.",
+            exists=True,
+            dir_okay=False,
+        ),
+    ] = None,
+) -> None:
+    """Pull the annotations into per-annotator label files.
+
+    Writes ``results/<id>/annotation/outputs/labels/<annotator_id>.jsonl`` with
+    anonymous ids (``A1``, ``A2``, ``A3``). No email is ever requested from the
+    API or written to any artifact. With ``-f`` the export is read from disk and
+    no credential is needed.
+    """
+    client = None
+    settings = None
+    if export_file is None:
+        try:
+            settings = LabelStudioSettings()
+        except ValueError as exc:
+            print_error(
+                "Label Studio is not configured. Set ARANDU_LABEL_STUDIO_URL and "
+                f"ARANDU_LABEL_STUDIO_TOKEN, or pass -f with a downloaded export. ({exc})"
+            )
+            raise typer.Exit(code=1) from exc
+        client = build_client_from_settings(settings)
+
+    source = str(export_file) if export_file is not None else (settings.url if settings else "")
+    print_info(f"Run: {pipeline_id} | source: {source}")
+
+    try:
+        summary = run_pull_annotation(
+            pipeline_id=pipeline_id, client=client, export_file=export_file
+        )
+    except FileNotFoundError as exc:
+        print_error(str(exc))
+        raise typer.Exit(code=1) from exc
+    except KeyError as exc:
+        print_error(f"Manifest and Label Studio project are out of sync: {exc}")
+        raise typer.Exit(code=1) from exc
+    except ValueError as exc:
+        print_error(f"Could not pull the annotations: {exc}")
+        raise typer.Exit(code=1) from exc
+    except LabelStudioError as exc:
+        print_error(f"Label Studio rejected the export request: {exc}")
+        raise typer.Exit(code=1) from exc
+    finally:
+        if client is not None:
+            client.close()
+
+    if not summary.annotators:
+        print_info(f"No annotations yet ({summary.total_items} task(s) waiting).")
+        return
+    progress = ", ".join(
+        f"{alias}: {done}/{summary.total_items}" for alias, done in summary.annotators.items()
+    )
+    print_success(f"Pulled annotations. {progress}")

--- a/src/arandu/cli/annotation.py
+++ b/src/arandu/cli/annotation.py
@@ -1,0 +1,63 @@
+"""CLI commands for the emic annotation instrument (spec §3).
+
+Three flat commands, matching the project convention (the CLI has no
+``add_typer`` anywhere):
+
+- ``emic-annotation-build``: offline, deterministic, no secret.
+- ``emic-annotation-push``: create the Label Studio project.
+- ``emic-annotation-pull``: fetch the annotations back.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Annotated
+
+import typer
+
+from arandu.shared.annotation.build import run_build_annotation
+from arandu.shared.annotation.ruler import RulerNotSignedOffError
+from arandu.utils.logger import print_error, print_info, print_success
+
+logger = logging.getLogger(__name__)
+
+
+def emic_annotation_build(
+    pipeline_id: Annotated[
+        str,
+        typer.Option("--id", help="Pipeline ID. The human_eval stage must be populated."),
+    ],
+    seed: Annotated[
+        int,
+        typer.Option("--seed", help="Shuffle seed for the presentation order."),
+    ],
+) -> None:
+    """Build the Label Studio artifacts for a run's human-eval sample.
+
+    Offline and deterministic: reads ``sample.jsonl`` and the signed-off emic
+    ruler, and writes ``labeling_config.xml``, ``tasks.json`` and
+    ``manifest.json`` under ``results/<id>/annotation/outputs/``. No network and
+    no credential is involved, so the artifacts can be audited for blinding and
+    anchor fidelity before anything reaches an annotator.
+    """
+    print_info(f"Run: {pipeline_id} | seed: {seed}")
+
+    try:
+        manifest = run_build_annotation(pipeline_id=pipeline_id, seed=seed)
+    except RulerNotSignedOffError as exc:
+        print_error(str(exc))
+        raise typer.Exit(code=1) from exc
+    except FileNotFoundError as exc:
+        print_error(str(exc))
+        raise typer.Exit(code=1) from exc
+    except ValueError as exc:
+        print_error(f"Could not build the annotation instrument: {exc}")
+        raise typer.Exit(code=1) from exc
+    except OSError as exc:
+        print_error(f"I/O error building the annotation instrument: {exc}")
+        raise typer.Exit(code=1) from exc
+
+    print_success(
+        f"Built {manifest.total_items} blinded tasks (seed {manifest.seed}). "
+        f"Artifacts under results/{pipeline_id}/annotation/outputs/."
+    )

--- a/src/arandu/cli/annotation.py
+++ b/src/arandu/cli/annotation.py
@@ -22,7 +22,7 @@ from arandu.shared.annotation.pull import run_pull_annotation
 from arandu.shared.annotation.push import run_push_annotation
 from arandu.shared.annotation.ruler import RulerNotSignedOffError
 from arandu.shared.annotation.settings import LabelStudioSettings
-from arandu.utils.logger import print_error, print_info, print_success
+from arandu.utils.logger import print_error, print_info, print_success, print_warning
 
 logger = logging.getLogger(__name__)
 
@@ -138,6 +138,13 @@ def emic_annotation_pull(
             dir_okay=False,
         ),
     ] = None,
+    project_id: Annotated[
+        int | None,
+        typer.Option(
+            "--project-id",
+            help="Project to pull from. Required when a --force re-push recorded several.",
+        ),
+    ] = None,
 ) -> None:
     """Pull the annotations into per-annotator label files.
 
@@ -164,7 +171,10 @@ def emic_annotation_pull(
 
     try:
         summary = run_pull_annotation(
-            pipeline_id=pipeline_id, client=client, export_file=export_file
+            pipeline_id=pipeline_id,
+            client=client,
+            export_file=export_file,
+            project_id=project_id,
         )
     except FileNotFoundError as exc:
         print_error(str(exc))
@@ -182,6 +192,11 @@ def emic_annotation_pull(
         if client is not None:
             client.close()
 
+    if summary.skipped:
+        print_warning(
+            f"{summary.skipped} annotation(s) were skipped in Label Studio and carry no "
+            f"rating. They are not counted below and those pairs still need rating."
+        )
     if not summary.annotators:
         print_info(f"No annotations yet ({summary.total_items} task(s) waiting).")
         return

--- a/src/arandu/cli/annotation.py
+++ b/src/arandu/cli/annotation.py
@@ -20,7 +20,7 @@ from arandu.shared.annotation.build import run_build_annotation
 from arandu.shared.annotation.client import LabelStudioError, build_client_from_settings
 from arandu.shared.annotation.pull import run_pull_annotation
 from arandu.shared.annotation.push import run_push_annotation
-from arandu.shared.annotation.ruler import RulerNotSignedOffError
+from arandu.shared.annotation.ruler import RULER_PATH, RulerNotSignedOffError
 from arandu.shared.annotation.settings import LabelStudioSettings
 from arandu.utils.logger import print_error, print_info, print_success, print_warning
 
@@ -54,6 +54,15 @@ def emic_annotation_build(
         raise typer.Exit(code=1) from exc
     except FileNotFoundError as exc:
         print_error(str(exc))
+        raise typer.Exit(code=1) from exc
+    except KeyError as exc:
+        # render_labeling_config indexes the ruler directly, so a ruler missing
+        # a section surfaces here. A raw traceback would say nothing about which
+        # file to fix.
+        print_error(
+            f"The emic ruler is missing a required key ({exc}). The labeling config cannot be "
+            f"rendered without it. Ruler: {RULER_PATH}"
+        )
         raise typer.Exit(code=1) from exc
     except ValueError as exc:
         print_error(f"Could not build the annotation instrument: {exc}")
@@ -142,7 +151,10 @@ def emic_annotation_pull(
         int | None,
         typer.Option(
             "--project-id",
-            help="Project to pull from. Required when a --force re-push recorded several.",
+            help=(
+                "Project to pull from. Required when a --force re-push recorded several. "
+                "Not usable together with -f."
+            ),
         ),
     ] = None,
 ) -> None:
@@ -152,6 +164,10 @@ def emic_annotation_pull(
     anonymous ids (``A1``, ``A2``, ``A3``). No email is ever requested from the
     API or written to any artifact. With ``-f`` the export is read from disk and
     no credential is needed.
+
+    ``labels/`` is left holding exactly what this pull wrote: files from an
+    earlier, wider pull that this export does not cover are removed and
+    reported, so the agreement analysis never reads a mix of two pulls.
     """
     client = None
     settings = None
@@ -192,6 +208,11 @@ def emic_annotation_pull(
         if client is not None:
             client.close()
 
+    if summary.stale_removed:
+        print_warning(
+            f"{summary.stale_removed} label file(s) from an earlier pull were removed: this "
+            f"export did not cover them. labels/ now holds only what this pull wrote."
+        )
     if summary.skipped:
         print_warning(
             f"{summary.skipped} annotation(s) were skipped in Label Studio and carry no "

--- a/src/arandu/cli/app.py
+++ b/src/arandu/cli/app.py
@@ -48,7 +48,7 @@ def main(
 
 
 # Register commands from submodules
-from arandu.cli.annotation import emic_annotation_build  # noqa: E402
+from arandu.cli.annotation import emic_annotation_build, emic_annotation_push  # noqa: E402
 from arandu.cli.answer import answer  # noqa: E402
 from arandu.cli.chunking import chunk  # noqa: E402
 from arandu.cli.emic_judge import emic_judge  # noqa: E402
@@ -93,6 +93,7 @@ app.command()(judge_answers)
 app.command()(emic_judge)
 app.command()(build_human_eval_sample)
 app.command()(emic_annotation_build)
+app.command()(emic_annotation_push)
 app.command()(rag_analysis)
 app.command()(generate_non_answerable)
 app.command()(replicate)

--- a/src/arandu/cli/app.py
+++ b/src/arandu/cli/app.py
@@ -48,7 +48,11 @@ def main(
 
 
 # Register commands from submodules
-from arandu.cli.annotation import emic_annotation_build, emic_annotation_push  # noqa: E402
+from arandu.cli.annotation import (  # noqa: E402
+    emic_annotation_build,
+    emic_annotation_pull,
+    emic_annotation_push,
+)
 from arandu.cli.answer import answer  # noqa: E402
 from arandu.cli.chunking import chunk  # noqa: E402
 from arandu.cli.emic_judge import emic_judge  # noqa: E402
@@ -94,6 +98,7 @@ app.command()(emic_judge)
 app.command()(build_human_eval_sample)
 app.command()(emic_annotation_build)
 app.command()(emic_annotation_push)
+app.command()(emic_annotation_pull)
 app.command()(rag_analysis)
 app.command()(generate_non_answerable)
 app.command()(replicate)

--- a/src/arandu/cli/app.py
+++ b/src/arandu/cli/app.py
@@ -48,6 +48,7 @@ def main(
 
 
 # Register commands from submodules
+from arandu.cli.annotation import emic_annotation_build  # noqa: E402
 from arandu.cli.answer import answer  # noqa: E402
 from arandu.cli.chunking import chunk  # noqa: E402
 from arandu.cli.emic_judge import emic_judge  # noqa: E402
@@ -91,6 +92,7 @@ app.command()(answer)
 app.command()(judge_answers)
 app.command()(emic_judge)
 app.command()(build_human_eval_sample)
+app.command()(emic_annotation_build)
 app.command()(rag_analysis)
 app.command()(generate_non_answerable)
 app.command()(replicate)

--- a/src/arandu/shared/annotation/__init__.py
+++ b/src/arandu/shared/annotation/__init__.py
@@ -1,0 +1,19 @@
+"""Emic annotation instrument: sample to Label Studio and back (spec parts 5, 6)."""
+
+from __future__ import annotations
+
+from arandu.shared.annotation.ruler import (
+    RULER_PATH,
+    RulerNotSignedOffError,
+    load_ruler,
+    require_signed_off,
+    ruler_sha256,
+)
+
+__all__ = [
+    "RULER_PATH",
+    "RulerNotSignedOffError",
+    "load_ruler",
+    "require_signed_off",
+    "ruler_sha256",
+]

--- a/src/arandu/shared/annotation/__init__.py
+++ b/src/arandu/shared/annotation/__init__.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
-from arandu.shared.annotation.labeling_config import render_labeling_config
+from arandu.shared.annotation.labeling_config import (
+    render_expert_instruction,
+    render_labeling_config,
+)
 from arandu.shared.annotation.ruler import (
     RULER_PATH,
     RulerNotSignedOffError,
@@ -25,6 +28,7 @@ __all__ = [
     "AnnotationTask",
     "RulerNotSignedOffError",
     "load_ruler",
+    "render_expert_instruction",
     "render_labeling_config",
     "require_signed_off",
     "ruler_sha256",

--- a/src/arandu/shared/annotation/__init__.py
+++ b/src/arandu/shared/annotation/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from arandu.shared.annotation.labeling_config import render_labeling_config
 from arandu.shared.annotation.ruler import (
     RULER_PATH,
     RulerNotSignedOffError,
@@ -14,6 +15,7 @@ __all__ = [
     "RULER_PATH",
     "RulerNotSignedOffError",
     "load_ruler",
+    "render_labeling_config",
     "require_signed_off",
     "ruler_sha256",
 ]

--- a/src/arandu/shared/annotation/__init__.py
+++ b/src/arandu/shared/annotation/__init__.py
@@ -10,9 +10,19 @@ from arandu.shared.annotation.ruler import (
     require_signed_off,
     ruler_sha256,
 )
+from arandu.shared.annotation.schemas import (
+    AnnotationBuildConfig,
+    AnnotationLabel,
+    AnnotationManifest,
+    AnnotationTask,
+)
 
 __all__ = [
     "RULER_PATH",
+    "AnnotationBuildConfig",
+    "AnnotationLabel",
+    "AnnotationManifest",
+    "AnnotationTask",
     "RulerNotSignedOffError",
     "load_ruler",
     "render_labeling_config",

--- a/src/arandu/shared/annotation/build.py
+++ b/src/arandu/shared/annotation/build.py
@@ -39,6 +39,7 @@ logger = logging.getLogger(__name__)
 CONFIG_FILENAME = "labeling_config.xml"
 TASKS_FILENAME = "tasks.json"
 MANIFEST_FILENAME = "manifest.json"
+LABELS_DIRNAME = "labels"
 
 
 def _shuffle_key(seed: int, pair_id: str) -> str:
@@ -91,8 +92,9 @@ def run_build_annotation(
     Raises:
         RulerNotSignedOffError: If the ruler gate is still open.
         FileNotFoundError: If the sample or its manifest is absent.
-        ValueError: If the sample count disagrees with the sample manifest, or a
-            previous build of this run has already been pushed.
+        ValueError: If the sample count disagrees with the sample manifest, if
+            the sample repeats a ``pair_id``, or if a previous build of this run
+            has already been pushed or already has pulled labels.
     """
     # Gate first: nothing is written while the anchors are unreviewed.
     ruler = load_ruler(ruler_path)
@@ -108,9 +110,8 @@ def run_build_annotation(
             f"Run `arandu build-human-eval-sample --id {pipeline_id} --seed <n>` first."
         )
 
-    existing_manifest_path = (
-        base / pipeline_id / PipelineType.ANNOTATION.value / "outputs" / MANIFEST_FILENAME
-    )
+    annotation_outputs = base / pipeline_id / PipelineType.ANNOTATION.value / "outputs"
+    existing_manifest_path = annotation_outputs / MANIFEST_FILENAME
     if existing_manifest_path.exists():
         existing = AnnotationManifest.load(existing_manifest_path)
         if existing.project_id is not None:
@@ -121,6 +122,20 @@ def run_build_annotation(
                 f"pull. Create a new run id instead."
             )
 
+    # The push guard above keys on project_id, which stays None on the file-mode
+    # pull path (a project created by hand in the UI, then `emic-annotation-pull
+    # -f`). Pulled labels are the other half of the same join, so their presence
+    # forbids a rebuild just as a live project does.
+    existing_labels = sorted((annotation_outputs / LABELS_DIRNAME).glob("*.jsonl"))
+    if existing_labels:
+        raise ValueError(
+            f"Run {pipeline_id!r} already has pulled labels "
+            f"({', '.join(path.name for path in existing_labels)}). Rebuilding would rewrite "
+            f"the task_id -> pair_id join those labels were resolved through, silently "
+            f"invalidating every pair_id in them with nothing marking the divergence. "
+            f"Create a new run id instead."
+        )
+
     sample_manifest = SampleManifest.load(sample_manifest_path)
     items = _load_sample(sample_path)
     if len(items) != sample_manifest.total_items:
@@ -130,7 +145,18 @@ def run_build_annotation(
             f"rebuild it before annotating."
         )
 
+    # Keying by pair_id collapses duplicates, so the count has to be re-checked
+    # after the dict is built: without this, a repeated pair_id would silently
+    # drop a pair and the reduced count would be recorded as authoritative.
     by_pair_id = {item.pair_id: item for item in items}
+    if len(by_pair_id) != sample_manifest.total_items:
+        raise ValueError(
+            f"{SAMPLE_FILENAME} holds {len(items)} pairs but only {len(by_pair_id)} distinct "
+            f"pair_id(s); {SAMPLE_MANIFEST_FILENAME} declares "
+            f"{sample_manifest.total_items}. A duplicated pair_id would silently shrink the "
+            f"instrument; rebuild the sample before annotating."
+        )
+
     ordered_pair_ids = shuffle_order(list(by_pair_id), seed=seed)
 
     tasks: list[AnnotationTask] = []

--- a/src/arandu/shared/annotation/build.py
+++ b/src/arandu/shared/annotation/build.py
@@ -2,8 +2,8 @@
 
 This is the auditable half: no network, no secret, fully deterministic. Given a
 run's ``human_eval`` sample and the signed-off ruler, it writes the Label Studio
-labeling config, the blinded tasks, and the manifest that holds the
-``task_id -> pair_id`` join.
+labeling config, the project instructions HTML, the blinded tasks, and the
+manifest that holds the ``task_id -> pair_id`` join.
 
 The join stays here because ``pair_id`` is ``"{source_file_id}:{pair_index}"``:
 shipping it would let an attentive annotator group pairs from the same interview
@@ -17,7 +17,10 @@ import json
 import logging
 from typing import TYPE_CHECKING
 
-from arandu.shared.annotation.labeling_config import render_labeling_config
+from arandu.shared.annotation.labeling_config import (
+    render_expert_instruction,
+    render_labeling_config,
+)
 from arandu.shared.annotation.ruler import load_ruler, require_signed_off, ruler_sha256
 from arandu.shared.annotation.schemas import (
     AnnotationBuildConfig,
@@ -37,6 +40,12 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 CONFIG_FILENAME = "labeling_config.xml"
+#: The full ruler, rendered for Label Studio's project instructions modal.
+#:
+#: A second artifact rather than a second thing for `push` to render: the build
+#: is the auditable half, and both annotator-facing surfaces have to be readable
+#: from disk before anything is created server-side.
+INSTRUCTION_FILENAME = "expert_instruction.html"
 TASKS_FILENAME = "tasks.json"
 MANIFEST_FILENAME = "manifest.json"
 LABELS_DIRNAME = "labels"
@@ -181,6 +190,7 @@ def run_build_annotation(
 
     outputs = results_mgr.outputs_dir
     (outputs / CONFIG_FILENAME).write_text(render_labeling_config(ruler), encoding="utf-8")
+    (outputs / INSTRUCTION_FILENAME).write_text(render_expert_instruction(ruler), encoding="utf-8")
     (outputs / TASKS_FILENAME).write_text(
         json.dumps(
             [task.to_label_studio() for task in tasks],

--- a/src/arandu/shared/annotation/build.py
+++ b/src/arandu/shared/annotation/build.py
@@ -1,0 +1,189 @@
+"""Offline builder for the emic annotation instrument (spec §3.1, §5).
+
+This is the auditable half: no network, no secret, fully deterministic. Given a
+run's ``human_eval`` sample and the signed-off ruler, it writes the Label Studio
+labeling config, the blinded tasks, and the manifest that holds the
+``task_id -> pair_id`` join.
+
+The join stays here because ``pair_id`` is ``"{source_file_id}:{pair_index}"``:
+shipping it would let an attentive annotator group pairs from the same interview
+and read the stratification off the instrument.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from typing import TYPE_CHECKING
+
+from arandu.shared.annotation.labeling_config import render_labeling_config
+from arandu.shared.annotation.ruler import load_ruler, require_signed_off, ruler_sha256
+from arandu.shared.annotation.schemas import (
+    AnnotationBuildConfig,
+    AnnotationManifest,
+    AnnotationTask,
+)
+from arandu.shared.config import ResultsConfig
+from arandu.shared.human_eval.batch import MANIFEST_FILENAME as SAMPLE_MANIFEST_FILENAME
+from arandu.shared.human_eval.batch import SAMPLE_FILENAME
+from arandu.shared.human_eval.schemas import SampleItem, SampleManifest
+from arandu.shared.results_manager import ResultsManager
+from arandu.shared.schemas import PipelineType
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+CONFIG_FILENAME = "labeling_config.xml"
+TASKS_FILENAME = "tasks.json"
+MANIFEST_FILENAME = "manifest.json"
+
+
+def _shuffle_key(seed: int, pair_id: str) -> str:
+    """Return the seeded ordering key for a pair.
+
+    Same construction as the sampler's selection key: a SHA-256 of
+    ``"{seed}:{pair_id}"`` is stable across Python versions and platforms and
+    depends only on the pair itself, so the order is reproducible from the
+    manifest alone.
+    """
+    return hashlib.sha256(f"{seed}:{pair_id}".encode()).hexdigest()
+
+
+def shuffle_order(pair_ids: list[str], seed: int) -> list[str]:
+    """Return ``pair_ids`` in the deterministic presentation order.
+
+    The sample arrives grouped by stratification cell. Presenting it that way
+    would let the annotator calibrate within a block of same-band pairs, so the
+    order is broken here, at the source, with a recorded seed. Label Studio's own
+    shuffle is per-annotator, random, and not recordable, which is why it is not
+    used.
+    """
+    return sorted(pair_ids, key=lambda pid: (_shuffle_key(seed, pid), pid))
+
+
+def _load_sample(path: Path) -> list[SampleItem]:
+    """Read ``sample.jsonl`` into sample items."""
+    with path.open(encoding="utf-8") as fh:
+        return [SampleItem.model_validate_json(line) for line in fh if line.strip()]
+
+
+def run_build_annotation(
+    pipeline_id: str,
+    *,
+    seed: int,
+    base_dir: Path | None = None,
+    ruler_path: Path | None = None,
+) -> AnnotationManifest:
+    """Build the annotation artifacts for ``pipeline_id``.
+
+    Args:
+        pipeline_id: Run identifier. The ``human_eval`` stage must be populated.
+        seed: Shuffle seed, recorded in the manifest.
+        base_dir: Override the project ``results/`` root.
+        ruler_path: Override the ruler location (tests and audits).
+
+    Returns:
+        The :class:`AnnotationManifest` describing the build.
+
+    Raises:
+        RulerNotSignedOffError: If the ruler gate is still open.
+        FileNotFoundError: If the sample or its manifest is absent.
+        ValueError: If the sample count disagrees with the sample manifest, or a
+            previous build of this run has already been pushed.
+    """
+    # Gate first: nothing is written while the anchors are unreviewed.
+    ruler = load_ruler(ruler_path)
+    require_signed_off(ruler)
+
+    base = base_dir if base_dir is not None else ResultsConfig().base_dir
+    sample_outputs = base / pipeline_id / PipelineType.HUMAN_EVAL.value / "outputs"
+    sample_path = sample_outputs / SAMPLE_FILENAME
+    sample_manifest_path = sample_outputs / SAMPLE_MANIFEST_FILENAME
+    if not sample_path.exists() or not sample_manifest_path.exists():
+        raise FileNotFoundError(
+            f"Human-eval sample not found for pipeline_id {pipeline_id!r}: {sample_path}. "
+            f"Run `arandu build-human-eval-sample --id {pipeline_id} --seed <n>` first."
+        )
+
+    existing_manifest_path = (
+        base / pipeline_id / PipelineType.ANNOTATION.value / "outputs" / MANIFEST_FILENAME
+    )
+    if existing_manifest_path.exists():
+        existing = AnnotationManifest.load(existing_manifest_path)
+        if existing.project_id is not None:
+            raise ValueError(
+                f"Run {pipeline_id!r} was already pushed as Label Studio project "
+                f"{existing.project_id}. Rebuilding would rewrite the task_id -> pair_id join "
+                f"while annotators work against the old one, silently mislabelling every "
+                f"pull. Create a new run id instead."
+            )
+
+    sample_manifest = SampleManifest.load(sample_manifest_path)
+    items = _load_sample(sample_path)
+    if len(items) != sample_manifest.total_items:
+        raise ValueError(
+            f"{SAMPLE_FILENAME} holds {len(items)} pairs but {SAMPLE_MANIFEST_FILENAME} "
+            f"declares {sample_manifest.total_items}. The sample stage is inconsistent; "
+            f"rebuild it before annotating."
+        )
+
+    by_pair_id = {item.pair_id: item for item in items}
+    ordered_pair_ids = shuffle_order(list(by_pair_id), seed=seed)
+
+    tasks: list[AnnotationTask] = []
+    task_map: dict[str, str] = {}
+    for task_id, pair_id in enumerate(ordered_pair_ids):
+        item = by_pair_id[pair_id]
+        tasks.append(
+            AnnotationTask(
+                task_id=task_id,
+                segment=item.segment,
+                question=item.question,
+                answer=item.answer,
+            )
+        )
+        task_map[str(task_id)] = pair_id
+
+    results_mgr = ResultsManager(base, PipelineType.ANNOTATION, pipeline_id=pipeline_id)
+    results_mgr.create_run(
+        AnnotationBuildConfig(seed=seed, total_items=len(tasks)),
+        input_source=str(sample_outputs),
+    )
+
+    outputs = results_mgr.outputs_dir
+    (outputs / CONFIG_FILENAME).write_text(render_labeling_config(ruler), encoding="utf-8")
+    (outputs / TASKS_FILENAME).write_text(
+        json.dumps(
+            [task.to_label_studio() for task in tasks],
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    manifest = AnnotationManifest(
+        pipeline_id=pipeline_id,
+        seed=seed,
+        total_items=len(tasks),
+        per_cell=sample_manifest.per_cell,
+        pool_sha256=sample_manifest.pool_sha256,
+        ruler_sha256=ruler_sha256(ruler_path),
+        task_map=task_map,
+    )
+    manifest.save(outputs / MANIFEST_FILENAME)
+
+    results_mgr.update_progress(len(tasks), 0, len(tasks))
+    results_mgr.complete_run(success=True)
+
+    logger.info(
+        "Built annotation instrument: %d tasks, seed=%d, ruler=%s.",
+        len(tasks),
+        seed,
+        manifest.ruler_sha256[:12],
+    )
+    return manifest

--- a/src/arandu/shared/annotation/client.py
+++ b/src/arandu/shared/annotation/client.py
@@ -7,12 +7,33 @@ server and without the network.
 No ``label-studio-sdk`` dependency: the project rule is that provider SDKs stay
 out of the pipeline layers, and three endpoints do not justify one.
 
-Errors never carry the token. A stack trace or a log line that leaks the
-credential is a worse failure than the request that produced it.
+Two authentication schemes are supported, because Label Studio issues either
+one depending on how the organization is configured and the operator cannot be
+expected to know which one they were handed:
+
+* **Legacy API token.** Sent as ``Authorization: Token <token>``.
+* **JWT personal access token.** What Account and Settings hands out on a
+  current instance is a *refresh* token. It is not accepted on the API
+  endpoints at all; it has to be exchanged at ``POST /api/token/refresh`` for a
+  short-lived *access* token, which is then sent as
+  ``Authorization: Bearer <access>``.
+
+The token's own shape decides which path runs, so nothing has to be declared in
+the environment. Access tokens are short-lived (a task import plus an export
+can outlive one), so the exchange is lazy, the result is cached, and a single
+401 triggers exactly one re-exchange and one retry.
+
+Errors never carry the token. Neither the refresh token nor the derived access
+token may appear in an exception message, a log line, or an artifact: a stack
+trace or a log line that leaks the credential is a worse failure than the
+request that produced it.
 """
 
 from __future__ import annotations
 
+import base64
+import binascii
+import json
 import logging
 from typing import TYPE_CHECKING, Any, Protocol
 
@@ -24,6 +45,40 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _MAX_BODY_IN_ERROR = 500
+_JWT_SEGMENTS = 3
+_REFRESH_PATH = "/api/token/refresh"
+
+
+def _decode_jwt_payload(token: str) -> dict[str, Any] | None:
+    """Return a JWT's unverified payload claims, or ``None`` if it is not a JWT.
+
+    Only enough of the token is read to pick a code path. Verifying the
+    signature is the server's job, and a whole ``pyjwt`` dependency to read one
+    unverified claim would not earn its place.
+
+    Args:
+        token: The credential as the operator pasted it.
+
+    Returns:
+        The decoded payload object, or ``None`` when the value is not a
+        three-segment token with a base64url-encoded JSON object in the middle.
+    """
+    segments = token.split(".")
+    if len(segments) != _JWT_SEGMENTS:
+        return None
+    payload_segment = segments[1]
+    padded = payload_segment + "=" * (-len(payload_segment) % 4)
+    try:
+        payload = json.loads(base64.urlsafe_b64decode(padded))
+    except (ValueError, binascii.Error):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _is_jwt_refresh_token(token: str) -> bool:
+    """Report whether ``token`` is a JWT refresh token needing an exchange."""
+    payload = _decode_jwt_payload(token)
+    return payload is not None and payload.get("token_type") == "refresh"
 
 
 class LabelStudioError(RuntimeError):
@@ -53,7 +108,9 @@ class HttpLabelStudioClient:
 
     Args:
         base_url: Instance base URL, without a trailing slash.
-        token: API token, sent as ``Authorization: Token <token>``.
+        token: API token. A legacy token is sent as
+            ``Authorization: Token <token>``; a JWT refresh token is exchanged
+            for an access token and sent as ``Authorization: Bearer <access>``.
         timeout: Per-request timeout in seconds.
         transport: Injected transport, for tests.
     """
@@ -66,19 +123,94 @@ class HttpLabelStudioClient:
         timeout: float = 60.0,
         transport: httpx.BaseTransport | None = None,
     ) -> None:
+        self._token = token
+        self._needs_exchange = _is_jwt_refresh_token(token)
+        self._access_token: str | None = None
         self._client = httpx.Client(
             base_url=base_url.rstrip("/"),
-            headers={"Authorization": f"Token {token}"},
             timeout=timeout,
             transport=transport,
         )
+        logger.debug(
+            "Label Studio authentication scheme: %s.",
+            "JWT bearer (refresh exchange)" if self._needs_exchange else "legacy token",
+        )
 
-    def _request(self, method: str, path: str, **kwargs: Any) -> httpx.Response:
-        """Issue a request and turn any non-2xx into a token-free error."""
+    def _exchange_refresh_token(self) -> str:
+        """Trade the JWT refresh token for a short-lived access token.
+
+        The request body carries the credential, so neither it nor the response
+        is ever logged or folded into an error message.
+
+        Returns:
+            The freshly issued access token.
+
+        Raises:
+            LabelStudioError: If the exchange fails or returns no access token.
+        """
         try:
-            response = self._client.request(method, path, **kwargs)
+            response = self._client.post(_REFRESH_PATH, json={"refresh": self._token})
+        except httpx.HTTPError as exc:
+            raise LabelStudioError(
+                f"Could not reach Label Studio to refresh the access token: {exc}"
+            ) from exc
+        if response.status_code >= httpx.codes.BAD_REQUEST:
+            raise LabelStudioError(
+                f"Label Studio rejected the personal access token at {_REFRESH_PATH} "
+                f"(HTTP {response.status_code}). Copy a current token from Account and "
+                "Settings, Access Token, into ARANDU_LABEL_STUDIO_TOKEN, and check that "
+                "ARANDU_LABEL_STUDIO_URL points at the instance that issued it."
+            )
+        try:
+            data = response.json()
+        except ValueError as exc:
+            raise LabelStudioError(
+                f"Label Studio answered {_REFRESH_PATH} with a non-JSON body."
+            ) from exc
+        access = data.get("access") if isinstance(data, dict) else None
+        if not isinstance(access, str) or not access:
+            raise LabelStudioError(
+                f"Label Studio answered {_REFRESH_PATH} without an 'access' token."
+            )
+        logger.debug("Obtained a Label Studio access token.")
+        return access
+
+    def _authorization(self) -> str:
+        """Return the ``Authorization`` header value, exchanging lazily."""
+        if not self._needs_exchange:
+            return f"Token {self._token}"
+        if self._access_token is None:
+            self._access_token = self._exchange_refresh_token()
+        return f"Bearer {self._access_token}"
+
+    def _send(self, method: str, path: str, **kwargs: Any) -> httpx.Response:
+        """Issue one authenticated request, wrapping transport errors."""
+        headers = {**kwargs.pop("headers", {}), "Authorization": self._authorization()}
+        try:
+            return self._client.request(method, path, headers=headers, **kwargs)
         except httpx.HTTPError as exc:
             raise LabelStudioError(f"{method} {path} failed to reach Label Studio: {exc}") from exc
+
+    def _request(self, method: str, path: str, **kwargs: Any) -> httpx.Response:
+        """Issue a request and turn any non-2xx into a token-free error.
+
+        Access tokens expire mid-run, so a single 401 is treated as an expiry:
+        the cached access token is dropped, exchanged once more, and the request
+        is retried exactly once. A second 401 is a real credential problem and
+        is reported rather than retried, so this can never loop.
+        """
+        response = self._send(method, path, **kwargs)
+        if response.status_code == httpx.codes.UNAUTHORIZED and self._needs_exchange:
+            logger.debug("%s %s returned 401; refreshing the access token once.", method, path)
+            self._access_token = None
+            response = self._send(method, path, **kwargs)
+            if response.status_code == httpx.codes.UNAUTHORIZED:
+                raise LabelStudioError(
+                    f"{method} {path} returned 401 again after refreshing the access token. "
+                    "The personal access token is most likely expired or revoked, or "
+                    "ARANDU_LABEL_STUDIO_URL points at a different instance than the one "
+                    "that issued it."
+                )
         if response.status_code >= httpx.codes.BAD_REQUEST:
             body = response.text[:_MAX_BODY_IN_ERROR]
             raise LabelStudioError(f"{method} {path} returned {response.status_code}: {body}")
@@ -156,7 +288,8 @@ def build_client_from_settings(settings: LabelStudioSettings) -> HttpLabelStudio
 
     The ``SecretStr`` token is unwrapped here, at the settings-to-client
     boundary: the client is transport only and should not know about
-    Pydantic's secret-wrapper type.
+    Pydantic's secret-wrapper type. Which authentication scheme the token
+    implies is decided by the client, from the token itself.
     """
     return HttpLabelStudioClient(
         base_url=settings.url,

--- a/src/arandu/shared/annotation/client.py
+++ b/src/arandu/shared/annotation/client.py
@@ -1,0 +1,142 @@
+"""Thin HTTP client for the Label Studio API (Community Edition 1.23).
+
+Transport only: three calls, no domain logic. ``push`` and ``pull`` depend on
+the :class:`LabelStudioClient` Protocol, so both are fully testable without a
+server and without the network.
+
+No ``label-studio-sdk`` dependency: the project rule is that provider SDKs stay
+out of the pipeline layers, and three endpoints do not justify one.
+
+Errors never carry the token. A stack trace or a log line that leaks the
+credential is a worse failure than the request that produced it.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any, Protocol
+
+import httpx
+
+if TYPE_CHECKING:
+    from arandu.shared.annotation.settings import LabelStudioSettings
+
+logger = logging.getLogger(__name__)
+
+_MAX_BODY_IN_ERROR = 500
+
+
+class LabelStudioError(RuntimeError):
+    """Raised when the Label Studio API rejects a request or answers unusably."""
+
+
+class LabelStudioClient(Protocol):
+    """The three operations the annotation instrument needs."""
+
+    def create_project(self, title: str, label_config: str) -> int:
+        """Create a project and return its id."""
+        ...
+
+    def import_tasks(self, project_id: int, tasks: list[dict[str, Any]]) -> int:
+        """Import tasks into a project and return how many were accepted."""
+        ...
+
+    def export_annotations(self, project_id: int) -> list[dict[str, Any]]:
+        """Return the project's tasks with their annotations."""
+        ...
+
+
+class HttpLabelStudioClient:
+    """:class:`LabelStudioClient` over httpx.
+
+    Args:
+        base_url: Instance base URL, without a trailing slash.
+        token: API token, sent as ``Authorization: Token <token>``.
+        timeout: Per-request timeout in seconds.
+        transport: Injected transport, for tests.
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        token: str,
+        *,
+        timeout: float = 60.0,
+        transport: httpx.BaseTransport | None = None,
+    ) -> None:
+        self._client = httpx.Client(
+            base_url=base_url.rstrip("/"),
+            headers={"Authorization": f"Token {token}"},
+            timeout=timeout,
+            transport=transport,
+        )
+
+    def _request(self, method: str, path: str, **kwargs: Any) -> httpx.Response:
+        """Issue a request and turn any non-2xx into a token-free error."""
+        try:
+            response = self._client.request(method, path, **kwargs)
+        except httpx.HTTPError as exc:
+            raise LabelStudioError(f"{method} {path} failed to reach Label Studio: {exc}") from exc
+        if response.status_code >= httpx.codes.BAD_REQUEST:
+            body = response.text[:_MAX_BODY_IN_ERROR]
+            raise LabelStudioError(f"{method} {path} returned {response.status_code}: {body}")
+        return response
+
+    def create_project(self, title: str, label_config: str) -> int:
+        """Create a project and return its id.
+
+        Raises:
+            LabelStudioError: On any API failure, or if the response carries no
+                integer id.
+        """
+        payload = {"title": title, "label_config": label_config}
+        data = self._request("POST", "/api/projects/", json=payload).json()
+        project_id = data.get("id") if isinstance(data, dict) else None
+        if not isinstance(project_id, int):
+            raise LabelStudioError(
+                f"Label Studio accepted the project but returned no integer id: {data!r}"
+            )
+        logger.info("Created Label Studio project %d.", project_id)
+        return project_id
+
+    def import_tasks(self, project_id: int, tasks: list[dict[str, Any]]) -> int:
+        """Import tasks and return the accepted count.
+
+        Raises:
+            LabelStudioError: On any API failure.
+        """
+        data = self._request("POST", f"/api/projects/{project_id}/import", json=tasks).json()
+        count = data.get("task_count") if isinstance(data, dict) else None
+        return count if isinstance(count, int) else len(tasks)
+
+    def export_annotations(self, project_id: int) -> list[dict[str, Any]]:
+        """Return the project's tasks with their annotations.
+
+        Raises:
+            LabelStudioError: On any API failure, or if the payload is not a
+                list of tasks.
+        """
+        data = self._request(
+            "GET", f"/api/projects/{project_id}/export", params={"exportType": "JSON"}
+        ).json()
+        if not isinstance(data, list):
+            raise LabelStudioError(
+                f"Expected a list of tasks from the export endpoint, got {type(data).__name__}."
+            )
+        return data
+
+    def close(self) -> None:
+        """Close the underlying HTTP connection pool."""
+        self._client.close()
+
+
+def build_client_from_settings(settings: LabelStudioSettings) -> HttpLabelStudioClient:
+    """Build a client from :class:`LabelStudioSettings`.
+
+    Kept as a free function (the same shape as
+    ``build_llm_client_from_settings``) so the CLI never constructs transport
+    details by hand.
+    """
+    return HttpLabelStudioClient(
+        base_url=settings.url, token=settings.token, timeout=settings.timeout
+    )

--- a/src/arandu/shared/annotation/client.py
+++ b/src/arandu/shared/annotation/client.py
@@ -94,8 +94,8 @@ class LabelStudioClient(Protocol):
         """Create a project and return its id."""
         ...
 
-    def import_tasks(self, project_id: int, tasks: list[dict[str, Any]]) -> int:
-        """Import tasks into a project and return how many were accepted."""
+    def import_tasks(self, project_id: int, tasks: list[dict[str, Any]]) -> int | None:
+        """Import tasks and return how many were accepted, or ``None`` if unreported."""
         ...
 
     def export_annotations(self, project_id: int) -> list[dict[str, Any]]:
@@ -248,15 +248,23 @@ class HttpLabelStudioClient:
         logger.info("Created Label Studio project %d.", project_id)
         return project_id
 
-    def import_tasks(self, project_id: int, tasks: list[dict[str, Any]]) -> int:
+    def import_tasks(self, project_id: int, tasks: list[dict[str, Any]]) -> int | None:
         """Import tasks and return the accepted count.
+
+        Returns:
+            The count the instance reports it accepted, or ``None`` when the
+            response carries no integer ``task_count``. An unreported count is
+            not an accepted one: falling back to ``len(tasks)`` here would make
+            the caller's partial-import guard unfireable in exactly the case it
+            exists for, so what "no count" means is the caller's policy to
+            decide and this transport stays generic.
 
         Raises:
             LabelStudioError: On any API failure.
         """
         data = self._request("POST", f"/api/projects/{project_id}/import", json=tasks).json()
         count = data.get("task_count") if isinstance(data, dict) else None
-        return count if isinstance(count, int) else len(tasks)
+        return count if isinstance(count, int) else None
 
     def export_annotations(self, project_id: int) -> list[dict[str, Any]]:
         """Return the project's tasks with their annotations.

--- a/src/arandu/shared/annotation/client.py
+++ b/src/arandu/shared/annotation/client.py
@@ -33,7 +33,9 @@ class LabelStudioError(RuntimeError):
 class LabelStudioClient(Protocol):
     """The three operations the annotation instrument needs."""
 
-    def create_project(self, title: str, label_config: str) -> int:
+    def create_project(
+        self, title: str, label_config: str, *, settings: dict[str, Any] | None = None
+    ) -> int:
         """Create a project and return its id."""
         ...
 
@@ -82,14 +84,29 @@ class HttpLabelStudioClient:
             raise LabelStudioError(f"{method} {path} returned {response.status_code}: {body}")
         return response
 
-    def create_project(self, title: str, label_config: str) -> int:
+    def create_project(
+        self, title: str, label_config: str, *, settings: dict[str, Any] | None = None
+    ) -> int:
         """Create a project and return its id.
+
+        Args:
+            title: Project title.
+            label_config: The labeling config XML.
+            settings: Extra project fields posted alongside ``title`` and
+                ``label_config``. The Label Studio project serializer accepts
+                the project's own settings in the create payload, so the caller
+                decides the policy and this transport stays generic.
+
+        Returns:
+            The created project id.
 
         Raises:
             LabelStudioError: On any API failure, or if the response carries no
                 integer id.
         """
-        payload = {"title": title, "label_config": label_config}
+        payload: dict[str, Any] = {"title": title, "label_config": label_config}
+        if settings:
+            payload.update(settings)
         data = self._request("POST", "/api/projects/", json=payload).json()
         project_id = data.get("id") if isinstance(data, dict) else None
         if not isinstance(project_id, int):

--- a/src/arandu/shared/annotation/client.py
+++ b/src/arandu/shared/annotation/client.py
@@ -136,7 +136,13 @@ def build_client_from_settings(settings: LabelStudioSettings) -> HttpLabelStudio
     Kept as a free function (the same shape as
     ``build_llm_client_from_settings``) so the CLI never constructs transport
     details by hand.
+
+    The ``SecretStr`` token is unwrapped here, at the settings-to-client
+    boundary: the client is transport only and should not know about
+    Pydantic's secret-wrapper type.
     """
     return HttpLabelStudioClient(
-        base_url=settings.url, token=settings.token, timeout=settings.timeout
+        base_url=settings.url,
+        token=settings.token.get_secret_value(),
+        timeout=settings.timeout,
     )

--- a/src/arandu/shared/annotation/labeling_config.py
+++ b/src/arandu/shared/annotation/labeling_config.py
@@ -1,4 +1,4 @@
-"""Render the Label Studio labeling config from the emic ruler.
+"""Render the two annotator-facing surfaces from the emic ruler.
 
 The annotator's widget IS the instrument. The five options carry the anchor
 sentences verbatim from ``ruler["scale"]`` so the human and the LLM judge score
@@ -6,19 +6,70 @@ against one ruler: the weighted kappa of spec section 6 only measures agreement
 if both read the same text, and a divergence is not recoverable after
 annotation.
 
+The ruler is roughly two screens of Portuguese prose. Rendering all of it
+between the pair and the rating widget pushed a 4000-character segment out of
+view by the time the annotator reached the radio buttons, once per task, 120
+times per annotator. So the ruler is split across two surfaces:
+
+* :func:`render_expert_instruction` renders the full ruler as HTML for Label
+  Studio's own instructions modal (the project's ``expert_instruction`` field,
+  reachable from the help button). That is the reference an annotator opens.
+* :func:`render_labeling_config` keeps a short collapsed summary on the canvas,
+  closed by default, holding only what is consulted mid-doubt: the scoring
+  cascade, the "does not reduce the score" list, and the annotator-only
+  calibration. The pair then sits immediately above the rating widget.
+
 ``shuffle`` is set to ``"false"`` explicitly. Shuffling an ordinal scale destroys
 its meaning, and relying on a platform default for that is not worth the risk.
 
 Judge-only material (the role framing, the JSON output contract, the rationale
-rules) is excluded: it would prime the annotator with the machine's framing.
+rules) is excluded from BOTH surfaces: it would prime the annotator with the
+machine's framing.
 """
 
 from __future__ import annotations
 
+from html import escape
 from typing import Any
 from xml.sax.saxutils import quoteattr
 
 _HEADER = "Validade êmica do par"
+_SUMMARY_TITLE = "Cascata de pontuação (resumo)"
+
+#: Canvas typography.
+#:
+#: Three jobs, all of them consequences of the dry run: cap the segment box so a
+#: long chunk scrolls inside itself instead of pushing the rating widget off
+#: screen; give the pair a visible frame so it reads as the object under
+#: judgment; and make the collapsed ruler summary secondary to it. Prose is
+#: capped at ~70 characters per line, which is where continuous reading stops
+#: costing extra eye travel.
+_STYLE = """
+    .emic-summary { margin: 0 0 14px; }
+    .emic-summary h4 { font-size: 0.95em; margin: 12px 0 4px; color: #3d3d3d; }
+    .emic-summary h6 {
+      max-width: 70ch; font-size: 0.88em; font-weight: 400; color: #5c5c5c;
+      line-height: 1.5; margin: 0 0 6px;
+    }
+    .emic-pair {
+      border: 1px solid #d0d0d0; border-radius: 6px; background: #fafafa;
+      padding: 10px 14px; margin: 0 0 16px;
+    }
+    .emic-pair h4 {
+      font-size: 0.78em; text-transform: uppercase; letter-spacing: 0.05em;
+      color: #6b6b6b; margin: 10px 0 3px;
+    }
+    .emic-segment {
+      max-height: 260px; overflow-y: auto; background: #ffffff;
+      border: 1px solid #e4e4e4; border-radius: 4px; padding: 8px 10px;
+      line-height: 1.55;
+    }
+    .emic-score h4 { font-size: 0.95em; margin: 12px 0 6px; color: #3d3d3d; }
+    .emic-score h6 {
+      max-width: 70ch; font-size: 0.88em; font-weight: 400; color: #5c5c5c;
+      line-height: 1.5; margin: 0 0 6px;
+    }
+"""
 
 
 def _attr(value: str) -> str:
@@ -26,7 +77,7 @@ def _attr(value: str) -> str:
     return quoteattr(value)
 
 
-def _paragraph(text: str) -> str:
+def _paragraph(text: str, indent: str) -> str:
     """Render a block of ruler prose as a static element.
 
     ``Header`` and not ``Text``: ``Text`` is how Label Studio binds a task
@@ -34,17 +85,74 @@ def _paragraph(text: str) -> str:
     that the bound set is exactly ``$segment``, ``$question``, ``$answer``.
     ``Header`` also takes no ``name``, which avoids the duplicate-name collision
     a repeated ``Text`` element would cause.
+
+    Args:
+        text: The ruler passage, copied verbatim.
+        indent: Leading whitespace for the emitted line.
+
+    Returns:
+        A single ``<Header>`` line.
     """
-    return f"  <Header value={_attr(text)} />"
+    return f'{indent}<Header value={_attr(text)} size="6" />'
 
 
-def _header(text: str) -> str:
-    """Render a section title (same element as prose; kept separate for intent)."""
-    return f"  <Header value={_attr(text)} />"
+def _header(text: str, indent: str, size: str = "4") -> str:
+    """Render a section title (same element as prose; kept separate for intent).
+
+    Args:
+        text: The title.
+        indent: Leading whitespace for the emitted line.
+        size: Label Studio ``Header`` size, which selects the heading level.
+
+    Returns:
+        A single ``<Header>`` line.
+    """
+    return f"{indent}<Header value={_attr(text)} size={_attr(size)} />"
+
+
+def _summary_lines(ruler: dict[str, Any]) -> list[str]:
+    """Render the collapsed canvas summary.
+
+    Only what an annotator consults mid-doubt: the cascade (the decision
+    procedure), the list of things that do not cost a point, and the
+    annotator-only calibration about the fine boundaries and the narrow door to
+    1. Everything else lives in the instructions modal.
+
+    Args:
+        ruler: The parsed ruler mapping.
+
+    Returns:
+        The lines of the ``<Collapse>`` block.
+    """
+    guide = ruler["guide"]
+    indent = "        "
+    lines = [
+        "  <Collapse>",
+        f"    <Panel value={_attr(_SUMMARY_TITLE)}>",
+        '      <View className="emic-summary">',
+        _paragraph(guide["cascade_intro"], indent),
+    ]
+    lines += [
+        _paragraph(f"{entry['score']}: {entry['condition']}", indent) for entry in guide["cascade"]
+    ]
+    lines += [
+        _header("Não reduzem a nota", indent),
+        _paragraph(guide["no_penalty"], indent),
+        _header("Quando hesitar", indent),
+    ]
+    lines += [_paragraph(text, indent) for text in ruler["annotator_only"].values()]
+    lines += ["      </View>", "    </Panel>", "  </Collapse>"]
+    return lines
 
 
 def render_labeling_config(ruler: dict[str, Any]) -> str:
     """Render the ``labeling_config.xml`` body for the annotation project.
+
+    Layout, top to bottom: the header, the collapsed ruler summary (closed by
+    default), the pair under judgment, then the rating widget and the rationale
+    box. The pair sits immediately above the widget so the annotator never has
+    to hold a 4000-character segment in their head while scrolling to the radio
+    buttons.
 
     Args:
         ruler: The parsed ruler mapping (see
@@ -54,69 +162,120 @@ def render_labeling_config(ruler: dict[str, Any]) -> str:
         A ``<View>`` XML document as a string. Well-formed, self-contained, and
         deterministic: the same ruler always renders byte-identical output.
     """
-    construct = ruler["construct"]
-    provisions = ruler["provisions"]
     guide = ruler["guide"]
-    annotator_only = ruler["annotator_only"]
 
-    lines: list[str] = ["<View>", _header(_HEADER)]
+    lines: list[str] = [
+        "<View>",
+        f"  <Style>{_STYLE}  </Style>",
+        _header(_HEADER, "  ", size="3"),
+    ]
+
+    lines += _summary_lines(ruler)
 
     # The pair under judgment. These three are the ONLY task variables bound:
     # anything else would let an attentive annotator reconstruct the
     # stratification (spec section 5).
     lines += [
-        _header("Trecho da entrevista"),
-        '  <Text name="segment" value="$segment" />',
-        _header("Pergunta"),
-        '  <Text name="question" value="$question" />',
-        _header("Resposta"),
-        '  <Text name="answer" value="$answer" />',
+        '  <View className="emic-pair">',
+        _header("Trecho da entrevista", "    "),
+        '    <View className="emic-segment">',
+        '      <Text name="segment" value="$segment" />',
+        "    </View>",
+        _header("Pergunta", "    "),
+        '    <Text name="question" value="$question" />',
+        _header("Resposta", "    "),
+        '    <Text name="answer" value="$answer" />',
+        "  </View>",
     ]
 
-    lines.append(_header("O construto"))
-    lines += [
-        _paragraph(construct[key])
-        for key in ("emic", "non_emic", "gradient", "question", "not_faithfulness")
-    ]
-
-    lines.append(_header("O que se avalia"))
-    lines += [
-        _paragraph(provisions["unit_of_judgment"]),
-        _paragraph(provisions["question_calibrates"]),
-        _paragraph(provisions["out_of_scope"]),
-    ]
-    lines += [_paragraph(text) for text in provisions["not_a_loss"]]
-
-    lines.append(_header("Tipos de perda êmica"))
-    lines += [_paragraph(f"{entry['name']}: {entry['what']}") for entry in ruler["loss_types"]]
-
-    lines.append(_header("Como pontuar"))
-    lines += [
-        _paragraph(guide["locate"]),
-        _paragraph(guide["extract"]),
-        _paragraph(guide["cascade_intro"]),
-    ]
-    lines += [_paragraph(f"{entry['score']}: {entry['condition']}") for entry in guide["cascade"]]
-    lines.append(_paragraph(guide["no_penalty"]))
-    lines += [_paragraph(text) for text in annotator_only.values()]
-
-    lines.append(_header("Sua nota"))
+    lines += ['  <View className="emic-score">', _header("Sua nota", "    ")]
     lines.append(
-        '  <Choices name="score" toName="answer" choice="single-radio" '
+        '    <Choices name="score" toName="answer" choice="single-radio" '
         'shuffle="false" required="true">'
     )
     for entry in ruler["scale"]:
         # "5 - Preserva o sentido, ...": the number the study records, next to the
         # anchor sentence the judge prompt puts beside the same number.
         option = f"{entry['score']} - {entry['label']}"
-        lines.append(f"    <Choice value={_attr(option)} />")
-    lines.append("  </Choices>")
+        lines.append(f"      <Choice value={_attr(option)} />")
+    lines.append("    </Choices>")
 
     lines += [
-        _header("Justificativa (opcional)"),
-        _paragraph(guide["name_the_condition"]),
-        '  <TextArea name="rationale" toName="answer" editable="true" '
+        _header("Justificativa (opcional)", "    "),
+        _paragraph(guide["name_the_condition"], "    "),
+        '    <TextArea name="rationale" toName="answer" editable="true" '
         'maxSubmissions="1" rows="3" />',
+        "  </View>",
         "</View>",
     ]
+    return "\n".join(lines) + "\n"
+
+
+def _html_paragraphs(texts: list[str]) -> list[str]:
+    """Render ruler passages as escaped ``<p>`` elements."""
+    return [f"<p>{escape(text)}</p>" for text in texts]
+
+
+def _html_list(items: list[str]) -> list[str]:
+    """Render ruler passages as an escaped ``<ul>``."""
+    return ["<ul>", *[f"  <li>{escape(item)}</li>" for item in items], "</ul>"]
+
+
+def render_expert_instruction(ruler: dict[str, Any]) -> str:
+    """Render the full ruler as HTML for Label Studio's instructions modal.
+
+    This is the project's ``expert_instruction`` field, shown behind the help
+    button when ``show_instruction`` is on. It carries the whole annotator-facing
+    ruler so the canvas does not have to: construct, scale, loss types,
+    provisions, the full scoring guide, and the annotator-only calibration.
+
+    Plain semantic HTML with no styling and no external reference: it is
+    injected into a page whose CSS is Label Studio's, and a research instrument
+    must not depend on a resource that can move or disappear between the audit
+    and the annotation round.
+
+    Judge-only material is excluded here for the same reason it is excluded from
+    the canvas.
+
+    Args:
+        ruler: The parsed ruler mapping (see
+            :func:`arandu.shared.annotation.ruler.load_ruler`).
+
+    Returns:
+        An HTML fragment as a string. Deterministic for a given ruler.
+
+    Raises:
+        KeyError: If the ruler is missing a section the instruction needs.
+    """
+    construct = ruler["construct"]
+    provisions = ruler["provisions"]
+    guide = ruler["guide"]
+
+    lines: list[str] = [f"<h1>{escape(_HEADER)}</h1>", "<h2>O construto</h2>"]
+    lines += _html_paragraphs(
+        [construct[key] for key in ("emic", "non_emic", "gradient", "question", "not_faithfulness")]
+    )
+
+    lines.append("<h2>A escala</h2>")
+    lines += _html_list([f"{entry['score']} - {entry['label']}" for entry in ruler["scale"]])
+
+    lines.append("<h2>O que se avalia</h2>")
+    lines += _html_paragraphs(
+        [provisions[key] for key in ("unit_of_judgment", "question_calibrates", "out_of_scope")]
+    )
+    lines.append("<h3>Não são perda</h3>")
+    lines += _html_list(list(provisions["not_a_loss"]))
+
+    lines.append("<h2>Tipos de perda êmica</h2>")
+    lines += _html_list([f"{entry['name']}: {entry['what']}" for entry in ruler["loss_types"]])
+
+    lines.append("<h2>Como pontuar</h2>")
+    lines += _html_paragraphs([guide["locate"], guide["extract"], guide["cascade_intro"]])
+    lines += _html_list([f"{entry['score']}: {entry['condition']}" for entry in guide["cascade"]])
+    lines.append("<h3>Não reduzem a nota</h3>")
+    lines += _html_paragraphs([guide["no_penalty"], guide["name_the_condition"]])
+
+    lines.append("<h2>Quando hesitar</h2>")
+    lines += _html_paragraphs(list(ruler["annotator_only"].values()))
+
     return "\n".join(lines) + "\n"

--- a/src/arandu/shared/annotation/labeling_config.py
+++ b/src/arandu/shared/annotation/labeling_config.py
@@ -165,6 +165,23 @@ def _header(text: str, indent: str, size: str = "4") -> str:
     return f"{indent}<Header value={_attr(text)} size={_attr(size)} />"
 
 
+def _cascade_sentence(entry: dict[str, Any]) -> str:
+    """Assemble one cascade step as a sentence.
+
+    The ruler stores each step as a lowercase subordinate clause with no final
+    period, so the ``Se ..., atribua nota N.`` frame lives here instead of being
+    baked into the data. Both surfaces call this, so the canvas summary and the
+    instructions modal cannot phrase the same step differently.
+
+    Args:
+        entry: One ``guide.cascade`` entry, carrying ``condition`` and ``score``.
+
+    Returns:
+        The step as a single Portuguese sentence.
+    """
+    return f"Se {entry['condition']}, atribua nota {entry['score']}."
+
+
 def _summary_lines(ruler: dict[str, Any]) -> list[str]:
     """Render the collapsed canvas summary.
 
@@ -194,9 +211,7 @@ def _summary_lines(ruler: dict[str, Any]) -> list[str]:
         '        <View className="emic-summary">',
         _paragraph(guide["cascade_intro"], indent),
     ]
-    lines += [
-        _paragraph(f"{entry['score']}: {entry['condition']}", indent) for entry in guide["cascade"]
-    ]
+    lines += [_paragraph(_cascade_sentence(entry), indent) for entry in guide["cascade"]]
     lines += [
         _header("Não reduzem a nota", indent),
         _paragraph(guide["no_penalty"], indent),
@@ -349,7 +364,7 @@ def render_expert_instruction(ruler: dict[str, Any]) -> str:
 
     lines.append("<h2>Como pontuar</h2>")
     lines += _html_paragraphs([guide["locate"], guide["extract"], guide["cascade_intro"]])
-    lines += _html_list([f"{entry['score']}: {entry['condition']}" for entry in guide["cascade"]])
+    lines += _html_list([_cascade_sentence(entry) for entry in guide["cascade"]])
     lines.append("<h3>Não reduzem a nota</h3>")
     lines += _html_paragraphs([guide["no_penalty"], guide["name_the_condition"]])
 

--- a/src/arandu/shared/annotation/labeling_config.py
+++ b/src/arandu/shared/annotation/labeling_config.py
@@ -34,7 +34,7 @@ from typing import Any
 from xml.sax.saxutils import quoteattr
 
 _HEADER = "Validade êmica do par"
-_SUMMARY_TITLE = "Cascata de pontuação (resumo)"
+_SUMMARY_TITLE = "Guia de avaliação"
 
 #: Canvas typography.
 #:

--- a/src/arandu/shared/annotation/labeling_config.py
+++ b/src/arandu/shared/annotation/labeling_config.py
@@ -51,7 +51,28 @@ _SUMMARY_TITLE = "Cascata de pontuação (resumo)"
 #: every surface and rule is a translucent neutral that darkens a light
 #: background and lightens a dark one. A dark-mode override with hardcoded dark
 #: values would only move the same failure to the next palette change.
+#:
+#: ``.emic-summary-wrap`` is the one place where the rules have to be blunt.
+#: ``<Collapse>``/``<Panel>`` are Label Studio components that render their own
+#: DOM with their own light-theme chrome (surface, border, shadow, text colour)
+#: inside our ``<View>``, so styling our wrapper alone leaves a white slab in a
+#: dark page. The class names of that inner DOM are not knowable from this
+#: repository and change between platform versions, so the override neutralises
+#: every descendant instead of naming one selector, and adds substring matches
+#: for the likely container classes to strip the box treatment as well. Being
+#: scoped to a class only this block carries is what makes that width safe:
+#: nothing outside our own wrapper can be reached by any of it.
 _STYLE = """
+    .emic-summary-wrap {
+      border: 1px solid rgba(128, 128, 128, 0.3); border-radius: 6px;
+      background: rgba(128, 128, 128, 0.06); margin: 0 0 14px;
+    }
+    .emic-summary-wrap * { background: transparent !important; color: inherit !important; }
+    .emic-summary-wrap [class*="collapse"], .emic-summary-wrap [class*="Collapse"],
+    .emic-summary-wrap [class*="panel"], .emic-summary-wrap [class*="Panel"],
+    .emic-summary-wrap [class*="accordion"] {
+      border-color: rgba(128, 128, 128, 0.3) !important; box-shadow: none !important;
+    }
     .emic-summary { margin: 0 0 14px; }
     .emic-summary h4 { font-size: 0.95em; margin: 12px 0 4px; color: inherit; }
     .emic-summary h6 {
@@ -152,18 +173,25 @@ def _summary_lines(ruler: dict[str, Any]) -> list[str]:
     annotator-only calibration about the fine boundaries and the narrow door to
     1. Everything else lives in the instructions modal.
 
+    The ``<Collapse>`` is wrapped in a ``<View>`` of our own carrying
+    ``emic-summary-wrap``. ``Collapse`` and ``Panel`` take no ``className``, and
+    the inner ``emic-summary`` view sits *inside* the panel body, so without that
+    outer wrapper there is no selector from which the component's own chrome can
+    be reached. See ``_STYLE``.
+
     Args:
         ruler: The parsed ruler mapping.
 
     Returns:
-        The lines of the ``<Collapse>`` block.
+        The lines of the wrapped ``<Collapse>`` block.
     """
     guide = ruler["guide"]
-    indent = "        "
+    indent = "          "
     lines = [
-        "  <Collapse>",
-        f"    <Panel value={_attr(_SUMMARY_TITLE)}>",
-        '      <View className="emic-summary">',
+        '  <View className="emic-summary-wrap">',
+        "    <Collapse>",
+        f"      <Panel value={_attr(_SUMMARY_TITLE)}>",
+        '        <View className="emic-summary">',
         _paragraph(guide["cascade_intro"], indent),
     ]
     lines += [
@@ -175,7 +203,7 @@ def _summary_lines(ruler: dict[str, Any]) -> list[str]:
         _header("Quando hesitar", indent),
     ]
     lines += [_paragraph(text, indent) for text in ruler["annotator_only"].values()]
-    lines += ["      </View>", "    </Panel>", "  </Collapse>"]
+    lines += ["        </View>", "      </Panel>", "    </Collapse>", "  </View>"]
     return lines
 
 

--- a/src/arandu/shared/annotation/labeling_config.py
+++ b/src/arandu/shared/annotation/labeling_config.py
@@ -1,0 +1,122 @@
+"""Render the Label Studio labeling config from the emic ruler.
+
+The annotator's widget IS the instrument. The five options carry the anchor
+sentences verbatim from ``ruler["scale"]`` so the human and the LLM judge score
+against one ruler: the weighted kappa of spec section 6 only measures agreement
+if both read the same text, and a divergence is not recoverable after
+annotation.
+
+``shuffle`` is set to ``"false"`` explicitly. Shuffling an ordinal scale destroys
+its meaning, and relying on a platform default for that is not worth the risk.
+
+Judge-only material (the role framing, the JSON output contract, the rationale
+rules) is excluded: it would prime the annotator with the machine's framing.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from xml.sax.saxutils import quoteattr
+
+_HEADER = "Validade êmica do par"
+
+
+def _attr(value: str) -> str:
+    """Quote and escape a string for use as an XML attribute value."""
+    return quoteattr(value)
+
+
+def _paragraph(text: str) -> str:
+    """Render a block of ruler prose as a static element.
+
+    ``Header`` and not ``Text``: ``Text`` is how Label Studio binds a task
+    variable, so reserving it for the three blinded fields lets a test assert
+    that the bound set is exactly ``$segment``, ``$question``, ``$answer``.
+    ``Header`` also takes no ``name``, which avoids the duplicate-name collision
+    a repeated ``Text`` element would cause.
+    """
+    return f"  <Header value={_attr(text)} />"
+
+
+def _header(text: str) -> str:
+    """Render a section title (same element as prose; kept separate for intent)."""
+    return f"  <Header value={_attr(text)} />"
+
+
+def render_labeling_config(ruler: dict[str, Any]) -> str:
+    """Render the ``labeling_config.xml`` body for the annotation project.
+
+    Args:
+        ruler: The parsed ruler mapping (see
+            :func:`arandu.shared.annotation.ruler.load_ruler`).
+
+    Returns:
+        A ``<View>`` XML document as a string. Well-formed, self-contained, and
+        deterministic: the same ruler always renders byte-identical output.
+    """
+    construct = ruler["construct"]
+    provisions = ruler["provisions"]
+    guide = ruler["guide"]
+    annotator_only = ruler["annotator_only"]
+
+    lines: list[str] = ["<View>", _header(_HEADER)]
+
+    # The pair under judgment. These three are the ONLY task variables bound:
+    # anything else would let an attentive annotator reconstruct the
+    # stratification (spec section 5).
+    lines += [
+        _header("Trecho da entrevista"),
+        '  <Text name="segment" value="$segment" />',
+        _header("Pergunta"),
+        '  <Text name="question" value="$question" />',
+        _header("Resposta"),
+        '  <Text name="answer" value="$answer" />',
+    ]
+
+    lines.append(_header("O construto"))
+    lines += [
+        _paragraph(construct[key])
+        for key in ("emic", "non_emic", "gradient", "question", "not_faithfulness")
+    ]
+
+    lines.append(_header("O que se avalia"))
+    lines += [
+        _paragraph(provisions["unit_of_judgment"]),
+        _paragraph(provisions["question_calibrates"]),
+        _paragraph(provisions["out_of_scope"]),
+    ]
+    lines += [_paragraph(text) for text in provisions["not_a_loss"]]
+
+    lines.append(_header("Tipos de perda êmica"))
+    lines += [_paragraph(f"{entry['name']}: {entry['what']}") for entry in ruler["loss_types"]]
+
+    lines.append(_header("Como pontuar"))
+    lines += [
+        _paragraph(guide["locate"]),
+        _paragraph(guide["extract"]),
+        _paragraph(guide["cascade_intro"]),
+    ]
+    lines += [_paragraph(f"{entry['score']}: {entry['condition']}") for entry in guide["cascade"]]
+    lines.append(_paragraph(guide["no_penalty"]))
+    lines += [_paragraph(text) for text in annotator_only.values()]
+
+    lines.append(_header("Sua nota"))
+    lines.append(
+        '  <Choices name="score" toName="answer" choice="single-radio" '
+        'shuffle="false" required="true">'
+    )
+    for entry in ruler["scale"]:
+        # "5 - Preserva o sentido, ...": the number the study records, next to the
+        # anchor sentence the judge prompt puts beside the same number.
+        option = f"{entry['score']} - {entry['label']}"
+        lines.append(f"    <Choice value={_attr(option)} />")
+    lines.append("  </Choices>")
+
+    lines += [
+        _header("Justificativa (opcional)"),
+        _paragraph(guide["name_the_condition"]),
+        '  <TextArea name="rationale" toName="answer" editable="true" '
+        'maxSubmissions="1" rows="3" />',
+        "</View>",
+    ]
+    return "\n".join(lines) + "\n"

--- a/src/arandu/shared/annotation/labeling_config.py
+++ b/src/arandu/shared/annotation/labeling_config.py
@@ -44,31 +44,65 @@ _SUMMARY_TITLE = "Cascata de pontuação (resumo)"
 #: judgment; and make the collapsed ruler summary secondary to it. Prose is
 #: capped at ~70 characters per line, which is where continuous reading stops
 #: costing extra eye travel.
+#:
+#: Theme-agnostic by construction. The first version hardcoded light-theme greys
+#: and went unreadable under Label Studio's dark theme, so no rule here may name
+#: a colour: text always inherits, emphasis is spent through ``opacity``, and
+#: every surface and rule is a translucent neutral that darkens a light
+#: background and lightens a dark one. A dark-mode override with hardcoded dark
+#: values would only move the same failure to the next palette change.
 _STYLE = """
     .emic-summary { margin: 0 0 14px; }
-    .emic-summary h4 { font-size: 0.95em; margin: 12px 0 4px; color: #3d3d3d; }
+    .emic-summary h4 { font-size: 0.95em; margin: 12px 0 4px; color: inherit; }
     .emic-summary h6 {
-      max-width: 70ch; font-size: 0.88em; font-weight: 400; color: #5c5c5c;
-      line-height: 1.5; margin: 0 0 6px;
+      max-width: 70ch; font-size: 0.88em; font-weight: 400; color: inherit;
+      line-height: 1.5; margin: 0 0 6px; opacity: 0.85;
     }
     .emic-pair {
-      border: 1px solid #d0d0d0; border-radius: 6px; background: #fafafa;
-      padding: 10px 14px; margin: 0 0 16px;
+      border: 1px solid rgba(128, 128, 128, 0.35); border-radius: 6px;
+      background: rgba(128, 128, 128, 0.08); padding: 10px 14px; margin: 0 0 16px;
     }
     .emic-pair h4 {
       font-size: 0.78em; text-transform: uppercase; letter-spacing: 0.05em;
-      color: #6b6b6b; margin: 10px 0 3px;
+      color: inherit; opacity: 0.75; margin: 10px 0 3px;
     }
     .emic-segment {
-      max-height: 260px; overflow-y: auto; background: #ffffff;
-      border: 1px solid #e4e4e4; border-radius: 4px; padding: 8px 10px;
-      line-height: 1.55;
+      max-height: 260px; overflow-y: auto;
+      border: 1px solid rgba(128, 128, 128, 0.3); border-radius: 4px;
+      padding: 8px 10px; line-height: 1.55;
     }
-    .emic-score h4 { font-size: 0.95em; margin: 12px 0 6px; color: #3d3d3d; }
+    .emic-score h4 { font-size: 0.95em; margin: 12px 0 6px; color: inherit; }
     .emic-score h6 {
-      max-width: 70ch; font-size: 0.88em; font-weight: 400; color: #5c5c5c;
-      line-height: 1.5; margin: 0 0 6px;
+      max-width: 70ch; font-size: 0.88em; font-weight: 400; color: inherit;
+      line-height: 1.5; margin: 0 0 6px; opacity: 0.85;
     }
+"""
+
+#: Wrapper class for the instructions modal, and the scope of every rule below.
+_INSTRUCTION_CLASS = "emic-instructions"
+
+#: Instructions-modal typography.
+#:
+#: Label Studio renders ``expert_instruction`` with its own tight modal defaults,
+#: which put headings flush against the preceding paragraph and turn the ruler
+#: into one undifferentiated block. Every rule is scoped to
+#: ``.emic-instructions`` so nothing leaks into the platform's own UI, and the
+#: same theme-agnostic constraint as ``_STYLE`` applies: no colour is named.
+#:
+#: The heading margins are deliberately asymmetric (much more space above than
+#: below) so a title binds to the section it opens, and each ``h2`` carries a
+#: translucent rule so the five major sections are separable at a glance.
+_INSTRUCTION_STYLE = """
+      .emic-instructions { max-width: 72ch; line-height: 1.6; color: inherit; }
+      .emic-instructions h1 { font-size: 1.5em; line-height: 1.3; margin: 0 0 0.9em; }
+      .emic-instructions h2 {
+        font-size: 1.18em; line-height: 1.3; margin: 2.4em 0 0.7em;
+        padding-top: 1.1em; border-top: 1px solid rgba(128, 128, 128, 0.3);
+      }
+      .emic-instructions h3 { font-size: 1em; line-height: 1.3; margin: 1.8em 0 0.5em; }
+      .emic-instructions p { margin: 0 0 0.9em; line-height: 1.6; }
+      .emic-instructions ul { margin: 0 0 1.1em; padding-left: 1.5em; list-style: disc; }
+      .emic-instructions li { margin: 0 0 0.45em; line-height: 1.55; }
 """
 
 
@@ -197,7 +231,14 @@ def render_labeling_config(ruler: dict[str, Any]) -> str:
         # "5 - Preserva o sentido, ...": the number the study records, next to the
         # anchor sentence the judge prompt puts beside the same number.
         option = f"{entry['score']} - {entry['label']}"
-        lines.append(f"      <Choice value={_attr(option)} />")
+        # The hotkey is pinned to the score, never left to position. Label Studio
+        # assigns hotkeys by position when the attribute is absent, and these
+        # options are ordered 5..1, so the defaults bound key 1 to score 5 and key
+        # 5 to score 1: an annotator pressing 5 for "preserves the meaning" silently
+        # recorded the most severe distortion, and the recorded value is a valid
+        # score, so the corruption is not detectable after the round.
+        hotkey = str(entry["score"])
+        lines.append(f"      <Choice value={_attr(option)} hotkey={_attr(hotkey)} />")
     lines.append("    </Choices>")
 
     lines += [
@@ -229,10 +270,14 @@ def render_expert_instruction(ruler: dict[str, Any]) -> str:
     ruler so the canvas does not have to: construct, scale, loss types,
     provisions, the full scoring guide, and the annotator-only calibration.
 
-    Plain semantic HTML with no styling and no external reference: it is
-    injected into a page whose CSS is Label Studio's, and a research instrument
-    must not depend on a resource that can move or disappear between the audit
-    and the annotation round.
+    Semantic HTML, self-contained, with no external reference: it is injected
+    into a page whose CSS is Label Studio's, and a research instrument must not
+    depend on a resource that can move or disappear between the audit and the
+    annotation round. Typography comes from a ``<style>`` block scoped to
+    ``.emic-instructions``, inlined in the fragment. Whether Label Studio's
+    sanitiser keeps that block is not knowable from here, so the markup is
+    written to read acceptably without it: every enumeration is a real ``<ul>``,
+    every section a real heading, and no meaning is carried by styling alone.
 
     Judge-only material is excluded here for the same reason it is excluded from
     the canvas.
@@ -251,7 +296,12 @@ def render_expert_instruction(ruler: dict[str, Any]) -> str:
     provisions = ruler["provisions"]
     guide = ruler["guide"]
 
-    lines: list[str] = [f"<h1>{escape(_HEADER)}</h1>", "<h2>O construto</h2>"]
+    lines: list[str] = [
+        f'<div class="{_INSTRUCTION_CLASS}">',
+        f"<style>{_INSTRUCTION_STYLE}</style>",
+        f"<h1>{escape(_HEADER)}</h1>",
+        "<h2>O construto</h2>",
+    ]
     lines += _html_paragraphs(
         [construct[key] for key in ("emic", "non_emic", "gradient", "question", "not_faithfulness")]
     )
@@ -278,4 +328,5 @@ def render_expert_instruction(ruler: dict[str, Any]) -> str:
     lines.append("<h2>Quando hesitar</h2>")
     lines += _html_paragraphs(list(ruler["annotator_only"].values()))
 
+    lines.append("</div>")
     return "\n".join(lines) + "\n"

--- a/src/arandu/shared/annotation/pull.py
+++ b/src/arandu/shared/annotation/pull.py
@@ -1,0 +1,284 @@
+"""Fetch annotations back and anonymize the annotators (spec §3.3, §8).
+
+Anonymity is structural here rather than by convention. Label Studio identifies
+users by email, but the export carries a numeric ``completed_by``, so this
+module maps that integer straight to ``A1``/``A2``/``A3`` and never requests an
+email from the API at all. The number-to-alias map is written beside the labels,
+not inside ``labels/``, so the directory that feeds the agreement analysis holds
+nothing identifying.
+
+An unknown ``task_id`` aborts the whole pull. A desynced manifest means the join
+is wrong, and silently dropping the row would leave a plausible-looking labels
+file that mislabels an unknown share of the sample.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING, Any
+
+from pydantic import BaseModel
+
+from arandu.shared.annotation.build import MANIFEST_FILENAME
+from arandu.shared.annotation.schemas import AnnotationLabel, AnnotationManifest
+from arandu.shared.config import ResultsConfig
+from arandu.shared.schemas import PipelineType
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from arandu.shared.annotation.client import LabelStudioClient
+
+logger = logging.getLogger(__name__)
+
+LABELS_DIRNAME = "labels"
+ANNOTATOR_MAP_FILENAME = "annotator_map.json"
+SCORE_FIELD = "score"
+RATIONALE_FIELD = "rationale"
+
+
+class PullSummary(BaseModel):
+    """Outcome of a pull.
+
+    Attributes:
+        project_id: Label Studio project the export came from; ``0`` for a
+            file-based pull.
+        annotators: Completed-annotation count per anonymous annotator id.
+        total_items: Tasks in the project (the denominator for progress).
+    """
+
+    project_id: int
+    annotators: dict[str, int]
+    total_items: int
+
+
+def anonymize(user_ids: list[int]) -> dict[int, str]:
+    """Map Label Studio user ids to stable anonymous aliases.
+
+    Sorted by user id so the mapping is deterministic and reproducible from the
+    export alone: the same project always yields the same ``A1``/``A2``/``A3``.
+
+    Args:
+        user_ids: Numeric Label Studio user ids, one per completed annotation.
+
+    Returns:
+        Mapping from each distinct user id to its anonymous alias.
+    """
+    return {user_id: f"A{rank}" for rank, user_id in enumerate(sorted(set(user_ids)), start=1)}
+
+
+def _completed_by_id(annotation: dict[str, Any]) -> int:
+    """Return the numeric user id, tolerating the expanded object form.
+
+    Some export shapes inline the user as an object. Only the ``id`` is read; the
+    email is deliberately ignored so it cannot reach any artifact.
+
+    Args:
+        annotation: One Label Studio annotation payload.
+
+    Returns:
+        The numeric ``completed_by`` user id.
+
+    Raises:
+        ValueError: If no numeric id can be found.
+    """
+    raw = annotation.get("completed_by")
+    if isinstance(raw, dict):
+        raw = raw.get("id")
+    if not isinstance(raw, int):
+        raise ValueError(
+            f"Annotation has no numeric completed_by: {raw!r}. Cannot attribute the label."
+        )
+    return raw
+
+
+def _extract_score(annotation: dict[str, Any]) -> int:
+    """Read the ordinal score out of the annotation result.
+
+    The option label is ``"<score> - <anchor>"``, so the score is the leading
+    integer. A label that does not parse is an error: guessing would silently
+    corrupt the measurement the whole study reports.
+
+    Args:
+        annotation: One Label Studio annotation payload.
+
+    Returns:
+        The ordinal emic-validity score, in ``1..5``.
+
+    Raises:
+        ValueError: If the annotation carries no score region, or the choice
+            label does not start with an integer.
+    """
+    for region in annotation.get("result", []):
+        if region.get("from_name") != SCORE_FIELD:
+            continue
+        choices = region.get("value", {}).get("choices") or []
+        if not choices:
+            break
+        head = str(choices[0]).split(" - ", maxsplit=1)[0].strip()
+        if not head.isdigit():
+            raise ValueError(
+                f"Could not read an ordinal score from the choice {choices[0]!r}. The "
+                f"labeling config and this parser have diverged."
+            )
+        return int(head)
+    raise ValueError(
+        f"Annotation carries no {SCORE_FIELD!r} region. The labeling config and this "
+        f"parser have diverged."
+    )
+
+
+def _extract_rationale(annotation: dict[str, Any]) -> str | None:
+    """Read the optional free-text justification, or ``None`` if absent.
+
+    Args:
+        annotation: One Label Studio annotation payload.
+
+    Returns:
+        The rationale text, or ``None`` if the annotator left it blank.
+    """
+    for region in annotation.get("result", []):
+        if region.get("from_name") != RATIONALE_FIELD:
+            continue
+        texts = region.get("value", {}).get("text") or []
+        if texts and str(texts[0]).strip():
+            return str(texts[0])
+    return None
+
+
+def _load_export(
+    manifest: AnnotationManifest,
+    client: LabelStudioClient | None,
+    export_file: Path | None,
+    pipeline_id: str,
+) -> tuple[list[dict[str, Any]], int]:
+    """Return the export payload and the project id it came from.
+
+    Args:
+        manifest: The build's manifest, used to find the pushed project id.
+        client: Label Studio transport. Ignored when ``export_file`` is given.
+        export_file: A JSON export downloaded from the UI, if given.
+        pipeline_id: Run identifier, used only for error messages.
+
+    Returns:
+        A tuple of the raw export payload and the project id it came from
+        (``0`` for a file-based pull).
+
+    Raises:
+        ValueError: If neither a client nor a file is given, if the file is
+            not a JSON list, or if the run was never pushed.
+    """
+    if export_file is not None:
+        data = json.loads(export_file.read_text(encoding="utf-8"))
+        if not isinstance(data, list):
+            raise ValueError(f"{export_file} is not a Label Studio JSON export (expected a list).")
+        return data, 0
+    if client is None:
+        raise ValueError("Pass either a client or export_file; there is nothing to read from.")
+    if manifest.project_id is None:
+        raise ValueError(
+            f"Run {pipeline_id!r} has no Label Studio project. Run "
+            f"`arandu emic-annotation-push --id {pipeline_id}` first, or pass a downloaded "
+            f"export with -f."
+        )
+    return client.export_annotations(manifest.project_id), manifest.project_id
+
+
+def run_pull_annotation(
+    pipeline_id: str,
+    *,
+    client: LabelStudioClient | None = None,
+    export_file: Path | None = None,
+    base_dir: Path | None = None,
+) -> PullSummary:
+    """Pull annotations into per-annotator label files.
+
+    Args:
+        pipeline_id: Run identifier with a built (and usually pushed) stage.
+        client: Label Studio transport. Ignored when ``export_file`` is given.
+        export_file: A JSON export downloaded from the UI. Reading it touches no
+            network and needs no credential.
+        base_dir: Override the project ``results/`` root.
+
+    Returns:
+        A :class:`PullSummary` with per-annotator completion counts.
+
+    Raises:
+        FileNotFoundError: If the annotation stage was never built.
+        ValueError: If the run was never pushed, no source was given, or a
+            score cannot be parsed.
+        KeyError: If the export references a task this build does not know. The
+            manifest and the project are out of sync and no label from that
+            project can be trusted.
+    """
+    base = base_dir if base_dir is not None else ResultsConfig().base_dir
+    outputs = base / pipeline_id / PipelineType.ANNOTATION.value / "outputs"
+    manifest_path = outputs / MANIFEST_FILENAME
+    if not manifest_path.exists():
+        raise FileNotFoundError(
+            f"Annotation manifest not found for pipeline_id {pipeline_id!r}: {manifest_path}. "
+            f"Run `arandu emic-annotation-build --id {pipeline_id} --seed <n>` first."
+        )
+
+    manifest = AnnotationManifest.load(manifest_path)
+    export, project_id = _load_export(manifest, client, export_file, pipeline_id)
+
+    # Resolve every task_id before writing anything: a desync must not leave a
+    # half-written labels directory behind.
+    pending: list[tuple[int, AnnotationLabel]] = []
+    user_ids: list[int] = []
+    for task in export:
+        task_id = task.get("data", {}).get("task_id")
+        if not isinstance(task_id, int):
+            raise ValueError(f"Export task {task.get('id')!r} carries no integer task_id.")
+        pair_id = manifest.pair_id_for(task_id)
+        for annotation in task.get("annotations", []):
+            user_id = _completed_by_id(annotation)
+            user_ids.append(user_id)
+            pending.append(
+                (
+                    user_id,
+                    AnnotationLabel(
+                        pair_id=pair_id,
+                        annotator_id="",  # filled once the alias map is known
+                        score=_extract_score(annotation),
+                        rationale=_extract_rationale(annotation),
+                        timestamp=str(annotation.get("created_at", "")),
+                    ),
+                )
+            )
+
+    aliases = anonymize(user_ids)
+    by_annotator: dict[str, list[AnnotationLabel]] = {}
+    for user_id, label in pending:
+        alias = aliases[user_id]
+        by_annotator.setdefault(alias, []).append(label.model_copy(update={"annotator_id": alias}))
+
+    labels_dir = outputs / LABELS_DIRNAME
+    labels_dir.mkdir(parents=True, exist_ok=True)
+    for alias, labels in sorted(by_annotator.items()):
+        with (labels_dir / f"{alias}.jsonl").open("w", encoding="utf-8") as fh:
+            for label in sorted(labels, key=lambda item: item.pair_id):
+                fh.write(label.model_dump_json())
+                fh.write("\n")
+
+    # Beside the labels, never inside: `labels/` is what feeds the agreement
+    # analysis and must hold nothing that links an alias to a person.
+    (outputs / ANNOTATOR_MAP_FILENAME).write_text(
+        json.dumps({str(uid): alias for uid, alias in sorted(aliases.items())}, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+    summary = PullSummary(
+        project_id=project_id,
+        annotators={alias: len(labels) for alias, labels in sorted(by_annotator.items())},
+        total_items=manifest.total_items,
+    )
+    logger.info(
+        "Pulled annotations for %s: %s of %d task(s) per annotator.",
+        pipeline_id,
+        summary.annotators,
+        summary.total_items,
+    )
+    return summary

--- a/src/arandu/shared/annotation/pull.py
+++ b/src/arandu/shared/annotation/pull.py
@@ -60,15 +60,19 @@ class PullSummary(BaseModel):
         annotators: Completed-annotation count per anonymous annotator id.
         total_items: Tasks in the project (the denominator for progress).
         skipped: Annotations the annotator cancelled (Label Studio's Skip
-            button) or left with no regions. They carry no rating, so they are
+            button) or left with no rating. They carry no score, so they are
             counted here instead of silently vanishing from the progress
             numbers.
+        stale_removed: Label files left by an earlier pull that this pull did
+            not rewrite, and deleted. Reported rather than done silently: a
+            file that vanishes is a fact the operator has to see.
     """
 
     project_id: int
     annotators: dict[str, int]
     total_items: int
     skipped: int = 0
+    stale_removed: int = 0
 
 
 def _alias_rank(alias: str) -> int:
@@ -166,13 +170,25 @@ def _is_unrated(annotation: dict[str, Any]) -> bool:
     irrecoverable without reconvening the annotators, and a permanent parse
     failure would block every other annotator's ratings too.
 
+    An annotation with regions but no ``score`` region at all is the same case.
+    ``required="true"`` on the Choices widget is enforced client-side only, and
+    annotations can also arrive through the API, so an annotation carrying just
+    the rationale is reachable. Aborting the whole pull over one of those is the
+    exact blast radius the skip handling exists to eliminate. A ``score`` region
+    that IS present but empty stays fatal: that is the measurement going
+    missing, not a task nobody rated.
+
     Args:
         annotation: One Label Studio annotation payload.
 
     Returns:
-        ``True`` if the annotation was cancelled or holds no regions.
+        ``True`` if the annotation was cancelled, holds no regions, or holds no
+        ``score`` region.
     """
-    return bool(annotation.get("was_cancelled")) or not annotation.get("result")
+    if annotation.get("was_cancelled"):
+        return True
+    regions = annotation.get("result") or []
+    return not any(region.get("from_name") == SCORE_FIELD for region in regions)
 
 
 def _extract_score(annotation: dict[str, Any]) -> int:
@@ -296,11 +312,23 @@ def _load_export(
         (``0`` for a file-based pull).
 
     Raises:
-        ValueError: If neither a client nor a file is given, if the file is not
-            a JSON list, if the run was never pushed, or if several projects
-            are recorded and none was named.
+        ValueError: If both a file and a project id are given, if neither a
+            client nor a file is given, if the file is not a JSON list, if the
+            run was never pushed, or if several projects are recorded and none
+            was named.
     """
     if export_file is not None:
+        # The two name different sources. Reading the file and discarding the
+        # operator's project choice would report project_id 0 for labels they
+        # believe came from project 99, and the feature already treats an
+        # ambiguous project selection as unsafe enough to hard-fail on.
+        if project_id is not None:
+            raise ValueError(
+                f"-f {export_file} and --project-id {project_id} select different sources: the "
+                f"file is read from disk and the project id is only used for a network export. "
+                f"Drop one of them: pass -f alone to read the downloaded file, or --project-id "
+                f"alone to export project {project_id} over the network."
+            )
         data = json.loads(export_file.read_text(encoding="utf-8"))
         if not isinstance(data, list):
             raise ValueError(f"{export_file} is not a Label Studio JSON export (expected a list).")
@@ -321,6 +349,11 @@ def run_pull_annotation(
 ) -> PullSummary:
     """Pull annotations into per-annotator label files.
 
+    ``labels/`` is left reflecting exactly this pull: any ``*.jsonl`` an earlier
+    pull wrote that this one did not rewrite is deleted and counted in
+    :attr:`PullSummary.stale_removed`. Keeping it would let the agreement
+    analysis read a mix of two pulls while the summary reports only one.
+
     Args:
         pipeline_id: Run identifier with a built (and usually pushed) stage.
         client: Label Studio transport. Ignored when ``export_file`` is given.
@@ -336,8 +369,9 @@ def run_pull_annotation(
     Raises:
         FileNotFoundError: If the annotation stage was never built.
         ValueError: If the run was never pushed, several projects are recorded
-            and none was named, no source was given, a score cannot be parsed,
-            or one annotator rated the same pair twice.
+            and none was named, both ``export_file`` and ``project_id`` were
+            given, no source was given, a score cannot be parsed, or one
+            annotator rated the same pair twice.
         KeyError: If the export references a task this build does not know. The
             manifest and the project are out of sync and no label from that
             project can be trusted.
@@ -404,6 +438,18 @@ def run_pull_annotation(
 
     labels_dir = outputs / LABELS_DIRNAME
     labels_dir.mkdir(parents=True, exist_ok=True)
+
+    # `labels/` reflects exactly one pull. A narrower export (a partial `-f`
+    # file, or another --project-id) would otherwise leave the previous pull's
+    # files in place, and the agreement analysis would read a mix of two pulls
+    # while the summary below reports only what this one wrote. Only `*.jsonl`
+    # is touched, and `annotator_map.json` lives one level up, outside this
+    # directory, so the alias bindings survive.
+    written = {f"{alias}.jsonl" for alias in by_annotator}
+    stale = [path for path in sorted(labels_dir.glob("*.jsonl")) if path.name not in written]
+    for path in stale:
+        path.unlink()
+
     for alias, labels in sorted(by_annotator.items()):
         with (labels_dir / f"{alias}.jsonl").open("w", encoding="utf-8") as fh:
             for label in sorted(labels, key=lambda item: item.pair_id):
@@ -422,12 +468,15 @@ def run_pull_annotation(
         annotators={alias: len(labels) for alias, labels in sorted(by_annotator.items())},
         total_items=manifest.total_items,
         skipped=skipped,
+        stale_removed=len(stale),
     )
     logger.info(
-        "Pulled annotations for %s: %s of %d task(s) per annotator, %d skipped.",
+        "Pulled annotations for %s: %s of %d task(s) per annotator, %d skipped, "
+        "%d stale label file(s) removed.",
         pipeline_id,
         summary.annotators,
         summary.total_items,
         summary.skipped,
+        summary.stale_removed,
     )
     return summary

--- a/src/arandu/shared/annotation/pull.py
+++ b/src/arandu/shared/annotation/pull.py
@@ -7,9 +7,15 @@ email from the API at all. The number-to-alias map is written beside the labels,
 not inside ``labels/``, so the directory that feeds the agreement analysis holds
 nothing identifying.
 
+Aliases are anchored, not recomputed: an existing ``annotator_map.json`` is read
+back and every binding in it preserved, so a progress pull run week after week
+keeps ``A1`` pointing at the same person as somebody submits their first rating.
+
 An unknown ``task_id`` aborts the whole pull. A desynced manifest means the join
 is wrong, and silently dropping the row would leave a plausible-looking labels
-file that mislabels an unknown share of the sample.
+file that mislabels an unknown share of the sample. A cancelled annotation is
+the opposite case: nobody rated that task yet, so it is counted and skipped
+rather than treated as a broken export.
 """
 
 from __future__ import annotations
@@ -20,7 +26,7 @@ from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel
 
-from arandu.shared.annotation.build import MANIFEST_FILENAME
+from arandu.shared.annotation.build import LABELS_DIRNAME, MANIFEST_FILENAME
 from arandu.shared.annotation.schemas import AnnotationLabel, AnnotationManifest
 from arandu.shared.config import ResultsConfig
 from arandu.shared.schemas import PipelineType
@@ -32,7 +38,14 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-LABELS_DIRNAME = "labels"
+__all__ = [
+    "ANNOTATOR_MAP_FILENAME",
+    "LABELS_DIRNAME",
+    "PullSummary",
+    "anonymize",
+    "run_pull_annotation",
+]
+
 ANNOTATOR_MAP_FILENAME = "annotator_map.json"
 SCORE_FIELD = "score"
 RATIONALE_FIELD = "rationale"
@@ -46,26 +59,77 @@ class PullSummary(BaseModel):
             file-based pull.
         annotators: Completed-annotation count per anonymous annotator id.
         total_items: Tasks in the project (the denominator for progress).
+        skipped: Annotations the annotator cancelled (Label Studio's Skip
+            button) or left with no regions. They carry no rating, so they are
+            counted here instead of silently vanishing from the progress
+            numbers.
     """
 
     project_id: int
     annotators: dict[str, int]
     total_items: int
+    skipped: int = 0
 
 
-def anonymize(user_ids: list[int]) -> dict[int, str]:
+def _alias_rank(alias: str) -> int:
+    """Return the numeric rank in an ``A<n>`` alias, or ``0`` if unparseable."""
+    tail = alias[1:]
+    return int(tail) if alias.startswith("A") and tail.isdigit() else 0
+
+
+def anonymize(user_ids: list[int], existing: dict[int, str] | None = None) -> dict[int, str]:
     """Map Label Studio user ids to stable anonymous aliases.
 
-    Sorted by user id so the mapping is deterministic and reproducible from the
-    export alone: the same project always yields the same ``A1``/``A2``/``A3``.
+    ``existing`` is preserved verbatim: an alias, once written, belongs to that
+    user id forever. Ranking over only the ids present in one export would
+    reassign aliases whenever somebody submits their first rating, and a later
+    pull would rewrite ``A1.jsonl`` with a different person's labels. Ids not
+    already bound are appended in sorted order, so a pull with no prior map is
+    still fully determined by the export.
 
     Args:
         user_ids: Numeric Label Studio user ids, one per completed annotation.
+        existing: Bindings recorded by an earlier pull, if any.
 
     Returns:
-        Mapping from each distinct user id to its anonymous alias.
+        Mapping from each distinct user id to its anonymous alias, containing
+        every binding in ``existing`` plus one per newly seen user id.
     """
-    return {user_id: f"A{rank}" for rank, user_id in enumerate(sorted(set(user_ids)), start=1)}
+    aliases = dict(existing or {})
+    next_rank = max((_alias_rank(alias) for alias in aliases.values()), default=0) + 1
+    for user_id in sorted(set(user_ids) - set(aliases)):
+        aliases[user_id] = f"A{next_rank}"
+        next_rank += 1
+    return aliases
+
+
+def _load_annotator_map(path: Path) -> dict[int, str]:
+    """Read a previously written ``annotator_map.json``, or ``{}`` if absent.
+
+    Args:
+        path: Location of the map written beside ``labels/``.
+
+    Returns:
+        The recorded id-to-alias bindings, with the JSON string keys parsed back
+        to ints.
+
+    Raises:
+        ValueError: If the file exists but is not an object of id-to-alias
+            entries. Guessing here would break the stability it exists to
+            provide.
+    """
+    if not path.exists():
+        return {}
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} is not a JSON object of user id to alias entries.")
+    try:
+        return {int(key): str(value) for key, value in data.items()}
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"{path} carries a non-integer user id key; the alias map is unusable and the "
+            f"aliases it pins cannot be preserved."
+        ) from exc
 
 
 def _completed_by_id(annotation: dict[str, Any]) -> int:
@@ -93,12 +157,31 @@ def _completed_by_id(annotation: dict[str, Any]) -> int:
     return raw
 
 
+def _is_unrated(annotation: dict[str, Any]) -> bool:
+    """Return whether the annotation carries no rating at all.
+
+    Label Studio's Skip button is on by default and writes a real annotation
+    with ``was_cancelled: true`` and an empty ``result``. That is a task nobody
+    rated, not a broken export, so it must not abort the pull: the labels are
+    irrecoverable without reconvening the annotators, and a permanent parse
+    failure would block every other annotator's ratings too.
+
+    Args:
+        annotation: One Label Studio annotation payload.
+
+    Returns:
+        ``True`` if the annotation was cancelled or holds no regions.
+    """
+    return bool(annotation.get("was_cancelled")) or not annotation.get("result")
+
+
 def _extract_score(annotation: dict[str, Any]) -> int:
     """Read the ordinal score out of the annotation result.
 
     The option label is ``"<score> - <anchor>"``, so the score is the leading
     integer. A label that does not parse is an error: guessing would silently
-    corrupt the measurement the whole study reports.
+    corrupt the measurement the whole study reports. Callers must filter
+    unrated annotations with :func:`_is_unrated` first.
 
     Args:
         annotation: One Label Studio annotation payload.
@@ -107,15 +190,19 @@ def _extract_score(annotation: dict[str, Any]) -> int:
         The ordinal emic-validity score, in ``1..5``.
 
     Raises:
-        ValueError: If the annotation carries no score region, or the choice
-            label does not start with an integer.
+        ValueError: If the annotation carries no score region, if the region is
+            present but empty, or if the choice label does not start with an
+            integer.
     """
     for region in annotation.get("result", []):
         if region.get("from_name") != SCORE_FIELD:
             continue
         choices = region.get("value", {}).get("choices") or []
         if not choices:
-            break
+            raise ValueError(
+                f"The {SCORE_FIELD!r} region is present but carries no choice. The labeling "
+                f"config and this parser have diverged."
+            )
         head = str(choices[0]).split(" - ", maxsplit=1)[0].strip()
         if not head.isdigit():
             raise ValueError(
@@ -147,11 +234,53 @@ def _extract_rationale(annotation: dict[str, Any]) -> str | None:
     return None
 
 
+def _resolve_project_id(
+    manifest: AnnotationManifest, project_id: int | None, pipeline_id: str
+) -> int:
+    """Pick the project to export from, refusing to guess between several.
+
+    A ``--force`` re-push leaves more than one live project recorded, and each
+    may hold real ratings. Pulling the newest would silently discard the older
+    project's labels; merging both would double-count anyone who annotated in
+    each. Neither has a safe default, so the operator chooses.
+
+    Args:
+        manifest: The build's manifest, holding every recorded project id.
+        project_id: Operator's explicit choice, if given.
+        pipeline_id: Run identifier, used only for error messages.
+
+    Returns:
+        The project id to export from.
+
+    Raises:
+        ValueError: If the run was never pushed, or if several projects are
+            recorded and none was named.
+    """
+    if project_id is not None:
+        return project_id
+    if manifest.project_id is None:
+        raise ValueError(
+            f"Run {pipeline_id!r} has no Label Studio project. Run "
+            f"`arandu emic-annotation-push --id {pipeline_id}` first, or pass a downloaded "
+            f"export with -f."
+        )
+    if len(manifest.project_ids) > 1:
+        recorded = ", ".join(str(pid) for pid in manifest.project_ids)
+        raise ValueError(
+            f"Run {pipeline_id!r} has more than one Label Studio project recorded: {recorded}. "
+            f"Each may hold real ratings, so pulling one of them silently would lose the "
+            f"others' labels and merging them would double-count anyone who annotated in "
+            f"more than one. Re-run with `--project-id <n>` naming the project to pull."
+        )
+    return manifest.project_id
+
+
 def _load_export(
     manifest: AnnotationManifest,
     client: LabelStudioClient | None,
     export_file: Path | None,
     pipeline_id: str,
+    project_id: int | None,
 ) -> tuple[list[dict[str, Any]], int]:
     """Return the export payload and the project id it came from.
 
@@ -160,14 +289,16 @@ def _load_export(
         client: Label Studio transport. Ignored when ``export_file`` is given.
         export_file: A JSON export downloaded from the UI, if given.
         pipeline_id: Run identifier, used only for error messages.
+        project_id: Explicit project to export from, overriding the manifest.
 
     Returns:
         A tuple of the raw export payload and the project id it came from
         (``0`` for a file-based pull).
 
     Raises:
-        ValueError: If neither a client nor a file is given, if the file is
-            not a JSON list, or if the run was never pushed.
+        ValueError: If neither a client nor a file is given, if the file is not
+            a JSON list, if the run was never pushed, or if several projects
+            are recorded and none was named.
     """
     if export_file is not None:
         data = json.loads(export_file.read_text(encoding="utf-8"))
@@ -176,13 +307,8 @@ def _load_export(
         return data, 0
     if client is None:
         raise ValueError("Pass either a client or export_file; there is nothing to read from.")
-    if manifest.project_id is None:
-        raise ValueError(
-            f"Run {pipeline_id!r} has no Label Studio project. Run "
-            f"`arandu emic-annotation-push --id {pipeline_id}` first, or pass a downloaded "
-            f"export with -f."
-        )
-    return client.export_annotations(manifest.project_id), manifest.project_id
+    resolved = _resolve_project_id(manifest, project_id, pipeline_id)
+    return client.export_annotations(resolved), resolved
 
 
 def run_pull_annotation(
@@ -191,6 +317,7 @@ def run_pull_annotation(
     client: LabelStudioClient | None = None,
     export_file: Path | None = None,
     base_dir: Path | None = None,
+    project_id: int | None = None,
 ) -> PullSummary:
     """Pull annotations into per-annotator label files.
 
@@ -200,14 +327,17 @@ def run_pull_annotation(
         export_file: A JSON export downloaded from the UI. Reading it touches no
             network and needs no credential.
         base_dir: Override the project ``results/`` root.
+        project_id: Project to export from, required when a ``--force`` re-push
+            left more than one recorded.
 
     Returns:
         A :class:`PullSummary` with per-annotator completion counts.
 
     Raises:
         FileNotFoundError: If the annotation stage was never built.
-        ValueError: If the run was never pushed, no source was given, or a
-            score cannot be parsed.
+        ValueError: If the run was never pushed, several projects are recorded
+            and none was named, no source was given, a score cannot be parsed,
+            or one annotator rated the same pair twice.
         KeyError: If the export references a task this build does not know. The
             manifest and the project are out of sync and no label from that
             project can be trusted.
@@ -222,18 +352,26 @@ def run_pull_annotation(
         )
 
     manifest = AnnotationManifest.load(manifest_path)
-    export, project_id = _load_export(manifest, client, export_file, pipeline_id)
+    export, source_project_id = _load_export(manifest, client, export_file, pipeline_id, project_id)
 
     # Resolve every task_id before writing anything: a desync must not leave a
     # half-written labels directory behind.
     pending: list[tuple[int, AnnotationLabel]] = []
     user_ids: list[int] = []
+    skipped = 0
     for task in export:
         task_id = task.get("data", {}).get("task_id")
         if not isinstance(task_id, int):
-            raise ValueError(f"Export task {task.get('id')!r} carries no integer task_id.")
+            raise ValueError(
+                f"Export task {task.get('id')!r} carries no integer task_id. This looks like a "
+                f"JSON_MIN export, which drops the task data the join needs; download the "
+                f"export with exportType=JSON instead."
+            )
         pair_id = manifest.pair_id_for(task_id)
         for annotation in task.get("annotations", []):
+            if _is_unrated(annotation):
+                skipped += 1
+                continue
             user_id = _completed_by_id(annotation)
             user_ids.append(user_id)
             pending.append(
@@ -249,10 +387,19 @@ def run_pull_annotation(
                 )
             )
 
-    aliases = anonymize(user_ids)
+    map_path = outputs / ANNOTATOR_MAP_FILENAME
+    aliases = anonymize(user_ids, _load_annotator_map(map_path))
     by_annotator: dict[str, list[AnnotationLabel]] = {}
+    seen: set[tuple[str, str]] = set()
     for user_id, label in pending:
         alias = aliases[user_id]
+        if (alias, label.pair_id) in seen:
+            raise ValueError(
+                f"Annotator {alias} rated pair {label.pair_id!r} more than once. Two ratings "
+                f"of the same pair by the same person cannot both be the measurement; resolve "
+                f"the duplicate annotation in Label Studio before pulling."
+            )
+        seen.add((alias, label.pair_id))
         by_annotator.setdefault(alias, []).append(label.model_copy(update={"annotator_id": alias}))
 
     labels_dir = outputs / LABELS_DIRNAME
@@ -265,20 +412,22 @@ def run_pull_annotation(
 
     # Beside the labels, never inside: `labels/` is what feeds the agreement
     # analysis and must hold nothing that links an alias to a person.
-    (outputs / ANNOTATOR_MAP_FILENAME).write_text(
+    map_path.write_text(
         json.dumps({str(uid): alias for uid, alias in sorted(aliases.items())}, indent=2) + "\n",
         encoding="utf-8",
     )
 
     summary = PullSummary(
-        project_id=project_id,
+        project_id=source_project_id,
         annotators={alias: len(labels) for alias, labels in sorted(by_annotator.items())},
         total_items=manifest.total_items,
+        skipped=skipped,
     )
     logger.info(
-        "Pulled annotations for %s: %s of %d task(s) per annotator.",
+        "Pulled annotations for %s: %s of %d task(s) per annotator, %d skipped.",
         pipeline_id,
         summary.annotators,
         summary.total_items,
+        summary.skipped,
     )
     return summary

--- a/src/arandu/shared/annotation/push.py
+++ b/src/arandu/shared/annotation/push.py
@@ -78,7 +78,7 @@ def run_push_annotation(
         FileNotFoundError: If the build artifacts are absent.
         ValueError: If a project already exists and ``force`` is false, if the
             task count disagrees with the manifest, or if Label Studio accepted
-            fewer tasks than were sent.
+            fewer tasks than were sent or reported no count at all.
         LabelStudioError: On any API failure.
     """
     base = base_dir if base_dir is not None else ResultsConfig().base_dir
@@ -132,6 +132,17 @@ def run_push_annotation(
     manifest.save(manifest_path)
 
     imported = client.import_tasks(project_id, tasks)
+    if imported is None:
+        raise ValueError(
+            f"Label Studio accepted the import into project {project_id} but reported no task "
+            f"count, so nothing here can tell whether all {len(tasks)} tasks landed. A missing "
+            f"task is indistinguishable from an unrated pair in every later pull, which is why "
+            f"this is not read as success. Open project {project_id} and compare its task count "
+            f"with {len(tasks)}: if it matches, the manifest already records the project, so "
+            f"leave it alone and invite the annotators; if it is short, import the remainder "
+            f"into the same project from the UI. Re-pushing with --force appends a second id "
+            f"and makes every later pull need `--project-id <n>`."
+        )
     if imported != len(tasks):
         raise ValueError(
             f"Label Studio accepted {imported} of the {len(tasks)} tasks sent to project "

--- a/src/arandu/shared/annotation/push.py
+++ b/src/arandu/shared/annotation/push.py
@@ -11,7 +11,12 @@ import json
 import logging
 from typing import TYPE_CHECKING, Any
 
-from arandu.shared.annotation.build import CONFIG_FILENAME, MANIFEST_FILENAME, TASKS_FILENAME
+from arandu.shared.annotation.build import (
+    CONFIG_FILENAME,
+    INSTRUCTION_FILENAME,
+    MANIFEST_FILENAME,
+    TASKS_FILENAME,
+)
 from arandu.shared.annotation.schemas import AnnotationManifest
 from arandu.shared.config import ResultsConfig
 from arandu.shared.schemas import PipelineType
@@ -33,7 +38,14 @@ logger = logging.getLogger(__name__)
 #: but occupies the slot of one. ``required="true"`` on the Choices widget blocks
 #: Submit, not Skip. ``pull`` still tolerates cancelled annotations, since a
 #: project created by hand in the UI does not go through this call.
-PROJECT_SETTINGS: dict[str, Any] = {"show_skip_button": False}
+#:
+#: ``show_instruction`` turns on the help button that opens the project's
+#: ``expert_instruction`` modal. The full ruler lives there rather than on the
+#: labeling canvas: rendered inline it put two screens of prose between the pair
+#: and the rating widget. The HTML itself is not in this mapping, because push
+#: transports only what the build wrote; it is read from
+#: ``expert_instruction.html`` and merged in at call time.
+PROJECT_SETTINGS: dict[str, Any] = {"show_skip_button": False, "show_instruction": True}
 
 
 def _outputs_dir(base: Path, pipeline_id: str) -> Path:
@@ -73,8 +85,14 @@ def run_push_annotation(
     outputs = _outputs_dir(base, pipeline_id)
     manifest_path = outputs / MANIFEST_FILENAME
     config_path = outputs / CONFIG_FILENAME
+    instruction_path = outputs / INSTRUCTION_FILENAME
     tasks_path = outputs / TASKS_FILENAME
-    if not (manifest_path.exists() and config_path.exists() and tasks_path.exists()):
+    if not (
+        manifest_path.exists()
+        and config_path.exists()
+        and instruction_path.exists()
+        and tasks_path.exists()
+    ):
         raise FileNotFoundError(
             f"Annotation artifacts not found for pipeline_id {pipeline_id!r}: {outputs}. "
             f"Run `arandu emic-annotation-build --id {pipeline_id} --seed <n>` first."
@@ -96,8 +114,12 @@ def run_push_annotation(
         )
 
     project_title = title or f"Validade êmica ({pipeline_id})"
+    settings: dict[str, Any] = {
+        **PROJECT_SETTINGS,
+        "expert_instruction": instruction_path.read_text(encoding="utf-8"),
+    }
     project_id = client.create_project(
-        project_title, config_path.read_text(encoding="utf-8"), settings=PROJECT_SETTINGS
+        project_title, config_path.read_text(encoding="utf-8"), settings=settings
     )
 
     # Record the project before importing, not after. If the import times out

--- a/src/arandu/shared/annotation/push.py
+++ b/src/arandu/shared/annotation/push.py
@@ -1,0 +1,96 @@
+"""Create the Label Studio project from the built artifacts (spec §3.2).
+
+The build is the auditable artifact; this step only transports it. Nothing is
+computed here that the build did not already write to disk, so what the
+annotators see is exactly what an auditor reviewed.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING, Any
+
+from arandu.shared.annotation.build import CONFIG_FILENAME, MANIFEST_FILENAME, TASKS_FILENAME
+from arandu.shared.annotation.schemas import AnnotationManifest
+from arandu.shared.config import ResultsConfig
+from arandu.shared.schemas import PipelineType
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from arandu.shared.annotation.client import LabelStudioClient
+
+logger = logging.getLogger(__name__)
+
+
+def _outputs_dir(base: Path, pipeline_id: str) -> Path:
+    """Return the annotation stage's outputs directory for ``pipeline_id``."""
+    return base / pipeline_id / PipelineType.ANNOTATION.value / "outputs"
+
+
+def run_push_annotation(
+    pipeline_id: str,
+    *,
+    client: LabelStudioClient,
+    base_dir: Path | None = None,
+    title: str | None = None,
+    force: bool = False,
+) -> int:
+    """Create the annotation project and import its tasks.
+
+    Args:
+        pipeline_id: Run identifier. The ``annotation`` stage must be built.
+        client: Label Studio transport.
+        base_dir: Override the project ``results/`` root.
+        title: Project title. Defaults to one naming the run.
+        force: Create a second project even though one is recorded. Both ids are
+            kept in ``project_ids`` so a duplicate is a recorded fact.
+
+    Returns:
+        The created project id.
+
+    Raises:
+        FileNotFoundError: If the build artifacts are absent.
+        ValueError: If a project already exists and ``force`` is false, or the
+            task count disagrees with the manifest.
+        LabelStudioError: On any API failure.
+    """
+    base = base_dir if base_dir is not None else ResultsConfig().base_dir
+    outputs = _outputs_dir(base, pipeline_id)
+    manifest_path = outputs / MANIFEST_FILENAME
+    config_path = outputs / CONFIG_FILENAME
+    tasks_path = outputs / TASKS_FILENAME
+    if not (manifest_path.exists() and config_path.exists() and tasks_path.exists()):
+        raise FileNotFoundError(
+            f"Annotation artifacts not found for pipeline_id {pipeline_id!r}: {outputs}. "
+            f"Run `arandu emic-annotation-build --id {pipeline_id} --seed <n>` first."
+        )
+
+    manifest = AnnotationManifest.load(manifest_path)
+    if manifest.project_id is not None and not force:
+        raise ValueError(
+            f"Run {pipeline_id!r} is already pushed as Label Studio project "
+            f"{manifest.project_id}. Pushing again would create a duplicate project and "
+            f"split the annotators across two. Use --force only if that is intended."
+        )
+
+    tasks: list[dict[str, Any]] = json.loads(tasks_path.read_text(encoding="utf-8"))
+    if len(tasks) != manifest.total_items:
+        raise ValueError(
+            f"{TASKS_FILENAME} holds {len(tasks)} tasks but the manifest declares "
+            f"{manifest.total_items}. The build is inconsistent; rebuild before pushing."
+        )
+
+    project_title = title or f"Validade êmica ({pipeline_id})"
+    project_id = client.create_project(project_title, config_path.read_text(encoding="utf-8"))
+    imported = client.import_tasks(project_id, tasks)
+
+    manifest.project_id = project_id
+    manifest.project_ids = [*manifest.project_ids, project_id]
+    manifest.save(manifest_path)
+
+    logger.info(
+        "Pushed %d task(s) to Label Studio project %d (%s).", imported, project_id, project_title
+    )
+    return project_id

--- a/src/arandu/shared/annotation/push.py
+++ b/src/arandu/shared/annotation/push.py
@@ -23,6 +23,18 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+#: Project settings posted with the create call.
+#:
+#: ``show_skip_button`` is a Label Studio ``Project`` boolean field (default
+#: ``True``, "Show a skip button in interface and allow annotators to skip the
+#: task") and is listed in ``ProjectSerializer.Meta.fields``, so it can be set at
+#: creation time. It is turned off because a skip writes an annotation with
+#: ``was_cancelled: true`` and an empty ``result``: a rating that does not exist
+#: but occupies the slot of one. ``required="true"`` on the Choices widget blocks
+#: Submit, not Skip. ``pull`` still tolerates cancelled annotations, since a
+#: project created by hand in the UI does not go through this call.
+PROJECT_SETTINGS: dict[str, Any] = {"show_skip_button": False}
+
 
 def _outputs_dir(base: Path, pipeline_id: str) -> Path:
     """Return the annotation stage's outputs directory for ``pipeline_id``."""
@@ -52,8 +64,9 @@ def run_push_annotation(
 
     Raises:
         FileNotFoundError: If the build artifacts are absent.
-        ValueError: If a project already exists and ``force`` is false, or the
-            task count disagrees with the manifest.
+        ValueError: If a project already exists and ``force`` is false, if the
+            task count disagrees with the manifest, or if Label Studio accepted
+            fewer tasks than were sent.
         LabelStudioError: On any API failure.
     """
     base = base_dir if base_dir is not None else ResultsConfig().base_dir
@@ -83,12 +96,27 @@ def run_push_annotation(
         )
 
     project_title = title or f"Validade êmica ({pipeline_id})"
-    project_id = client.create_project(project_title, config_path.read_text(encoding="utf-8"))
-    imported = client.import_tasks(project_id, tasks)
+    project_id = client.create_project(
+        project_title, config_path.read_text(encoding="utf-8"), settings=PROJECT_SETTINGS
+    )
 
+    # Record the project before importing, not after. If the import times out
+    # while the server has already accepted the tasks, an unrecorded id would
+    # leave the duplicate guard silent and the next run would create a second
+    # live project: exactly the split the guard exists to prevent. A recorded id
+    # with a failed import is the safe direction, since it is recoverable.
     manifest.project_id = project_id
     manifest.project_ids = [*manifest.project_ids, project_id]
     manifest.save(manifest_path)
+
+    imported = client.import_tasks(project_id, tasks)
+    if imported != len(tasks):
+        raise ValueError(
+            f"Label Studio accepted {imported} of the {len(tasks)} tasks sent to project "
+            f"{project_id}. The missing tasks would be indistinguishable from unrated ones "
+            f"in every pull. Inspect the project and re-import the remainder, or delete it "
+            f"and push a fresh run."
+        )
 
     logger.info(
         "Pushed %d task(s) to Label Studio project %d (%s).", imported, project_id, project_title

--- a/src/arandu/shared/annotation/push.py
+++ b/src/arandu/shared/annotation/push.py
@@ -114,8 +114,14 @@ def run_push_annotation(
         raise ValueError(
             f"Label Studio accepted {imported} of the {len(tasks)} tasks sent to project "
             f"{project_id}. The missing tasks would be indistinguishable from unrated ones "
-            f"in every pull. Inspect the project and re-import the remainder, or delete it "
-            f"and push a fresh run."
+            f"in every pull. Project {project_id} is already recorded in the manifest (it is "
+            f"recorded before the import so a timeout cannot leave a live project unguarded), "
+            f"so recovering has two shapes. Either import the remaining tasks into project "
+            f"{project_id} from the Label Studio UI and leave the manifest alone, which is the "
+            f"cheaper path and keeps a single recorded project; or delete project {project_id} "
+            f"server-side and re-push with --force, which appends a second id to project_ids "
+            f"and makes every later pull need `--project-id <n>` even though only one project "
+            f"ever held tasks. Building under a fresh run id avoids both."
         )
 
     logger.info(

--- a/src/arandu/shared/annotation/ruler.py
+++ b/src/arandu/shared/annotation/ruler.py
@@ -1,0 +1,94 @@
+"""Load the signed-off emic-validity ruler and enforce its gate.
+
+``prompts/judge/criteria/emic_validity/ruler.pt.yaml`` is the single source of
+the construct, the 1-5 scale and the loss types. The judge prompt and the
+annotator sheet already render it; the Label Studio labeling config is the third
+consumer.
+
+The ``signed_off`` flag is the mechanical form of the
+``anthropologist-validation-of-readings`` gate: while it is false the annotation
+build refuses to run, so an unreviewed ruler cannot reach the annotators.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import TYPE_CHECKING, Any
+
+import yaml
+
+from arandu.utils.paths import get_project_root
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+RULER_PATH: Path = (
+    get_project_root() / "prompts" / "judge" / "criteria" / "emic_validity" / "ruler.pt.yaml"
+)
+
+GATE_NAME = "anthropologist-validation-of-readings"
+
+
+class RulerNotSignedOffError(RuntimeError):
+    """Raised when the ruler has not been signed off by the anthropologist."""
+
+
+def load_ruler(path: Path | None = None) -> dict[str, Any]:
+    """Load the emic-validity ruler.
+
+    Args:
+        path: Override the shipped ruler location (tests and audits).
+
+    Returns:
+        The parsed ruler mapping.
+
+    Raises:
+        FileNotFoundError: If the ruler file does not exist.
+        ValueError: If the file does not parse into a mapping.
+    """
+    target = path if path is not None else RULER_PATH
+    if not target.exists():
+        raise FileNotFoundError(f"Emic ruler not found: {target}")
+    data = yaml.safe_load(target.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"Emic ruler at {target} did not parse into a mapping.")
+    return data
+
+
+def ruler_sha256(path: Path | None = None) -> str:
+    """Return the SHA-256 of the ruler file bytes.
+
+    Recorded in the annotation manifest so an auditor can tell which ruler the
+    annotators actually saw. A ruler edit after the project is pushed would
+    otherwise be invisible.
+
+    Args:
+        path: Override the shipped ruler location (tests and audits).
+
+    Returns:
+        The hex-encoded SHA-256 digest of the ruler file contents.
+    """
+    target = path if path is not None else RULER_PATH
+    return hashlib.sha256(target.read_bytes()).hexdigest()
+
+
+def require_signed_off(ruler: dict[str, Any]) -> None:
+    """Raise unless the ruler carries an explicit boolean sign-off.
+
+    Only ``True`` passes. A missing flag, a string, or any other truthy value is
+    treated as unsigned: a typo must not open the gate.
+
+    Args:
+        ruler: The parsed ruler mapping, as returned by `load_ruler`.
+
+    Raises:
+        RulerNotSignedOffError: If the ruler is not signed off.
+    """
+    if ruler.get("signed_off") is not True:
+        gate = ruler.get("gate", GATE_NAME)
+        raise RulerNotSignedOffError(
+            f"The emic ruler is not signed off (signed_off is not true). The gate {gate!r} "
+            f"must close first: the anchors the annotators read have to be the reviewed ones, "
+            f"and a mismatch with the judge prompt is not recoverable after annotation. "
+            f"Ruler: {RULER_PATH}"
+        )

--- a/src/arandu/shared/annotation/schemas.py
+++ b/src/arandu/shared/annotation/schemas.py
@@ -1,0 +1,129 @@
+"""Schemas for the emic annotation instrument (spec §4, §5, §8).
+
+The blinding contract of spec §5 is enforced here rather than downstream:
+:class:`AnnotationTask` forbids extra fields, so an attempt to smuggle
+``bloom_level`` or ``pair_id`` into the payload is a validation error at
+construction, not a silent leak into a live project.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class AnnotationBuildConfig(BaseModel):
+    """Config snapshotted into ``run_metadata.json`` for an annotation build.
+
+    Attributes:
+        seed: Shuffle seed (recorded so the task order is reproducible).
+        total_items: Number of tasks built.
+    """
+
+    seed: int
+    total_items: int
+
+
+class AnnotationTask(BaseModel):
+    """One blinded task as Label Studio receives it.
+
+    These four fields are the complete payload. ``pair_id`` is deliberately
+    absent: it is ``"{source_file_id}:{pair_index}"``, so shipping it would let
+    an attentive annotator group pairs from the same interview and infer the
+    stratification. The join lives in :class:`AnnotationManifest`.
+
+    Attributes:
+        task_id: Opaque 0-based index into the shuffled order.
+        segment: Source transcript segment.
+        question: The generated question.
+        answer: The generated answer.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    task_id: int = Field(..., ge=0)
+    segment: str
+    question: str
+    answer: str
+
+    def to_label_studio(self) -> dict[str, dict[str, object]]:
+        """Return the Label Studio import shape (``{"data": {...}}``)."""
+        return {"data": self.model_dump()}
+
+
+class AnnotationManifest(BaseModel):
+    """Provenance, reproducibility, and the ``task_id -> pair_id`` join.
+
+    Attributes:
+        pipeline_id: Run identifier.
+        seed: Shuffle seed.
+        total_items: Number of tasks built.
+        per_cell: Pairs per stratification cell, copied from the sample manifest
+            for cross-checking.
+        pool_sha256: Copied from the sample manifest (ties this build to the
+            exact sample it came from).
+        ruler_sha256: Hash of the ruler the labeling config was rendered from.
+            A ruler edit after the push would otherwise be invisible.
+        task_map: ``str(task_id) -> pair_id``. JSON object keys are strings, so
+            the int is stringified on the way out and parsed on the way back.
+        project_id: Label Studio project created by ``push``; ``None`` until
+            then.
+        project_ids: Every project ever created from this build, in order. A
+            ``--force`` re-push appends rather than overwriting, so a duplicate
+            project is a recorded fact instead of a lost one.
+    """
+
+    pipeline_id: str
+    seed: int
+    total_items: int
+    per_cell: int
+    pool_sha256: str
+    ruler_sha256: str
+    task_map: dict[str, str]
+    project_id: int | None = None
+    project_ids: list[int] = Field(default_factory=list)
+
+    def pair_id_for(self, task_id: int) -> str:
+        """Resolve a ``task_id`` back to its canonical ``pair_id``.
+
+        Raises:
+            KeyError: If the task is not in this build. That means the manifest
+                and the Label Studio project are out of sync, which invalidates
+                every label pulled from it.
+        """
+        key = str(task_id)
+        if key not in self.task_map:
+            raise KeyError(
+                f"task_id {task_id} is not in this build's task_map "
+                f"({self.total_items} tasks). The manifest and the Label Studio project "
+                f"are out of sync; do not trust labels pulled from it."
+            )
+        return self.task_map[key]
+
+    def save(self, path: str | Path) -> None:
+        """Write the manifest to JSON."""
+        Path(path).write_text(self.model_dump_json(indent=2), encoding="utf-8")
+
+    @classmethod
+    def load(cls, path: str | Path) -> AnnotationManifest:
+        """Load a manifest from JSON."""
+        return cls.model_validate_json(Path(path).read_text(encoding="utf-8"))
+
+
+class AnnotationLabel(BaseModel):
+    """One annotator's rating of one pair, keyed back to the canonical pair.
+
+    Attributes:
+        pair_id: Canonical ``"{source_file_id}:{pair_index}"``.
+        annotator_id: Anonymous stable id (``A1``, ``A2``, ``A3``).
+        score: Ordinal emic-validity rating {1..5}.
+        rationale: Optional free-text justification.
+        timestamp: Label Studio ``created_at`` for the annotation, verbatim.
+    """
+
+    pair_id: str
+    annotator_id: str
+    score: int = Field(..., ge=1, le=5)
+    rationale: str | None = None
+    timestamp: str

--- a/src/arandu/shared/annotation/settings.py
+++ b/src/arandu/shared/annotation/settings.py
@@ -1,0 +1,34 @@
+"""Settings for the Label Studio instance (env prefix ``ARANDU_LABEL_STUDIO_``)."""
+
+from __future__ import annotations
+
+from pydantic import Field, field_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class LabelStudioSettings(BaseSettings):
+    """Connection settings for the annotation platform.
+
+    The token is required and has no default: a missing credential must fail
+    loudly at startup rather than produce a confusing 401 mid-push. It is read
+    from the environment and never written to any artifact under ``results/``,
+    because the labels directory is the study's most sensitive output.
+
+    Attributes:
+        url: Base URL of the instance, without a trailing slash.
+        token: Label Studio API token (Account and Settings, Access Token).
+        timeout: Per-request timeout in seconds. Generous by default: a 120-task
+            import is one request.
+    """
+
+    url: str = Field(..., description="Base URL of the Label Studio instance")
+    token: str = Field(..., description="Label Studio API token")
+    timeout: float = Field(default=60.0, gt=0, description="Per-request timeout in seconds")
+
+    model_config = SettingsConfigDict(env_prefix="ARANDU_LABEL_STUDIO_", extra="ignore")
+
+    @field_validator("url")
+    @classmethod
+    def _strip_trailing_slash(cls, value: str) -> str:
+        """Normalize the base URL so path joins never double the separator."""
+        return value.rstrip("/")

--- a/src/arandu/shared/annotation/settings.py
+++ b/src/arandu/shared/annotation/settings.py
@@ -11,8 +11,17 @@ class LabelStudioSettings(BaseSettings):
 
     The token is required and has no default: a missing credential must fail
     loudly at startup rather than produce a confusing 401 mid-push. It is read
-    from the environment and never written to any artifact under ``results/``,
-    because the labels directory is the study's most sensitive output.
+    from the environment or from ``.env``, matching every other settings class
+    in this codebase (``ResultsConfig``, ``KGConfig``, the QA and transcription
+    configs), so a documented ``.env`` entry is not silently ignored.
+
+    The token value never reaches an artifact under ``results/``. Two mechanisms
+    keep it out, because this stage writes the study's most sensitive output:
+    ``SecretStr`` masks it in every repr and ``model_dump()`` (so it cannot
+    reach a ``ConfigSnapshot``'s ``config_values``), and
+    :func:`~arandu.shared.schemas.is_secret_env_name` redacts the raw
+    ``ARANDU_LABEL_STUDIO_TOKEN`` environment variable out of the environment
+    snapshot every stage writes into its ``run_metadata.json``.
 
     ``token`` is a :class:`~pydantic.SecretStr`, not a plain ``str``: this is
     the first settings class in this codebase to hold a live secret value
@@ -34,7 +43,13 @@ class LabelStudioSettings(BaseSettings):
     token: SecretStr = Field(..., description="Label Studio API token")
     timeout: float = Field(default=60.0, gt=0, description="Per-request timeout in seconds")
 
-    model_config = SettingsConfigDict(env_prefix="ARANDU_LABEL_STUDIO_", extra="ignore")
+    model_config = SettingsConfigDict(
+        env_prefix="ARANDU_LABEL_STUDIO_",
+        env_file=".env",
+        env_file_encoding="utf-8",
+        case_sensitive=False,
+        extra="ignore",
+    )
 
     @field_validator("url")
     @classmethod

--- a/src/arandu/shared/annotation/settings.py
+++ b/src/arandu/shared/annotation/settings.py
@@ -15,6 +15,15 @@ class LabelStudioSettings(BaseSettings):
     in this codebase (``ResultsConfig``, ``KGConfig``, the QA and transcription
     configs), so a documented ``.env`` entry is not silently ignored.
 
+    ``min_length=1`` makes an empty value fail the same way an absent one does.
+    ``.env.example`` ships ``ARANDU_LABEL_STUDIO_TOKEN=`` with no value, since
+    the credential is only needed by the two commands that talk to the instance;
+    without the constraint, the ordinary copy-the-example flow validates and
+    sends ``Authorization: Token `` instead of printing the CLI's "Label Studio
+    is not configured" message. The class is only ever constructed inside those
+    two commands (and in ``pull`` only on the network path), so this constrains
+    nothing for a checkout that never annotates.
+
     The token value never reaches an artifact under ``results/``. Two mechanisms
     keep it out, because this stage writes the study's most sensitive output:
     ``SecretStr`` masks it in every repr and ``model_dump()`` (so it cannot
@@ -40,7 +49,7 @@ class LabelStudioSettings(BaseSettings):
     """
 
     url: str = Field(..., description="Base URL of the Label Studio instance")
-    token: SecretStr = Field(..., description="Label Studio API token")
+    token: SecretStr = Field(..., min_length=1, description="Label Studio API token")
     timeout: float = Field(default=60.0, gt=0, description="Per-request timeout in seconds")
 
     model_config = SettingsConfigDict(

--- a/src/arandu/shared/annotation/settings.py
+++ b/src/arandu/shared/annotation/settings.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from pydantic import Field, field_validator
+from pydantic import Field, SecretStr, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -14,6 +14,15 @@ class LabelStudioSettings(BaseSettings):
     from the environment and never written to any artifact under ``results/``,
     because the labels directory is the study's most sensitive output.
 
+    ``token`` is a :class:`~pydantic.SecretStr`, not a plain ``str``: this is
+    the first settings class in this codebase to hold a live secret value
+    (``LLMSettings`` only stores an env-var *name*, ``api_key_env``, never the
+    key itself). ``SecretStr`` keeps the token out of Pydantic's default repr
+    and out of ``model_dump()``, so a future stray ``logger.info(settings)`` or
+    an unhandled exception that renders the object cannot print it. Callers
+    that need the raw value call ``token.get_secret_value()`` at the point of
+    use (see :func:`arandu.shared.annotation.client.build_client_from_settings`).
+
     Attributes:
         url: Base URL of the instance, without a trailing slash.
         token: Label Studio API token (Account and Settings, Access Token).
@@ -22,7 +31,7 @@ class LabelStudioSettings(BaseSettings):
     """
 
     url: str = Field(..., description="Base URL of the Label Studio instance")
-    token: str = Field(..., description="Label Studio API token")
+    token: SecretStr = Field(..., description="Label Studio API token")
     timeout: float = Field(default=60.0, gt=0, description="Per-request timeout in seconds")
 
     model_config = SettingsConfigDict(env_prefix="ARANDU_LABEL_STUDIO_", extra="ignore")

--- a/src/arandu/shared/schemas.py
+++ b/src/arandu/shared/schemas.py
@@ -202,6 +202,7 @@ class PipelineType(StrEnum):
     NON_ANSWERABLE = "non_answerable"
     EMIC_JUDGE = "emic_judge"
     HUMAN_EVAL = "human_eval"
+    ANNOTATION = "annotation"
     EVALUATION = "evaluation"
 
 

--- a/src/arandu/shared/schemas.py
+++ b/src/arandu/shared/schemas.py
@@ -18,6 +18,39 @@ from arandu.shared.judge.schemas import (
 # explicit ``None`` value during legacy-payload migration.
 _MISSING = object()
 
+#: Substrings that mark an environment variable name as carrying a credential.
+#: Matched case-insensitively against the whole variable name.
+#:
+#: The list is deliberately broad and has no allowlist. Some captured names hold
+#: a variable *name* rather than a secret (``ARANDU_*_API_KEY_ENV`` points at the
+#: variable holding the key), and redacting those is harmless; carving out an
+#: exception for them is what would eventually let a real secret through.
+SECRET_ENV_NAME_MARKERS: tuple[str, ...] = (
+    "TOKEN",
+    "SECRET",
+    "PASSWORD",
+    "KEY",
+    "CREDENTIAL",
+)
+
+#: Written in place of a secret value in a captured environment snapshot. The
+#: key is kept so the snapshot still records that the variable was set.
+REDACTED_PLACEHOLDER = "***REDACTED***"
+
+
+def is_secret_env_name(name: str) -> bool:
+    """Return whether an environment variable name looks like a credential.
+
+    Args:
+        name: Environment variable name.
+
+    Returns:
+        ``True`` if the name contains any marker in
+        :data:`SECRET_ENV_NAME_MARKERS`, case-insensitively.
+    """
+    upper = name.upper()
+    return any(marker in upper for marker in SECRET_ENV_NAME_MARKERS)
+
 
 class InputRecord(BaseModel):
     """Schema for input records from file metadata.
@@ -356,17 +389,32 @@ class HardwareInfo(BaseModel):
 
 
 class ConfigSnapshot(BaseModel):
-    """Captures configuration at the time of run execution."""
+    """Captures configuration at the time of run execution.
+
+    The captured environment is written verbatim into every run's
+    ``run_metadata.json`` under ``results/``, so credential-looking variables
+    are masked before they get there (see :func:`is_secret_env_name`).
+    """
 
     config_type: str = Field(..., description="Configuration class name")
     config_values: dict = Field(..., description="Configuration values as dictionary")
     environment_variables: dict[str, str] = Field(
-        default_factory=dict, description="Relevant environment variables"
+        default_factory=dict,
+        description="Relevant environment variables, with credential values redacted",
     )
 
     @classmethod
     def from_config(cls, config: BaseModel, env_prefix: str = "ARANDU_") -> ConfigSnapshot:
         """Create snapshot from a Pydantic BaseSettings/BaseModel.
+
+        Every captured variable whose name looks like a credential
+        (``TOKEN``, ``SECRET``, ``PASSWORD``, ``KEY``, ``CREDENTIAL``) has its
+        value replaced by :data:`REDACTED_PLACEHOLDER`. The snapshot lands in
+        ``results/<id>/<stage>/run_metadata.json``, which is a durable artifact
+        of the study: a plaintext token there would outlive the shell that
+        exported it and spread to every other stage run from the same shell.
+        The key is kept, so the snapshot still records that the variable was
+        set at run time.
 
         Args:
             config: The configuration object to snapshot.
@@ -377,8 +425,12 @@ class ConfigSnapshot(BaseModel):
         """
         import os
 
-        # Capture relevant environment variables
-        env_vars = {key: value for key, value in os.environ.items() if key.startswith(env_prefix)}
+        # Capture relevant environment variables, masking credential values.
+        env_vars = {
+            key: (REDACTED_PLACEHOLDER if is_secret_env_name(key) else value)
+            for key, value in os.environ.items()
+            if key.startswith(env_prefix)
+        }
 
         return cls(
             config_type=config.__class__.__name__,

--- a/tests/cli/test_annotation_cli.py
+++ b/tests/cli/test_annotation_cli.py
@@ -87,7 +87,7 @@ class TestPullCommand:
         assert "emic-annotation-pull" in result.stdout
 
     def test_file_mode_needs_no_credentials(self, mocker: MockerFixture, tmp_path: Path) -> None:
-        summary = mocker.Mock(project_id=0, annotators={"A1": 3}, total_items=3)
+        summary = mocker.Mock(project_id=0, annotators={"A1": 3}, total_items=3, skipped=0)
         pull = mocker.patch("arandu.cli.annotation.run_pull_annotation", return_value=summary)
         settings = mocker.patch("arandu.cli.annotation.LabelStudioSettings")
         export = tmp_path / "export.json"
@@ -105,3 +105,31 @@ class TestPullCommand:
         )
         result = runner.invoke(app, ["emic-annotation-pull", "--id", "run-a"])
         assert result.exit_code == 1
+
+    def test_project_id_is_threaded_through(self, mocker: MockerFixture) -> None:
+        summary = mocker.Mock(project_id=42, annotators={"A1": 3}, total_items=3, skipped=0)
+        mocker.patch("arandu.cli.annotation.LabelStudioSettings")
+        mocker.patch("arandu.cli.annotation.build_client_from_settings")
+        pull = mocker.patch("arandu.cli.annotation.run_pull_annotation", return_value=summary)
+        result = runner.invoke(app, ["emic-annotation-pull", "--id", "run-a", "--project-id", "42"])
+        assert result.exit_code == 0
+        assert pull.call_args.kwargs["project_id"] == 42
+
+    def test_project_id_defaults_to_none(self, mocker: MockerFixture) -> None:
+        summary = mocker.Mock(project_id=42, annotators={"A1": 3}, total_items=3, skipped=0)
+        mocker.patch("arandu.cli.annotation.LabelStudioSettings")
+        mocker.patch("arandu.cli.annotation.build_client_from_settings")
+        pull = mocker.patch("arandu.cli.annotation.run_pull_annotation", return_value=summary)
+        runner.invoke(app, ["emic-annotation-pull", "--id", "run-a"])
+        assert pull.call_args.kwargs["project_id"] is None
+
+    def test_skips_are_reported(self, mocker: MockerFixture) -> None:
+        summary = mocker.Mock(project_id=42, annotators={"A1": 2}, total_items=3, skipped=1)
+        mocker.patch("arandu.cli.annotation.LabelStudioSettings")
+        mocker.patch("arandu.cli.annotation.build_client_from_settings")
+        mocker.patch("arandu.cli.annotation.run_pull_annotation", return_value=summary)
+        result = runner.invoke(app, ["emic-annotation-pull", "--id", "run-a"])
+        assert result.exit_code == 0
+        # print_warning writes to stderr_console; the merged `.output` carries it
+        # (see TestBuildCommand above).
+        assert "skipped" in result.output

--- a/tests/cli/test_annotation_cli.py
+++ b/tests/cli/test_annotation_cli.py
@@ -11,6 +11,7 @@ from arandu.cli.app import app
 if TYPE_CHECKING:
     from pathlib import Path
 
+    import pytest
     from pytest_mock import MockerFixture
 
 runner = CliRunner()
@@ -51,6 +52,21 @@ class TestBuildCommand:
         result = runner.invoke(app, ["emic-annotation-build", "--id", "run-a", "--seed", "9"])
         assert result.exit_code == 0
         assert "annotation/outputs" in result.stdout
+
+    def test_a_malformed_ruler_exits_one_instead_of_traceback(self, mocker: MockerFixture) -> None:
+        """render_labeling_config indexes the ruler, so a missing key is a KeyError."""
+        mocker.patch(
+            "arandu.cli.annotation.run_build_annotation", side_effect=KeyError("loss_types")
+        )
+        result = runner.invoke(app, ["emic-annotation-build", "--id", "x", "--seed", "1"])
+        assert result.exit_code == 1
+        assert result.exception is None or isinstance(result.exception, SystemExit)
+        # print_error writes to stderr_console; the merged `.output` carries it
+        # (see test_unsigned_ruler_exits_one_and_names_the_gate above).
+        # Rich folds the long ruler path across lines; rejoin before matching.
+        unwrapped = "".join(result.output.split())
+        assert "loss_types" in unwrapped
+        assert "ruler.pt.yaml" in unwrapped
 
 
 class TestPushCommand:
@@ -124,7 +140,9 @@ class TestPullCommand:
         assert pull.call_args.kwargs["project_id"] is None
 
     def test_skips_are_reported(self, mocker: MockerFixture) -> None:
-        summary = mocker.Mock(project_id=42, annotators={"A1": 2}, total_items=3, skipped=1)
+        summary = mocker.Mock(
+            project_id=42, annotators={"A1": 2}, total_items=3, skipped=1, stale_removed=0
+        )
         mocker.patch("arandu.cli.annotation.LabelStudioSettings")
         mocker.patch("arandu.cli.annotation.build_client_from_settings")
         mocker.patch("arandu.cli.annotation.run_pull_annotation", return_value=summary)
@@ -133,3 +151,50 @@ class TestPullCommand:
         # print_warning writes to stderr_console; the merged `.output` carries it
         # (see TestBuildCommand above).
         assert "skipped" in result.output
+
+    def test_removed_stale_label_files_are_reported(self, mocker: MockerFixture) -> None:
+        """A label file that vanishes must be visible, not silent."""
+        summary = mocker.Mock(
+            project_id=42, annotators={"A1": 2}, total_items=3, skipped=0, stale_removed=2
+        )
+        mocker.patch("arandu.cli.annotation.LabelStudioSettings")
+        mocker.patch("arandu.cli.annotation.build_client_from_settings")
+        mocker.patch("arandu.cli.annotation.run_pull_annotation", return_value=summary)
+        result = runner.invoke(app, ["emic-annotation-pull", "--id", "run-a"])
+        assert result.exit_code == 0
+        unwrapped = "".join(result.output.split())
+        assert "2labelfile(s)fromanearlierpullwereremoved" in unwrapped
+
+    def test_a_file_and_a_project_id_together_exit_one(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The core refuses the pair; the CLI must surface it as exit 1, not ignore it."""
+        from arandu.shared.annotation.build import MANIFEST_FILENAME
+        from arandu.shared.annotation.schemas import AnnotationManifest
+
+        outputs = tmp_path / "results" / "run-a" / "annotation" / "outputs"
+        outputs.mkdir(parents=True)
+        AnnotationManifest(
+            pipeline_id="run-a",
+            seed=5,
+            total_items=1,
+            per_cell=15,
+            pool_sha256="c" * 64,
+            ruler_sha256="d" * 64,
+            task_map={"0": "src-a:0"},
+            project_id=42,
+            project_ids=[42],
+        ).save(outputs / MANIFEST_FILENAME)
+        monkeypatch.setenv("ARANDU_RESULTS_BASE_DIR", str(tmp_path / "results"))
+
+        export = tmp_path / "export.json"
+        export.write_text("[]", encoding="utf-8")
+        result = runner.invoke(
+            app,
+            ["emic-annotation-pull", "--id", "run-a", "-f", str(export), "--project-id", "99"],
+        )
+
+        assert result.exit_code == 1
+        unwrapped = "".join(result.output.split())
+        assert "--project-id99" in unwrapped
+        assert not (outputs / "labels").exists()

--- a/tests/cli/test_annotation_cli.py
+++ b/tests/cli/test_annotation_cli.py
@@ -1,0 +1,53 @@
+"""CLI surface for the annotation instrument."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from typer.testing import CliRunner
+
+from arandu.cli.app import app
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from pytest_mock import MockerFixture
+
+runner = CliRunner()
+
+
+class TestBuildCommand:
+    def test_is_registered(self) -> None:
+        result = runner.invoke(app, ["--help"])
+        assert result.exit_code == 0
+        assert "emic-annotation-build" in result.stdout
+
+    def test_missing_sample_exits_one(self, mocker: MockerFixture) -> None:
+        mocker.patch(
+            "arandu.cli.annotation.run_build_annotation",
+            side_effect=FileNotFoundError("no sample"),
+        )
+        result = runner.invoke(app, ["emic-annotation-build", "--id", "x", "--seed", "1"])
+        assert result.exit_code == 1
+
+    def test_unsigned_ruler_exits_one_and_names_the_gate(self, mocker: MockerFixture) -> None:
+        from arandu.shared.annotation.ruler import RulerNotSignedOffError
+
+        mocker.patch(
+            "arandu.cli.annotation.run_build_annotation",
+            side_effect=RulerNotSignedOffError("gate anthropologist-validation is open"),
+        )
+        result = runner.invoke(app, ["emic-annotation-build", "--id", "x", "--seed", "1"])
+        assert result.exit_code == 1
+        # print_error writes to stderr_console; CliRunner keeps stdout/stderr
+        # separate on this click version, so the merged `.output` is what
+        # carries the message (matches the convention in the other CLI test
+        # modules, e.g. tests/cli/test_kg_build_retriever_index_cli.py).
+        assert "anthropologist-validation" in result.output
+
+    def test_success_reports_the_output_dir(self, mocker: MockerFixture, tmp_path: Path) -> None:
+        manifest = mocker.Mock(total_items=120, seed=9, project_id=None)
+        mocker.patch("arandu.cli.annotation.run_build_annotation", return_value=manifest)
+        result = runner.invoke(app, ["emic-annotation-build", "--id", "run-a", "--seed", "9"])
+        assert result.exit_code == 0
+        assert "annotation/outputs" in result.stdout

--- a/tests/cli/test_annotation_cli.py
+++ b/tests/cli/test_annotation_cli.py
@@ -79,3 +79,29 @@ class TestPushCommand:
         )
         result = runner.invoke(app, ["emic-annotation-push", "--id", "run-a"])
         assert result.exit_code == 1
+
+
+class TestPullCommand:
+    def test_is_registered(self) -> None:
+        result = runner.invoke(app, ["--help"])
+        assert "emic-annotation-pull" in result.stdout
+
+    def test_file_mode_needs_no_credentials(self, mocker: MockerFixture, tmp_path: Path) -> None:
+        summary = mocker.Mock(project_id=0, annotators={"A1": 3}, total_items=3)
+        pull = mocker.patch("arandu.cli.annotation.run_pull_annotation", return_value=summary)
+        settings = mocker.patch("arandu.cli.annotation.LabelStudioSettings")
+        export = tmp_path / "export.json"
+        export.write_text("[]", encoding="utf-8")
+        result = runner.invoke(app, ["emic-annotation-pull", "--id", "run-a", "-f", str(export)])
+        assert result.exit_code == 0
+        settings.assert_not_called()
+        assert pull.call_args.kwargs["export_file"] == export
+
+    def test_desync_exits_one(self, mocker: MockerFixture) -> None:
+        mocker.patch("arandu.cli.annotation.LabelStudioSettings")
+        mocker.patch("arandu.cli.annotation.build_client_from_settings")
+        mocker.patch(
+            "arandu.cli.annotation.run_pull_annotation", side_effect=KeyError("task_id 99")
+        )
+        result = runner.invoke(app, ["emic-annotation-pull", "--id", "run-a"])
+        assert result.exit_code == 1

--- a/tests/cli/test_annotation_cli.py
+++ b/tests/cli/test_annotation_cli.py
@@ -51,3 +51,31 @@ class TestBuildCommand:
         result = runner.invoke(app, ["emic-annotation-build", "--id", "run-a", "--seed", "9"])
         assert result.exit_code == 0
         assert "annotation/outputs" in result.stdout
+
+
+class TestPushCommand:
+    def test_is_registered(self) -> None:
+        result = runner.invoke(app, ["--help"])
+        assert "emic-annotation-push" in result.stdout
+
+    def test_missing_credentials_exit_one(self, mocker: MockerFixture) -> None:
+        mocker.patch(
+            "arandu.cli.annotation.LabelStudioSettings",
+            side_effect=ValueError("token is required"),
+        )
+        result = runner.invoke(app, ["emic-annotation-push", "--id", "run-a"])
+        assert result.exit_code == 1
+        # print_error writes to stderr_console; CliRunner keeps stdout/stderr
+        # separate on this click version, so the merged `.output` is what
+        # carries the message (see TestBuildCommand above).
+        assert "ARANDU_LABEL_STUDIO_TOKEN" in result.output
+
+    def test_duplicate_push_exits_one(self, mocker: MockerFixture) -> None:
+        mocker.patch("arandu.cli.annotation.LabelStudioSettings")
+        mocker.patch("arandu.cli.annotation.build_client_from_settings")
+        mocker.patch(
+            "arandu.cli.annotation.run_push_annotation",
+            side_effect=ValueError("already pushed as project 42"),
+        )
+        result = runner.invoke(app, ["emic-annotation-push", "--id", "run-a"])
+        assert result.exit_code == 1

--- a/tests/shared/annotation/test_build.py
+++ b/tests/shared/annotation/test_build.py
@@ -10,6 +10,7 @@ import yaml
 
 from arandu.shared.annotation.build import (
     CONFIG_FILENAME,
+    LABELS_DIRNAME,
     MANIFEST_FILENAME,
     TASKS_FILENAME,
     run_build_annotation,
@@ -212,3 +213,61 @@ class TestErrors:
         pushed.save(path)
         with pytest.raises(ValueError, match="42"):
             run_build_annotation("run-a", seed=5, base_dir=sample_run)
+
+    def test_duplicate_pair_id_in_the_sample_fails(self, sample_run: Path) -> None:
+        """Keying by pair_id collapses duplicates; the count must catch that."""
+        sample_path = sample_run / "run-a" / "human_eval" / "outputs" / "sample.jsonl"
+        lines = sample_path.read_text(encoding="utf-8").splitlines()
+        lines[-1] = lines[0]
+        sample_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        with pytest.raises(ValueError, match="distinct pair_id"):
+            run_build_annotation("run-a", seed=5, base_dir=sample_run)
+
+    def test_duplicate_pair_id_writes_no_tasks(self, sample_run: Path) -> None:
+        sample_path = sample_run / "run-a" / "human_eval" / "outputs" / "sample.jsonl"
+        lines = sample_path.read_text(encoding="utf-8").splitlines()
+        lines[-1] = lines[0]
+        sample_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        with pytest.raises(ValueError):
+            run_build_annotation("run-a", seed=5, base_dir=sample_run)
+        assert not (sample_run / "run-a" / "annotation" / "outputs" / TASKS_FILENAME).exists()
+
+
+class TestRebuildUnderPulledLabels:
+    """Labels are the other half of the join, so they forbid a rebuild too."""
+
+    def _write_labels(self, sample_run: Path) -> None:
+        labels = sample_run / "run-a" / "annotation" / "outputs" / LABELS_DIRNAME
+        labels.mkdir(parents=True, exist_ok=True)
+        (labels / "A1.jsonl").write_text(
+            '{"pair_id": "src-0:0", "annotator_id": "A1", "score": 5, '
+            '"rationale": null, "timestamp": "2026-09-01T10:00:00Z"}\n',
+            encoding="utf-8",
+        )
+
+    def test_rebuild_with_pulled_labels_refuses(self, sample_run: Path) -> None:
+        run_build_annotation("run-a", seed=5, base_dir=sample_run)
+        self._write_labels(sample_run)
+        with pytest.raises(ValueError, match=r"A1\.jsonl"):
+            run_build_annotation("run-a", seed=6, base_dir=sample_run)
+
+    def test_the_refusal_explains_the_join(self, sample_run: Path) -> None:
+        run_build_annotation("run-a", seed=5, base_dir=sample_run)
+        self._write_labels(sample_run)
+        with pytest.raises(ValueError, match="task_id -> pair_id"):
+            run_build_annotation("run-a", seed=6, base_dir=sample_run)
+
+    def test_the_refusal_leaves_the_old_tasks_untouched(self, sample_run: Path) -> None:
+        """It has to fire before create_run, or the outputs are already stirred."""
+        run_build_annotation("run-a", seed=5, base_dir=sample_run)
+        outputs = sample_run / "run-a" / "annotation" / "outputs"
+        before = (outputs / TASKS_FILENAME).read_bytes()
+        self._write_labels(sample_run)
+        with pytest.raises(ValueError):
+            run_build_annotation("run-a", seed=6, base_dir=sample_run)
+        assert (outputs / TASKS_FILENAME).read_bytes() == before
+
+    def test_an_empty_labels_dir_does_not_block_a_rebuild(self, sample_run: Path) -> None:
+        run_build_annotation("run-a", seed=5, base_dir=sample_run)
+        (sample_run / "run-a" / "annotation" / "outputs" / LABELS_DIRNAME).mkdir()
+        assert run_build_annotation("run-a", seed=6, base_dir=sample_run).seed == 6

--- a/tests/shared/annotation/test_build.py
+++ b/tests/shared/annotation/test_build.py
@@ -10,6 +10,7 @@ import yaml
 
 from arandu.shared.annotation.build import (
     CONFIG_FILENAME,
+    INSTRUCTION_FILENAME,
     LABELS_DIRNAME,
     MANIFEST_FILENAME,
     TASKS_FILENAME,
@@ -118,12 +119,24 @@ class TestSignOffGate:
 
 
 class TestArtifacts:
-    def test_writes_the_three_artifacts(self, sample_run: Path) -> None:
+    def test_writes_the_four_artifacts(self, sample_run: Path) -> None:
         run_build_annotation("run-a", seed=5, base_dir=sample_run)
         outputs = sample_run / "run-a" / "annotation" / "outputs"
         assert (outputs / CONFIG_FILENAME).exists()
+        assert (outputs / INSTRUCTION_FILENAME).exists()
         assert (outputs / TASKS_FILENAME).exists()
         assert (outputs / MANIFEST_FILENAME).exists()
+
+    def test_the_instruction_holds_the_full_ruler(self, sample_run: Path) -> None:
+        """Push transports it verbatim, so the build is where it has to be correct."""
+        run_build_annotation("run-a", seed=5, base_dir=sample_run)
+        outputs = sample_run / "run-a" / "annotation" / "outputs"
+        html = (outputs / INSTRUCTION_FILENAME).read_text(encoding="utf-8")
+        ruler = yaml.safe_load(RULER_PATH.read_text(encoding="utf-8"))
+        assert ruler["construct"]["emic"] in html
+        for entry in ruler["guide"]["cascade"]:
+            assert entry["condition"] in html
+        assert ruler["judge_only"]["role"] not in html
 
     def test_task_count_matches_the_sample(self, sample_run: Path) -> None:
         manifest = run_build_annotation("run-a", seed=5, base_dir=sample_run)

--- a/tests/shared/annotation/test_build.py
+++ b/tests/shared/annotation/test_build.py
@@ -1,0 +1,214 @@
+"""The offline build: determinism, blinding, and the sign-off gate."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+import yaml
+
+from arandu.shared.annotation.build import (
+    CONFIG_FILENAME,
+    MANIFEST_FILENAME,
+    TASKS_FILENAME,
+    run_build_annotation,
+    shuffle_order,
+)
+from arandu.shared.annotation.ruler import RULER_PATH, RulerNotSignedOffError
+from arandu.shared.annotation.schemas import AnnotationManifest
+from arandu.shared.human_eval.schemas import SampleItem, SampleManifest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+FORBIDDEN_KEYS = {
+    "pair_id",
+    "source_file_id",
+    "pair_index",
+    "bloom_level",
+    "emic_score",
+    "cell_id",
+    "slot_id",
+}
+
+
+def _item(index: int) -> SampleItem:
+    return SampleItem(
+        pair_id=f"src-{index // 2}:{index}",
+        source_file_id=f"src-{index // 2}",
+        pair_index=index,
+        segment=f"segmento {index}",
+        question=f"pergunta {index}",
+        answer=f"resposta {index}",
+        bloom_level=("remember", "understand", "analyze", "evaluate")[index % 4],
+        emic_score=(index % 5) + 1,
+        cell_id=f"{('remember', 'understand', 'analyze', 'evaluate')[index % 4]}:limpa",
+        slot_id=index,
+    )
+
+
+@pytest.fixture
+def sample_run(tmp_path: Path) -> Path:
+    """A results tree with a populated human_eval stage (16 pairs)."""
+    outputs = tmp_path / "run-a" / "human_eval" / "outputs"
+    outputs.mkdir(parents=True)
+    items = [_item(i) for i in range(16)]
+    with (outputs / "sample.jsonl").open("w", encoding="utf-8") as fh:
+        for item in items:
+            fh.write(item.model_dump_json())
+            fh.write("\n")
+    SampleManifest(
+        pipeline_id="run-a",
+        seed=1,
+        total_items=len(items),
+        per_cell=2,
+        cell_counts={},
+        population_by_cell={},
+        pool_sha256="c" * 64,
+    ).save(outputs / "sample_manifest.json")
+    return tmp_path
+
+
+def _unsigned_ruler(tmp_path: Path) -> Path:
+    data = yaml.safe_load(RULER_PATH.read_text(encoding="utf-8"))
+    data["signed_off"] = False
+    path = tmp_path / "unsigned.yaml"
+    path.write_text(yaml.safe_dump(data, allow_unicode=True), encoding="utf-8")
+    return path
+
+
+class TestShuffleOrder:
+    def test_is_a_permutation(self) -> None:
+        ids = [f"s:{i}" for i in range(20)]
+        assert sorted(shuffle_order(ids, seed=3)) == sorted(ids)
+
+    def test_same_seed_same_order(self) -> None:
+        ids = [f"s:{i}" for i in range(20)]
+        assert shuffle_order(ids, seed=3) == shuffle_order(ids, seed=3)
+
+    def test_different_seed_different_order(self) -> None:
+        ids = [f"s:{i}" for i in range(20)]
+        assert shuffle_order(ids, seed=3) != shuffle_order(ids, seed=4)
+
+    def test_order_is_independent_of_input_order(self) -> None:
+        ids = [f"s:{i}" for i in range(20)]
+        assert shuffle_order(ids, seed=3) == shuffle_order(list(reversed(ids)), seed=3)
+
+    def test_it_actually_breaks_the_cell_grouping(self) -> None:
+        """The sample arrives grouped by cell; the point is to destroy that."""
+        ids = [f"s:{i}" for i in range(20)]
+        assert shuffle_order(ids, seed=3) != ids
+
+
+class TestSignOffGate:
+    def test_unsigned_ruler_refuses_to_build(self, sample_run: Path, tmp_path: Path) -> None:
+        with pytest.raises(RulerNotSignedOffError, match="anthropologist-validation"):
+            run_build_annotation(
+                "run-a", seed=5, base_dir=sample_run, ruler_path=_unsigned_ruler(tmp_path)
+            )
+
+    def test_unsigned_ruler_writes_no_tasks(self, sample_run: Path, tmp_path: Path) -> None:
+        with pytest.raises(RulerNotSignedOffError):
+            run_build_annotation(
+                "run-a", seed=5, base_dir=sample_run, ruler_path=_unsigned_ruler(tmp_path)
+            )
+        assert not (sample_run / "run-a" / "annotation" / "outputs" / TASKS_FILENAME).exists()
+
+
+class TestArtifacts:
+    def test_writes_the_three_artifacts(self, sample_run: Path) -> None:
+        run_build_annotation("run-a", seed=5, base_dir=sample_run)
+        outputs = sample_run / "run-a" / "annotation" / "outputs"
+        assert (outputs / CONFIG_FILENAME).exists()
+        assert (outputs / TASKS_FILENAME).exists()
+        assert (outputs / MANIFEST_FILENAME).exists()
+
+    def test_task_count_matches_the_sample(self, sample_run: Path) -> None:
+        manifest = run_build_annotation("run-a", seed=5, base_dir=sample_run)
+        outputs = sample_run / "run-a" / "annotation" / "outputs"
+        tasks = json.loads((outputs / TASKS_FILENAME).read_text(encoding="utf-8"))
+        assert len(tasks) == 16
+        assert manifest.total_items == 16
+
+    def test_manifest_copies_provenance_from_the_sample(self, sample_run: Path) -> None:
+        manifest = run_build_annotation("run-a", seed=5, base_dir=sample_run)
+        assert manifest.pool_sha256 == "c" * 64
+        assert manifest.per_cell == 2
+        assert len(manifest.ruler_sha256) == 64
+        assert manifest.project_id is None
+
+
+class TestBlinding:
+    def test_tasks_carry_only_the_four_allowed_keys(self, sample_run: Path) -> None:
+        run_build_annotation("run-a", seed=5, base_dir=sample_run)
+        outputs = sample_run / "run-a" / "annotation" / "outputs"
+        tasks = json.loads((outputs / TASKS_FILENAME).read_text(encoding="utf-8"))
+        for task in tasks:
+            assert set(task.keys()) == {"data"}
+            assert set(task["data"].keys()) == {"task_id", "segment", "question", "answer"}
+
+    def test_no_forbidden_value_appears_anywhere_in_tasks_json(self, sample_run: Path) -> None:
+        """Checked against the raw text, so a nested leak cannot hide."""
+        run_build_annotation("run-a", seed=5, base_dir=sample_run)
+        outputs = sample_run / "run-a" / "annotation" / "outputs"
+        raw = (outputs / TASKS_FILENAME).read_text(encoding="utf-8")
+        for key in FORBIDDEN_KEYS:
+            assert key not in raw
+        assert "src-0:0" not in raw
+
+
+class TestJoin:
+    def test_task_map_covers_every_task_exactly_once(self, sample_run: Path) -> None:
+        manifest = run_build_annotation("run-a", seed=5, base_dir=sample_run)
+        assert sorted(int(k) for k in manifest.task_map) == list(range(16))
+        assert len(set(manifest.task_map.values())) == 16
+
+    def test_task_map_matches_the_shuffled_payload(self, sample_run: Path) -> None:
+        manifest = run_build_annotation("run-a", seed=5, base_dir=sample_run)
+        outputs = sample_run / "run-a" / "annotation" / "outputs"
+        tasks = json.loads((outputs / TASKS_FILENAME).read_text(encoding="utf-8"))
+        for task in tasks:
+            task_id = task["data"]["task_id"]
+            pair_index = int(manifest.pair_id_for(task_id).split(":")[1])
+            assert task["data"]["question"] == f"pergunta {pair_index}"
+
+
+class TestDeterminism:
+    def test_same_seed_reproduces_tasks_json_byte_for_byte(self, sample_run: Path) -> None:
+        run_build_annotation("run-a", seed=5, base_dir=sample_run)
+        outputs = sample_run / "run-a" / "annotation" / "outputs"
+        first = (outputs / TASKS_FILENAME).read_bytes()
+        run_build_annotation("run-a", seed=5, base_dir=sample_run)
+        assert (outputs / TASKS_FILENAME).read_bytes() == first
+
+    def test_different_seed_changes_the_order(self, sample_run: Path) -> None:
+        run_build_annotation("run-a", seed=5, base_dir=sample_run)
+        outputs = sample_run / "run-a" / "annotation" / "outputs"
+        first = (outputs / TASKS_FILENAME).read_bytes()
+        run_build_annotation("run-a", seed=6, base_dir=sample_run)
+        assert (outputs / TASKS_FILENAME).read_bytes() != first
+
+
+class TestErrors:
+    def test_missing_sample_names_the_upstream_command(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError, match="build-human-eval-sample"):
+            run_build_annotation("absent", seed=5, base_dir=tmp_path)
+
+    def test_count_mismatch_with_the_sample_manifest_fails(self, sample_run: Path) -> None:
+        manifest_path = sample_run / "run-a" / "human_eval" / "outputs" / "sample_manifest.json"
+        stale = SampleManifest.load(manifest_path)
+        stale.total_items = 120
+        stale.save(manifest_path)
+        with pytest.raises(ValueError, match="120"):
+            run_build_annotation("run-a", seed=5, base_dir=sample_run)
+
+    def test_rebuild_after_push_refuses(self, sample_run: Path) -> None:
+        """Rebuilding under a live project would desync the join."""
+        run_build_annotation("run-a", seed=5, base_dir=sample_run)
+        path = sample_run / "run-a" / "annotation" / "outputs" / MANIFEST_FILENAME
+        pushed = AnnotationManifest.load(path)
+        pushed.project_id = 42
+        pushed.save(path)
+        with pytest.raises(ValueError, match="42"):
+            run_build_annotation("run-a", seed=5, base_dir=sample_run)

--- a/tests/shared/annotation/test_client.py
+++ b/tests/shared/annotation/test_client.py
@@ -1,0 +1,114 @@
+"""The Label Studio client is transport only, and it never leaks the token."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+
+from arandu.shared.annotation.client import (
+    HttpLabelStudioClient,
+    LabelStudioError,
+    build_client_from_settings,
+)
+from arandu.shared.annotation.settings import LabelStudioSettings
+
+
+def _client(handler: Any) -> HttpLabelStudioClient:
+    transport = httpx.MockTransport(handler)
+    return HttpLabelStudioClient(
+        base_url="https://label.example.test",
+        token="secret-token",
+        transport=transport,
+    )
+
+
+class TestSettings:
+    def test_reads_the_arandu_label_studio_prefix(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ARANDU_LABEL_STUDIO_URL", "https://label.example.test")
+        monkeypatch.setenv("ARANDU_LABEL_STUDIO_TOKEN", "abc")
+        settings = LabelStudioSettings()
+        assert settings.url == "https://label.example.test"
+        assert settings.token == "abc"
+
+    def test_missing_token_is_a_validation_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ARANDU_LABEL_STUDIO_TOKEN", raising=False)
+        monkeypatch.setenv("ARANDU_LABEL_STUDIO_URL", "https://label.example.test")
+        with pytest.raises(ValueError):
+            LabelStudioSettings(_env_file=None)
+
+    def test_trailing_slash_is_normalized(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ARANDU_LABEL_STUDIO_URL", "https://label.example.test/")
+        monkeypatch.setenv("ARANDU_LABEL_STUDIO_TOKEN", "abc")
+        assert LabelStudioSettings().url == "https://label.example.test"
+
+    def test_builder_returns_a_configured_client(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ARANDU_LABEL_STUDIO_URL", "https://label.example.test")
+        monkeypatch.setenv("ARANDU_LABEL_STUDIO_TOKEN", "abc")
+        assert isinstance(build_client_from_settings(LabelStudioSettings()), HttpLabelStudioClient)
+
+
+class TestCreateProject:
+    def test_posts_title_and_config_and_returns_the_id(self) -> None:
+        seen: dict[str, Any] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen["url"] = str(request.url)
+            seen["auth"] = request.headers.get("Authorization")
+            seen["body"] = request.read().decode()
+            return httpx.Response(201, json={"id": 42, "title": "t"})
+
+        assert _client(handler).create_project("t", "<View/>") == 42
+        assert seen["url"] == "https://label.example.test/api/projects/"
+        assert seen["auth"] == "Token secret-token"
+        assert "<View/>" in seen["body"]
+
+    def test_http_error_is_wrapped_without_the_token(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(403, text="forbidden")
+
+        with pytest.raises(LabelStudioError) as excinfo:
+            _client(handler).create_project("t", "<View/>")
+        assert "403" in str(excinfo.value)
+        assert "secret-token" not in str(excinfo.value)
+
+    def test_response_without_an_id_is_an_error(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(201, json={"title": "t"})
+
+        with pytest.raises(LabelStudioError, match="id"):
+            _client(handler).create_project("t", "<View/>")
+
+
+class TestImportTasks:
+    def test_posts_the_task_list_and_returns_the_count(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.url.path == "/api/projects/42/import"
+            return httpx.Response(201, json={"task_count": 2})
+
+        assert _client(handler).import_tasks(42, [{"data": {}}, {"data": {}}]) == 2
+
+    def test_error_is_wrapped(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(500, text="boom")
+
+        with pytest.raises(LabelStudioError, match="500"):
+            _client(handler).import_tasks(42, [])
+
+
+class TestExportAnnotations:
+    def test_requests_json_export_and_returns_the_list(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.url.path == "/api/projects/42/export"
+            assert request.url.params["exportType"] == "JSON"
+            return httpx.Response(200, json=[{"id": 1, "data": {"task_id": 0}}])
+
+        assert _client(handler).export_annotations(42)[0]["data"]["task_id"] == 0
+
+    def test_non_list_payload_is_an_error(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={"detail": "nope"})
+
+        with pytest.raises(LabelStudioError, match="list"):
+            _client(handler).export_annotations(42)

--- a/tests/shared/annotation/test_client.py
+++ b/tests/shared/annotation/test_client.py
@@ -30,7 +30,16 @@ class TestSettings:
         monkeypatch.setenv("ARANDU_LABEL_STUDIO_TOKEN", "abc")
         settings = LabelStudioSettings()
         assert settings.url == "https://label.example.test"
-        assert settings.token == "abc"
+        assert settings.token.get_secret_value() == "abc"
+
+    def test_token_never_appears_in_repr_or_model_dump(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("ARANDU_LABEL_STUDIO_URL", "https://label.example.test")
+        monkeypatch.setenv("ARANDU_LABEL_STUDIO_TOKEN", "super-secret-value")
+        settings = LabelStudioSettings()
+        assert "super-secret-value" not in repr(settings)
+        assert "super-secret-value" not in str(settings.model_dump())
 
     def test_missing_token_is_a_validation_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("ARANDU_LABEL_STUDIO_TOKEN", raising=False)
@@ -71,6 +80,15 @@ class TestCreateProject:
         with pytest.raises(LabelStudioError) as excinfo:
             _client(handler).create_project("t", "<View/>")
         assert "403" in str(excinfo.value)
+        assert "secret-token" not in str(excinfo.value)
+
+    def test_transport_error_is_wrapped_without_the_token(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectError("connection refused")
+
+        with pytest.raises(LabelStudioError) as excinfo:
+            _client(handler).create_project("t", "<View/>")
+        assert "connection refused" in str(excinfo.value)
         assert "secret-token" not in str(excinfo.value)
 
     def test_response_without_an_id_is_an_error(self) -> None:

--- a/tests/shared/annotation/test_client.py
+++ b/tests/shared/annotation/test_client.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import httpx
 import pytest
@@ -14,6 +14,9 @@ from arandu.shared.annotation.client import (
     build_client_from_settings,
 )
 from arandu.shared.annotation.settings import LabelStudioSettings
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def _client(handler: Any) -> HttpLabelStudioClient:
@@ -52,6 +55,39 @@ class TestSettings:
         monkeypatch.setenv("ARANDU_LABEL_STUDIO_URL", "https://label.example.test/")
         monkeypatch.setenv("ARANDU_LABEL_STUDIO_TOKEN", "abc")
         assert LabelStudioSettings().url == "https://label.example.test"
+
+    def test_reads_a_dot_env_file(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """`.env.example` documents these vars, so `.env` has to be read."""
+        monkeypatch.delenv("ARANDU_LABEL_STUDIO_URL", raising=False)
+        monkeypatch.delenv("ARANDU_LABEL_STUDIO_TOKEN", raising=False)
+        (tmp_path / ".env").write_text(
+            "ARANDU_LABEL_STUDIO_URL=https://from-dotenv.example.test\n"
+            "ARANDU_LABEL_STUDIO_TOKEN=dotenv-token\n",
+            encoding="utf-8",
+        )
+        monkeypatch.chdir(tmp_path)
+
+        settings = LabelStudioSettings()
+
+        assert settings.url == "https://from-dotenv.example.test"
+        assert settings.token.get_secret_value() == "dotenv-token"
+
+    def test_the_environment_wins_over_dot_env(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        (tmp_path / ".env").write_text(
+            "ARANDU_LABEL_STUDIO_URL=https://from-dotenv.example.test\n"
+            "ARANDU_LABEL_STUDIO_TOKEN=dotenv-token\n",
+            encoding="utf-8",
+        )
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("ARANDU_LABEL_STUDIO_URL", "https://from-env.example.test")
+        monkeypatch.setenv("ARANDU_LABEL_STUDIO_TOKEN", "env-token")
+
+        settings = LabelStudioSettings()
+
+        assert settings.url == "https://from-env.example.test"
+        assert settings.token.get_secret_value() == "env-token"
 
     def test_builder_returns_a_configured_client(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("ARANDU_LABEL_STUDIO_URL", "https://label.example.test")

--- a/tests/shared/annotation/test_client.py
+++ b/tests/shared/annotation/test_client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from typing import Any
 
 import httpx
@@ -72,6 +73,20 @@ class TestCreateProject:
         assert seen["url"] == "https://label.example.test/api/projects/"
         assert seen["auth"] == "Token secret-token"
         assert "<View/>" in seen["body"]
+
+    def test_settings_are_posted_alongside_title_and_config(self) -> None:
+        seen: dict[str, Any] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen["body"] = json.loads(request.read().decode())
+            return httpx.Response(201, json={"id": 42})
+
+        _client(handler).create_project("t", "<View/>", settings={"show_skip_button": False})
+        assert seen["body"] == {
+            "title": "t",
+            "label_config": "<View/>",
+            "show_skip_button": False,
+        }
 
     def test_http_error_is_wrapped_without_the_token(self) -> None:
         def handler(request: httpx.Request) -> httpx.Response:

--- a/tests/shared/annotation/test_client.py
+++ b/tests/shared/annotation/test_client.py
@@ -65,6 +65,18 @@ class TestSettings:
         with pytest.raises(ValueError):
             LabelStudioSettings(_env_file=None)
 
+    def test_an_empty_token_is_a_validation_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """`.env.example` ships the key with no value, so this is the copy-it flow.
+
+        Without the constraint it validates and the push sends
+        `Authorization: Token ` for a 401 mid-import, instead of the CLI's
+        "Label Studio is not configured" message.
+        """
+        monkeypatch.setenv("ARANDU_LABEL_STUDIO_URL", "https://label.example.test")
+        monkeypatch.setenv("ARANDU_LABEL_STUDIO_TOKEN", "")
+        with pytest.raises(ValueError):
+            LabelStudioSettings(_env_file=None)
+
     def test_trailing_slash_is_normalized(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("ARANDU_LABEL_STUDIO_URL", "https://label.example.test/")
         monkeypatch.setenv("ARANDU_LABEL_STUDIO_TOKEN", "abc")
@@ -302,6 +314,24 @@ class TestImportTasks:
             return httpx.Response(201, json={"task_count": 2})
 
         assert _client(handler).import_tasks(42, [{"data": {}}, {"data": {}}]) == 2
+
+    def test_a_response_without_a_count_returns_none(self) -> None:
+        """An unreported count must not be read as `len(tasks)`.
+
+        That fallback would report success for a partial import and leave the
+        missing pairs indistinguishable from unrated ones in every pull.
+        """
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(201, json={"import": 12, "status": "created"})
+
+        assert _client(handler).import_tasks(42, [{"data": {}}, {"data": {}}]) is None
+
+    def test_a_non_dict_response_returns_none(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(201, json=[{"id": 1}])
+
+        assert _client(handler).import_tasks(42, [{"data": {}}]) is None
 
     def test_error_is_wrapped(self) -> None:
         def handler(request: httpx.Request) -> httpx.Response:

--- a/tests/shared/annotation/test_client.py
+++ b/tests/shared/annotation/test_client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import base64
 import json
 from typing import TYPE_CHECKING, Any
 
@@ -19,13 +20,26 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
-def _client(handler: Any) -> HttpLabelStudioClient:
+def _client(handler: Any, token: str = "secret-token") -> HttpLabelStudioClient:
     transport = httpx.MockTransport(handler)
     return HttpLabelStudioClient(
         base_url="https://label.example.test",
-        token="secret-token",
+        token=token,
         transport=transport,
     )
+
+
+def _b64url(payload: dict[str, Any]) -> str:
+    """Encode a JWT segment the way a real token does, without the padding."""
+    raw = json.dumps(payload).encode("utf-8")
+    return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+
+def _jwt(token_type: str = "refresh") -> str:
+    """Build a JWT-shaped fixture token. No real credential is involved."""
+    header = _b64url({"alg": "HS256", "typ": "JWT"})
+    payload = _b64url({"token_type": token_type, "exp": 1, "jti": "fixture", "user_id": 1})
+    return f"{header}.{payload}.c2lnbmF0dXJl"
 
 
 class TestSettings:
@@ -93,6 +107,137 @@ class TestSettings:
         monkeypatch.setenv("ARANDU_LABEL_STUDIO_URL", "https://label.example.test")
         monkeypatch.setenv("ARANDU_LABEL_STUDIO_TOKEN", "abc")
         assert isinstance(build_client_from_settings(LabelStudioSettings()), HttpLabelStudioClient)
+
+
+class TestAuthentication:
+    """Both token schemes, pinned by behaviour rather than by our assumption.
+
+    The live instance issues JWT personal access tokens and rejects the legacy
+    ``Token`` header outright. Asserting only the header our own code produces
+    could never have caught that, so these tests assert what the server is
+    asked for: which endpoints are called, in which order, with which body.
+    """
+
+    def test_a_legacy_token_is_sent_as_token_and_never_refreshes(self) -> None:
+        calls: list[tuple[str, str]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            calls.append((request.url.path, request.headers.get("Authorization", "")))
+            return httpx.Response(201, json={"id": 42})
+
+        assert _client(handler, token="secret-token").create_project("t", "<View/>") == 42
+        assert calls == [("/api/projects/", "Token secret-token")]
+
+    def test_a_token_with_dots_but_no_json_payload_is_legacy(self) -> None:
+        """Decode failures fall back to the legacy scheme instead of raising."""
+        calls: list[tuple[str, str]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            calls.append((request.url.path, request.headers.get("Authorization", "")))
+            return httpx.Response(201, json={"id": 42})
+
+        _client(handler, token="not.a.jwt").create_project("t", "<View/>")
+        assert calls == [("/api/projects/", "Token not.a.jwt")]
+
+    def test_a_jwt_refresh_token_is_exchanged_for_a_bearer_access_token(self) -> None:
+        refresh = _jwt()
+        calls: list[tuple[str, str]] = []
+        bodies: list[Any] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            calls.append((request.url.path, request.headers.get("Authorization", "")))
+            if request.url.path == "/api/token/refresh":
+                bodies.append(json.loads(request.read().decode()))
+                return httpx.Response(200, json={"access": "access-1"})
+            return httpx.Response(201, json={"id": 42})
+
+        assert _client(handler, token=refresh).create_project("t", "<View/>") == 42
+        assert [path for path, _ in calls] == ["/api/token/refresh", "/api/projects/"]
+        assert bodies == [{"refresh": refresh}]
+        assert calls[1][1] == "Bearer access-1"
+
+    def test_the_exchange_happens_once_and_is_cached(self) -> None:
+        refreshes = 0
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal refreshes
+            if request.url.path == "/api/token/refresh":
+                refreshes += 1
+                return httpx.Response(200, json={"access": "access-1"})
+            if request.url.path.endswith("/import"):
+                return httpx.Response(201, json={"task_count": 1})
+            return httpx.Response(200, json=[])
+
+        client = _client(handler, token=_jwt())
+        client.import_tasks(42, [{"data": {}}])
+        client.export_annotations(42)
+
+        assert refreshes == 1
+
+    def test_a_401_triggers_exactly_one_re_exchange_and_one_retry(self) -> None:
+        issued = ["access-1", "access-2"]
+        seen: list[str] = []
+        refreshes = 0
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal refreshes
+            if request.url.path == "/api/token/refresh":
+                access = issued[refreshes]
+                refreshes += 1
+                return httpx.Response(200, json={"access": access})
+            seen.append(request.headers.get("Authorization", ""))
+            if len(seen) == 1:
+                return httpx.Response(401, json={"detail": "token not valid"})
+            return httpx.Response(200, json=[{"id": 1}])
+
+        assert _client(handler, token=_jwt()).export_annotations(42) == [{"id": 1}]
+        assert refreshes == 2
+        assert seen == ["Bearer access-1", "Bearer access-2"]
+
+    def test_a_second_consecutive_401_raises_without_looping(self) -> None:
+        refresh = _jwt()
+        refreshes = 0
+        attempts = 0
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal refreshes, attempts
+            if request.url.path == "/api/token/refresh":
+                refreshes += 1
+                return httpx.Response(200, json={"access": "access-token-value"})
+            attempts += 1
+            return httpx.Response(401, json={"detail": "token not valid"})
+
+        with pytest.raises(LabelStudioError) as excinfo:
+            _client(handler, token=refresh).export_annotations(42)
+
+        assert refreshes == 2
+        assert attempts == 2
+        message = str(excinfo.value)
+        assert "401" in message
+        assert refresh not in message
+        assert "access-token-value" not in message
+
+    def test_a_failed_refresh_is_an_actionable_error_without_the_tokens(self) -> None:
+        refresh = _jwt()
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.url.path == "/api/token/refresh"
+            return httpx.Response(401, json={"detail": refresh, "code": "token_not_valid"})
+
+        with pytest.raises(LabelStudioError) as excinfo:
+            _client(handler, token=refresh).create_project("t", "<View/>")
+
+        message = str(excinfo.value)
+        assert "Access Token" in message
+        assert "ARANDU_LABEL_STUDIO_URL" in message
+        assert refresh not in message
+
+    def test_a_refresh_response_without_an_access_token_is_an_error(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={"refresh": "rotated"})
+
+        with pytest.raises(LabelStudioError, match="access"):
+            _client(handler, token=_jwt()).create_project("t", "<View/>")
 
 
 class TestCreateProject:

--- a/tests/shared/annotation/test_labeling_config.py
+++ b/tests/shared/annotation/test_labeling_config.py
@@ -62,6 +62,39 @@ def surfaces(config: str, instruction: str) -> str:
     return _decoded_config(config) + "\n" + unescape(instruction)
 
 
+def _instruction_css(instruction: str) -> str:
+    """Return the CSS of the instruction fragment's scoped ``<style>`` block."""
+    style = ET.fromstring(f"<div>{instruction}</div>").find(".//style")
+    assert style is not None, "the instruction carries no style block"
+    return str(style.text)
+
+
+def _css_color_declarations(css: str) -> list[str]:
+    """Return the value of every ``color:`` declaration, excluding compounds.
+
+    ``background-color`` and ``border-color`` are not text colour, so the
+    lookbehind drops any property that ends in ``-color``.
+    """
+    return [value.strip() for value in re.findall(r"(?<![-\w])color\s*:\s*([^;}]+)", css)]
+
+
+def _assert_theme_agnostic(css: str) -> None:
+    """Fail if the CSS names a colour instead of inheriting or tinting.
+
+    The instrument is read under both Label Studio themes. Any literal colour
+    picks one of them and makes the other unreadable, which is what happened to
+    the first version of the canvas style, so this is asserted mechanically
+    rather than by eye: no hex literal anywhere, no opaque ``rgb()``, every
+    translucent neutral below full alpha, and ``color`` only ever ``inherit``.
+    """
+    assert re.search(r"#[0-9a-fA-F]{3,8}", css) is None, "hex colour literal in CSS"
+    assert "rgb(" not in css, "opaque rgb() in CSS"
+    alphas = [float(alpha) for alpha in re.findall(r"rgba\([^)]*,\s*([0-9.]+)\s*\)", css)]
+    assert alphas, "expected translucent neutrals to carry the surfaces"
+    assert all(alpha < 1.0 for alpha in alphas), "fully opaque rgba() in CSS"
+    assert set(_css_color_declarations(css)) <= {"inherit"}, "CSS sets an explicit text colour"
+
+
 def _ruler_passages(ruler: dict[str, Any]) -> list[tuple[str, str]]:
     """Return every annotator-facing ruler passage as ``(where, text)``.
 
@@ -134,6 +167,23 @@ class TestStructure:
         assert rendered == expected
         assert [str(v).split(" - ")[0] for v in rendered] == ["5", "4", "3", "2", "1"]
 
+    def test_every_option_hotkey_equals_its_own_score(self, config: str) -> None:
+        """The regression that must never come back.
+
+        With no explicit ``hotkey`` Label Studio numbers the options by position,
+        and these run 5..1, so key 1 recorded a 5 and key 5 recorded a 1. An
+        annotator pressing 5 for "preserves the meaning" stored the most severe
+        distortion label, and nothing in the UI said so.
+        """
+        choices = ET.fromstring(config).find(".//Choices")
+        assert choices is not None
+        options = list(choices.iter("Choice"))
+        assert options
+        for option in options:
+            score = re.match(r"\d+", str(option.get("value")))
+            assert score is not None, option.get("value")
+            assert option.get("hotkey") == score.group()
+
     def test_rationale_is_an_optional_textarea(self, config: str) -> None:
         area = ET.fromstring(config).find(".//TextArea")
         assert area is not None
@@ -182,6 +232,60 @@ class TestLayout:
         css = str(style.text)
         assert "max-height" in css
         assert "overflow-y: auto" in css
+
+
+class TestStyling:
+    """Both surfaces are read under a light and a dark theme, and neither picks one."""
+
+    def test_the_canvas_style_names_no_colour(self, config: str) -> None:
+        style = ET.fromstring(config).find("Style")
+        assert style is not None
+        _assert_theme_agnostic(str(style.text))
+
+    def test_the_canvas_style_keeps_its_layout_duties(self, config: str) -> None:
+        style = ET.fromstring(config).find("Style")
+        assert style is not None
+        css = str(style.text)
+        for declaration in ("max-height", "overflow-y: auto", "max-width: 70ch"):
+            assert declaration in css
+
+    def test_the_instruction_style_names_no_colour(self, instruction: str) -> None:
+        _assert_theme_agnostic(_instruction_css(instruction))
+
+    def test_the_instruction_style_is_scoped_to_its_wrapper(self, instruction: str) -> None:
+        """Nothing may leak into Label Studio's own UI, which shares the modal."""
+        root = ET.fromstring(f"<div>{instruction}</div>")
+        wrapper = root.find("./div")
+        assert wrapper is not None
+        assert wrapper.get("class") == "emic-instructions"
+        selectors = re.findall(r"([^{}]+)\{", _instruction_css(instruction))
+        assert selectors
+        for selector in selectors:
+            assert selector.strip().startswith(".emic-instructions"), selector
+
+    @pytest.mark.parametrize("level", ["h2", "h3"])
+    def test_a_heading_gets_more_space_above_than_below(self, instruction: str, level: str) -> None:
+        """A title must bind to the section it opens, not to the paragraph before it."""
+        rule = re.search(
+            rf"\.emic-instructions {level} \{{(.*?)\}}", _instruction_css(instruction), re.DOTALL
+        )
+        assert rule is not None
+        margin = re.search(r"margin:\s*([0-9.]+)em\s+\S+\s+([0-9.]+)em", rule.group(1))
+        assert margin is not None
+        assert float(margin.group(1)) > float(margin.group(2))
+
+    def test_it_still_reads_without_the_style_block(
+        self, instruction: str, ruler: dict[str, Any]
+    ) -> None:
+        """Label Studio may sanitise the block away, so meaning rides on the markup."""
+        root = ET.fromstring(f"<div>{instruction}</div>")
+        assert len(list(root.iter("h1"))) == 1
+        assert len(list(root.iter("h2"))) >= 5
+        items = {str(li.text) for ul in root.iter("ul") for li in ul}
+        for entry in ruler["scale"]:
+            assert f"{entry['score']} - {entry['label']}" in items
+        for element in root.iter():
+            assert element.get("style") is None, "no meaning may ride on an inline style"
 
 
 class TestRulerFidelity:
@@ -248,8 +352,9 @@ class TestInstructionHtml:
         assert ET.fromstring(f"<div>{instruction}</div>") is not None
 
     def test_uses_plain_semantic_elements(self, instruction: str) -> None:
+        """The wrapper and its scoped style block aside, the markup stays semantic."""
         root = ET.fromstring(f"<div>{instruction}</div>")
-        tags = {el.tag for el in root.iter()} - {"div"}
+        tags = {el.tag for el in root.iter()} - {"div", "style"}
         assert tags <= {"h1", "h2", "h3", "p", "ul", "li"}
 
     def test_carries_no_script(self, instruction: str) -> None:

--- a/tests/shared/annotation/test_labeling_config.py
+++ b/tests/shared/annotation/test_labeling_config.py
@@ -92,6 +92,18 @@ class TestRulerFidelity:
         for text in ruler["annotator_only"].values():
             assert text in config
 
+    def test_provisions_appear_verbatim(self, config: str, ruler: dict[str, Any]) -> None:
+        provisions = ruler["provisions"]
+        for key in ("unit_of_judgment", "question_calibrates", "out_of_scope"):
+            assert provisions[key] in config
+        for text in provisions["not_a_loss"]:
+            assert text in config
+
+    def test_guide_name_the_condition_appears_verbatim(
+        self, config: str, ruler: dict[str, Any]
+    ) -> None:
+        assert ruler["guide"]["name_the_condition"] in config
+
 
 class TestBlinding:
     def test_judge_only_text_never_reaches_the_annotator(

--- a/tests/shared/annotation/test_labeling_config.py
+++ b/tests/shared/annotation/test_labeling_config.py
@@ -1,0 +1,110 @@
+"""The labeling config carries the ruler verbatim and nothing that primes."""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+from typing import Any
+
+import pytest
+
+from arandu.shared.annotation.labeling_config import render_labeling_config
+from arandu.shared.annotation.ruler import load_ruler
+
+
+@pytest.fixture
+def ruler() -> dict[str, Any]:
+    return load_ruler()
+
+
+@pytest.fixture
+def config(ruler: dict[str, Any]) -> str:
+    return render_labeling_config(ruler)
+
+
+class TestStructure:
+    def test_is_well_formed_xml_rooted_at_view(self, config: str) -> None:
+        assert ET.fromstring(config).tag == "View"
+
+    def test_exposes_the_three_blinded_fields_only(self, config: str) -> None:
+        """`Text` is reserved for bound task variables; ruler prose uses `Header`."""
+        root = ET.fromstring(config)
+        values = {el.get("value") for el in root.iter("Text")}
+        assert values == {"$segment", "$question", "$answer"}
+
+    def test_no_static_element_binds_a_variable(self, config: str) -> None:
+        root = ET.fromstring(config)
+        for el in root.iter("Header"):
+            assert not str(el.get("value", "")).startswith("$")
+
+    def test_element_names_are_unique(self, config: str) -> None:
+        """Duplicate `name` attributes make Label Studio reject the config."""
+        names = [
+            el.get("name") for el in ET.fromstring(config).iter() if el.get("name") is not None
+        ]
+        assert len(names) == len(set(names))
+
+    def test_score_is_a_single_radio_with_shuffle_off(self, config: str) -> None:
+        choices = ET.fromstring(config).find(".//Choices")
+        assert choices is not None
+        assert choices.get("name") == "score"
+        assert choices.get("choice") == "single-radio"
+        assert choices.get("shuffle") == "false"
+        assert choices.get("required") == "true"
+
+    def test_options_are_descending_anchors(self, config: str, ruler: dict[str, Any]) -> None:
+        choices = ET.fromstring(config).find(".//Choices")
+        assert choices is not None
+        rendered = [el.get("value") for el in choices.iter("Choice")]
+        expected = [f"{e['score']} - {e['label']}" for e in ruler["scale"]]
+        assert rendered == expected
+        assert [v.split(" - ")[0] for v in rendered] == ["5", "4", "3", "2", "1"]
+
+    def test_rationale_is_an_optional_textarea(self, config: str) -> None:
+        area = ET.fromstring(config).find(".//TextArea")
+        assert area is not None
+        assert area.get("name") == "rationale"
+        assert area.get("required") in (None, "false")
+
+
+class TestRulerFidelity:
+    def test_every_scale_anchor_appears_verbatim(self, config: str, ruler: dict[str, Any]) -> None:
+        for entry in ruler["scale"]:
+            assert entry["label"] in config
+
+    def test_construct_and_guide_text_appear_verbatim(
+        self, config: str, ruler: dict[str, Any]
+    ) -> None:
+        for text in ruler["construct"].values():
+            assert text in config
+        for key in ("locate", "extract", "cascade_intro", "no_penalty"):
+            assert ruler["guide"][key] in config
+        for entry in ruler["guide"]["cascade"]:
+            assert entry["condition"] in config
+
+    def test_loss_types_appear_verbatim(self, config: str, ruler: dict[str, Any]) -> None:
+        for entry in ruler["loss_types"]:
+            assert entry["name"] in config
+            assert entry["what"] in config
+
+    def test_annotator_only_calibration_is_included(
+        self, config: str, ruler: dict[str, Any]
+    ) -> None:
+        for text in ruler["annotator_only"].values():
+            assert text in config
+
+
+class TestBlinding:
+    def test_judge_only_text_never_reaches_the_annotator(
+        self, config: str, ruler: dict[str, Any]
+    ) -> None:
+        judge_only = ruler["judge_only"]
+        assert judge_only["role"] not in config
+        assert judge_only["output"] not in config
+        for rule in judge_only["rationale_rules"]:
+            assert rule not in config
+
+    @pytest.mark.parametrize(
+        "leak", ["$pair_id", "$bloom_level", "$emic_score", "$cell_id", "$source_file_id"]
+    )
+    def test_no_stratification_variable_is_bound(self, config: str, leak: str) -> None:
+        assert leak not in config

--- a/tests/shared/annotation/test_labeling_config.py
+++ b/tests/shared/annotation/test_labeling_config.py
@@ -19,6 +19,7 @@ from typing import Any
 import pytest
 
 from arandu.shared.annotation.labeling_config import (
+    _SUMMARY_TITLE,
     render_expert_instruction,
     render_labeling_config,
 )
@@ -203,7 +204,9 @@ class TestLayout:
         assert collapse is not None
         panels = list(collapse.iter("Panel"))
         assert len(panels) == 1
-        assert "resumo" in str(panels[0].get("value"))
+        # Keyed on the constant, not a word from it: the panel's wording is the
+        # researcher's to change, and a title edit is not a layout regression.
+        assert panels[0].get("value") == _SUMMARY_TITLE
 
     def test_the_collapse_sits_inside_a_wrapper_we_can_style(self, config: str) -> None:
         """`Collapse`/`Panel` take no `className`, and their own chrome is light-theme.

--- a/tests/shared/annotation/test_labeling_config.py
+++ b/tests/shared/annotation/test_labeling_config.py
@@ -73,9 +73,13 @@ def _css_color_declarations(css: str) -> list[str]:
     """Return the value of every ``color:`` declaration, excluding compounds.
 
     ``background-color`` and ``border-color`` are not text colour, so the
-    lookbehind drops any property that ends in ``-color``.
+    lookbehind drops any property that ends in ``-color``. A trailing
+    ``!important`` is priority, not colour, so it is stripped before comparison:
+    ``inherit !important`` is still inheriting, and ``red !important`` still
+    fails.
     """
-    return [value.strip() for value in re.findall(r"(?<![-\w])color\s*:\s*([^;}]+)", css)]
+    values = re.findall(r"(?<![-\w])color\s*:\s*([^;}]+)", css)
+    return [re.sub(r"\s*!important$", "", value.strip()) for value in values]
 
 
 def _assert_theme_agnostic(css: str) -> None:
@@ -195,16 +199,28 @@ class TestLayout:
     """The pair sits immediately above the widget, and the ruler is out of the way."""
 
     def test_the_summary_is_a_panel_inside_a_collapse(self, config: str) -> None:
-        collapse = ET.fromstring(config).find("Collapse")
+        collapse = ET.fromstring(config).find(".//Collapse")
         assert collapse is not None
         panels = list(collapse.iter("Panel"))
         assert len(panels) == 1
         assert "resumo" in str(panels[0].get("value"))
 
+    def test_the_collapse_sits_inside_a_wrapper_we_can_style(self, config: str) -> None:
+        """`Collapse`/`Panel` take no `className`, and their own chrome is light-theme.
+
+        The only selector that can reach the component's DOM is a wrapper of
+        ours around it, so the wrapper is part of the contract, not decoration.
+        """
+        wrapper = ET.fromstring(config).find("./View[@className='emic-summary-wrap']")
+        assert wrapper is not None
+        assert wrapper.find("Collapse") is not None
+
     def test_the_pair_block_is_between_the_summary_and_the_score(self, config: str) -> None:
         root = ET.fromstring(config)
         order = [el.get("className") if el.tag == "View" else el.tag for el in root]
-        assert order.index("Collapse") < order.index("emic-pair") < order.index("emic-score")
+        assert (
+            order.index("emic-summary-wrap") < order.index("emic-pair") < order.index("emic-score")
+        )
 
     def test_the_score_widget_and_the_pair_are_adjacent(self, config: str) -> None:
         """Nothing may be inserted between them; that regression is the whole bug."""
@@ -247,6 +263,34 @@ class TestStyling:
         assert style is not None
         css = str(style.text)
         for declaration in ("max-height", "overflow-y: auto", "max-width: 70ch"):
+            assert declaration in css
+
+    def test_the_canvas_style_is_scoped_to_our_own_classes(self, config: str) -> None:
+        """The summary override is deliberately broad, so its scope is asserted.
+
+        Neutralising every descendant of the wrapper is the only way to reach
+        chrome whose class names we cannot read from here. That width is safe
+        only while every selector is anchored to a class this config emits, so
+        an unanchored rule (or one starting at a bare element or ``*``) fails.
+        """
+        style = ET.fromstring(config).find("Style")
+        assert style is not None
+        selectors = [
+            part.strip()
+            for group in re.findall(r"([^{}]+)\{", str(style.text))
+            for part in group.split(",")
+        ]
+        assert selectors
+        for selector in selectors:
+            assert selector.startswith(".emic-"), selector
+
+    def test_the_summary_override_neutralises_the_panel_chrome(self, config: str) -> None:
+        """Label Studio's `Panel` ships a light surface and text colour of its own."""
+        style = ET.fromstring(config).find("Style")
+        assert style is not None
+        css = str(style.text)
+        assert ".emic-summary-wrap * {" in css
+        for declaration in ("background: transparent !important", "color: inherit !important"):
             assert declaration in css
 
     def test_the_instruction_style_names_no_colour(self, instruction: str) -> None:

--- a/tests/shared/annotation/test_labeling_config.py
+++ b/tests/shared/annotation/test_labeling_config.py
@@ -1,13 +1,27 @@
-"""The labeling config carries the ruler verbatim and nothing that primes."""
+"""The two surfaces carry the ruler verbatim between them, and nothing that primes.
+
+The ruler used to be rendered whole onto the labeling canvas, which put two
+screens of prose between the pair and the rating widget. It is now split: the
+full text goes to Label Studio's instructions modal, and the canvas keeps a
+collapsed summary. Fidelity is therefore asserted against the UNION of the two
+surfaces, never against one of them alone; the placements that are themselves
+load-bearing (the anchors on the options, the cascade in the summary) are
+asserted individually on top of that.
+"""
 
 from __future__ import annotations
 
+import re
 import xml.etree.ElementTree as ET
+from html import unescape
 from typing import Any
 
 import pytest
 
-from arandu.shared.annotation.labeling_config import render_labeling_config
+from arandu.shared.annotation.labeling_config import (
+    render_expert_instruction,
+    render_labeling_config,
+)
 from arandu.shared.annotation.ruler import load_ruler
 
 
@@ -19,6 +33,67 @@ def ruler() -> dict[str, Any]:
 @pytest.fixture
 def config(ruler: dict[str, Any]) -> str:
     return render_labeling_config(ruler)
+
+
+@pytest.fixture
+def instruction(ruler: dict[str, Any]) -> str:
+    return render_expert_instruction(ruler)
+
+
+def _decoded_config(config: str) -> str:
+    """Return every attribute value and text node of the config, decoded.
+
+    The config carries ruler prose in XML attributes, so a passage holding a
+    quote or an ampersand is stored escaped. Comparing against the decoded
+    values asserts what the annotator reads rather than how it was serialised.
+    """
+    root = ET.fromstring(config)
+    parts: list[str] = []
+    for element in root.iter():
+        parts.extend(str(value) for value in element.attrib.values())
+        if element.text:
+            parts.append(element.text)
+    return "\n".join(parts)
+
+
+@pytest.fixture
+def surfaces(config: str, instruction: str) -> str:
+    """The union of both annotator-facing surfaces, decoded."""
+    return _decoded_config(config) + "\n" + unescape(instruction)
+
+
+def _ruler_passages(ruler: dict[str, Any]) -> list[tuple[str, str]]:
+    """Return every annotator-facing ruler passage as ``(where, text)``.
+
+    Iterated from the ruler itself: a new key, cascade step, loss type or
+    ``not_a_loss`` entry is covered the moment it is added, with no count or
+    literal to update here.
+    """
+    guide = ruler["guide"]
+    provisions = ruler["provisions"]
+    passages: list[tuple[str, str]] = []
+    passages += [(f"construct.{key}", text) for key, text in ruler["construct"].items()]
+    passages += [(f"scale[{entry['score']}]", entry["label"]) for entry in ruler["scale"]]
+    for entry in ruler["loss_types"]:
+        passages.append((f"loss_types[{entry['name']}].name", entry["name"]))
+        passages.append((f"loss_types[{entry['name']}].what", entry["what"]))
+    passages += [
+        (f"guide.{key}", guide[key])
+        for key in ("locate", "extract", "cascade_intro", "no_penalty", "name_the_condition")
+    ]
+    passages += [
+        (f"guide.cascade[{entry['score']}]", entry["condition"]) for entry in guide["cascade"]
+    ]
+    passages += [
+        (f"provisions.{key}", provisions[key])
+        for key in ("unit_of_judgment", "question_calibrates", "out_of_scope")
+    ]
+    passages += [
+        (f"provisions.not_a_loss[{index}]", text)
+        for index, text in enumerate(provisions["not_a_loss"])
+    ]
+    passages += [(f"annotator_only.{key}", text) for key, text in ruler["annotator_only"].items()]
+    return passages
 
 
 class TestStructure:
@@ -57,7 +132,7 @@ class TestStructure:
         rendered = [el.get("value") for el in choices.iter("Choice")]
         expected = [f"{e['score']} - {e['label']}" for e in ruler["scale"]]
         assert rendered == expected
-        assert [v.split(" - ")[0] for v in rendered] == ["5", "4", "3", "2", "1"]
+        assert [str(v).split(" - ")[0] for v in rendered] == ["5", "4", "3", "2", "1"]
 
     def test_rationale_is_an_optional_textarea(self, config: str) -> None:
         area = ET.fromstring(config).find(".//TextArea")
@@ -66,57 +141,150 @@ class TestStructure:
         assert area.get("required") in (None, "false")
 
 
+class TestLayout:
+    """The pair sits immediately above the widget, and the ruler is out of the way."""
+
+    def test_the_summary_is_a_panel_inside_a_collapse(self, config: str) -> None:
+        collapse = ET.fromstring(config).find("Collapse")
+        assert collapse is not None
+        panels = list(collapse.iter("Panel"))
+        assert len(panels) == 1
+        assert "resumo" in str(panels[0].get("value"))
+
+    def test_the_pair_block_is_between_the_summary_and_the_score(self, config: str) -> None:
+        root = ET.fromstring(config)
+        order = [el.get("className") if el.tag == "View" else el.tag for el in root]
+        assert order.index("Collapse") < order.index("emic-pair") < order.index("emic-score")
+
+    def test_the_score_widget_and_the_pair_are_adjacent(self, config: str) -> None:
+        """Nothing may be inserted between them; that regression is the whole bug."""
+        root = ET.fromstring(config)
+        order = [el.get("className") if el.tag == "View" else el.tag for el in root]
+        assert order.index("emic-score") == order.index("emic-pair") + 1
+
+    def test_the_pair_block_holds_all_three_bound_fields(self, config: str) -> None:
+        pair = ET.fromstring(config).find("./View[@className='emic-pair']")
+        assert pair is not None
+        assert {el.get("value") for el in pair.iter("Text")} == {
+            "$segment",
+            "$question",
+            "$answer",
+        }
+
+    def test_the_segment_is_wrapped_in_its_own_capped_box(self, config: str) -> None:
+        """A 4000-character chunk must scroll inside itself, not push the widget away."""
+        root = ET.fromstring(config)
+        box = root.find(".//View[@className='emic-segment']")
+        assert box is not None
+        assert [el.get("value") for el in box.iter("Text")] == ["$segment"]
+        style = root.find("Style")
+        assert style is not None
+        css = str(style.text)
+        assert "max-height" in css
+        assert "overflow-y: auto" in css
+
+
 class TestRulerFidelity:
-    def test_every_scale_anchor_appears_verbatim(self, config: str, ruler: dict[str, Any]) -> None:
+    def test_every_passage_appears_verbatim_across_the_two_surfaces(
+        self, surfaces: str, ruler: dict[str, Any]
+    ) -> None:
+        missing = [where for where, text in _ruler_passages(ruler) if text not in surfaces]
+        assert missing == []
+
+    def test_the_scale_anchors_are_on_the_options_themselves(
+        self, config: str, ruler: dict[str, Any]
+    ) -> None:
+        """The fidelity-critical placement: the annotator picks the anchor, not a number."""
+        choices = ET.fromstring(config).find(".//Choices")
+        assert choices is not None
+        options = [str(el.get("value")) for el in choices.iter("Choice")]
         for entry in ruler["scale"]:
-            assert entry["label"] in config
+            assert any(entry["label"] in option for option in options)
 
-    def test_construct_and_guide_text_appear_verbatim(
-        self, config: str, ruler: dict[str, Any]
-    ) -> None:
-        for text in ruler["construct"].values():
-            assert text in config
-        for key in ("locate", "extract", "cascade_intro", "no_penalty"):
-            assert ruler["guide"][key] in config
+    def test_the_cascade_is_in_the_canvas_summary(self, config: str, ruler: dict[str, Any]) -> None:
+        summary = _decoded_config(config)
+        assert ruler["guide"]["cascade_intro"] in summary
         for entry in ruler["guide"]["cascade"]:
-            assert entry["condition"] in config
+            assert entry["condition"] in summary
 
-    def test_loss_types_appear_verbatim(self, config: str, ruler: dict[str, Any]) -> None:
-        for entry in ruler["loss_types"]:
-            assert entry["name"] in config
-            assert entry["what"] in config
-
-    def test_annotator_only_calibration_is_included(
+    def test_the_no_penalty_list_is_in_the_canvas_summary(
         self, config: str, ruler: dict[str, Any]
     ) -> None:
+        assert ruler["guide"]["no_penalty"] in _decoded_config(config)
+
+    def test_the_annotator_calibration_is_in_the_canvas_summary(
+        self, config: str, ruler: dict[str, Any]
+    ) -> None:
+        summary = _decoded_config(config)
         for text in ruler["annotator_only"].values():
-            assert text in config
+            assert text in summary
 
-    def test_provisions_appear_verbatim(self, config: str, ruler: dict[str, Any]) -> None:
-        provisions = ruler["provisions"]
-        for key in ("unit_of_judgment", "question_calibrates", "out_of_scope"):
-            assert provisions[key] in config
-        for text in provisions["not_a_loss"]:
-            assert text in config
-
-    def test_guide_name_the_condition_appears_verbatim(
-        self, config: str, ruler: dict[str, Any]
+    def test_the_full_ruler_is_in_the_instruction(
+        self, instruction: str, ruler: dict[str, Any]
     ) -> None:
-        assert ruler["guide"]["name_the_condition"] in config
+        text = unescape(instruction)
+        provisions = ruler["provisions"]
+        for passage in ruler["construct"].values():
+            assert passage in text
+        for key in ("unit_of_judgment", "question_calibrates", "out_of_scope"):
+            assert provisions[key] in text
+        for entry in provisions["not_a_loss"]:
+            assert entry in text
+        for entry in ruler["loss_types"]:
+            assert entry["name"] in text
+            assert entry["what"] in text
+        for key, passage in ruler["guide"].items():
+            if isinstance(passage, str):
+                assert passage in text, key
+        for entry in ruler["guide"]["cascade"]:
+            assert entry["condition"] in text
+        for passage in ruler["annotator_only"].values():
+            assert passage in text
+
+
+class TestInstructionHtml:
+    def test_is_well_formed(self, instruction: str) -> None:
+        """It is a fragment, so it is parsed under a synthetic root."""
+        assert ET.fromstring(f"<div>{instruction}</div>") is not None
+
+    def test_uses_plain_semantic_elements(self, instruction: str) -> None:
+        root = ET.fromstring(f"<div>{instruction}</div>")
+        tags = {el.tag for el in root.iter()} - {"div"}
+        assert tags <= {"h1", "h2", "h3", "p", "ul", "li"}
+
+    def test_carries_no_script(self, instruction: str) -> None:
+        assert "<script" not in instruction.lower()
+
+    def test_references_nothing_off_host(self, instruction: str) -> None:
+        """A research instrument must not depend on a resource that can move."""
+        targets = re.findall(r'(?:src|href)\s*=\s*"([^"]*)"', instruction)
+        assert [t for t in targets if re.match(r"^(?:[a-zA-Z][\w+.-]*:)?//", t)] == []
+
+    def test_escapes_its_ruler_text(self, ruler: dict[str, Any]) -> None:
+        rendered = render_expert_instruction(
+            {**ruler, "annotator_only": {"x": 'a "quote" and <b> and &'}}
+        )
+        assert "&quot;quote&quot;" in rendered
+        assert "&lt;b&gt;" in rendered
+        assert ET.fromstring(f"<div>{rendered}</div>") is not None
 
 
 class TestBlinding:
-    def test_judge_only_text_never_reaches_the_annotator(
-        self, config: str, ruler: dict[str, Any]
+    def test_judge_only_text_reaches_neither_surface(
+        self, config: str, instruction: str, surfaces: str, ruler: dict[str, Any]
     ) -> None:
         judge_only = ruler["judge_only"]
-        assert judge_only["role"] not in config
-        assert judge_only["output"] not in config
-        for rule in judge_only["rationale_rules"]:
-            assert rule not in config
+        forbidden = [judge_only["role"], judge_only["output"], *judge_only["rationale_rules"]]
+        for text in forbidden:
+            assert text not in surfaces
+            assert text not in config
+            assert text not in instruction
 
     @pytest.mark.parametrize(
         "leak", ["$pair_id", "$bloom_level", "$emic_score", "$cell_id", "$source_file_id"]
     )
-    def test_no_stratification_variable_is_bound(self, config: str, leak: str) -> None:
+    def test_no_stratification_variable_is_bound(
+        self, config: str, instruction: str, leak: str
+    ) -> None:
         assert leak not in config
+        assert leak not in instruction

--- a/tests/shared/annotation/test_pull.py
+++ b/tests/shared/annotation/test_pull.py
@@ -44,7 +44,9 @@ class FakeClient:
         self.export = export
         self.exported: list[int] = []
 
-    def create_project(self, title: str, label_config: str) -> int:  # pragma: no cover
+    def create_project(  # pragma: no cover
+        self, title: str, label_config: str, *, settings: dict[str, Any] | None = None
+    ) -> int:
         raise AssertionError("pull must not create projects")
 
     def import_tasks(self, project_id: int, tasks: list[dict[str, Any]]) -> int:  # pragma: no cover
@@ -79,12 +81,33 @@ def _labels(base: Path, annotator: str) -> list[AnnotationLabel]:
         return [AnnotationLabel.model_validate_json(line) for line in fh if line.strip()]
 
 
+def _cancelled(user_id: int) -> dict[str, Any]:
+    """Label Studio's Skip button: a real annotation with no rating in it."""
+    return {
+        "completed_by": user_id,
+        "created_at": "2026-09-01T10:00:00Z",
+        "was_cancelled": True,
+        "result": [],
+    }
+
+
+def _annotator_map(base: Path) -> dict[str, str]:
+    path = base / "run-a" / "annotation" / "outputs" / ANNOTATOR_MAP_FILENAME
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
 class TestAnonymize:
     def test_assigns_a_prefixed_id_per_user_in_sorted_order(self) -> None:
         assert anonymize([77, 3, 51]) == {3: "A1", 51: "A2", 77: "A3"}
 
     def test_is_stable_across_calls(self) -> None:
         assert anonymize([77, 3]) == anonymize([3, 77])
+
+    def test_existing_bindings_are_preserved_verbatim(self) -> None:
+        assert anonymize([5, 12, 30], {12: "A1", 30: "A2"}) == {12: "A1", 30: "A2", 5: "A3"}
+
+    def test_new_ids_continue_the_numbering(self) -> None:
+        assert anonymize([1, 2], {9: "A1"}) == {9: "A1", 1: "A2", 2: "A3"}
 
 
 class TestPull:
@@ -157,7 +180,153 @@ class TestAnonymity:
         assert "completed_by" not in raw
 
 
+class TestSkippedAnnotations:
+    """A skip is a task nobody rated, not a broken export."""
+
+    def test_a_cancelled_annotation_does_not_abort_the_pull(self, pushed: Path) -> None:
+        export = [
+            _task(0, [_annotation(7, "5 - Preserva."), _cancelled(9)]),
+            _task(1, [_annotation(9, "4 - Apaga.")]),
+        ]
+        summary = run_pull_annotation("run-a", client=FakeClient(export), base_dir=pushed)
+        assert summary.annotators == {"A1": 1, "A2": 1}
+
+    def test_skips_are_counted_in_the_summary(self, pushed: Path) -> None:
+        export = [_task(0, [_cancelled(9)]), _task(1, [_cancelled(9)])]
+        summary = run_pull_annotation("run-a", client=FakeClient(export), base_dir=pushed)
+        assert summary.skipped == 2
+        assert summary.annotators == {}
+
+    def test_a_skip_writes_no_label(self, pushed: Path) -> None:
+        export = [_task(0, [_cancelled(7)]), _task(1, [_annotation(7, "3 - Acrescenta.")])]
+        run_pull_annotation("run-a", client=FakeClient(export), base_dir=pushed)
+        assert [label.pair_id for label in _labels(pushed, "A1")] == ["src-a:4"]
+
+    def test_an_empty_result_without_the_cancel_flag_is_also_a_skip(self, pushed: Path) -> None:
+        export = [
+            _task(0, [{"completed_by": 7, "created_at": "2026-09-01T10:00:00Z", "result": []}])
+        ]
+        summary = run_pull_annotation("run-a", client=FakeClient(export), base_dir=pushed)
+        assert summary.skipped == 1
+
+    def test_a_present_but_empty_score_region_still_raises(self, pushed: Path) -> None:
+        """A malformed rating is the measurement going missing; it must not pass."""
+        export = [
+            _task(
+                0,
+                [
+                    {
+                        "completed_by": 7,
+                        "created_at": "2026-09-01T10:00:00Z",
+                        "result": [
+                            {"from_name": "score", "type": "choices", "value": {"choices": []}}
+                        ],
+                    }
+                ],
+            )
+        ]
+        with pytest.raises(ValueError, match="carries no choice"):
+            run_pull_annotation("run-a", client=FakeClient(export), base_dir=pushed)
+
+
+class TestAliasStability:
+    """An alias, once written, belongs to that user id forever."""
+
+    def test_a_second_pull_with_a_new_annotator_preserves_the_first_aliases(
+        self, pushed: Path
+    ) -> None:
+        first = [_task(0, [_annotation(12, "5 - Preserva."), _annotation(30, "4 - Apaga.")])]
+        run_pull_annotation("run-a", client=FakeClient(first), base_dir=pushed)
+        assert _annotator_map(pushed) == {"12": "A1", "30": "A2"}
+
+        second = [
+            _task(
+                0,
+                [
+                    _annotation(12, "5 - Preserva."),
+                    _annotation(30, "4 - Apaga."),
+                    _annotation(5, "3 - Acrescenta."),
+                ],
+            )
+        ]
+        run_pull_annotation("run-a", client=FakeClient(second), base_dir=pushed)
+        assert _annotator_map(pushed) == {"5": "A3", "12": "A1", "30": "A2"}
+
+    def test_a_1_keeps_the_same_persons_labels_across_pulls(self, pushed: Path) -> None:
+        first = [_task(0, [_annotation(12, "5 - Preserva.")])]
+        run_pull_annotation("run-a", client=FakeClient(first), base_dir=pushed)
+        assert _labels(pushed, "A1")[0].score == 5
+
+        second = [
+            _task(0, [_annotation(12, "5 - Preserva.")]),
+            _task(1, [_annotation(5, "1 - Troca.")]),
+        ]
+        run_pull_annotation("run-a", client=FakeClient(second), base_dir=pushed)
+        assert _labels(pushed, "A1")[0].score == 5
+        assert _labels(pushed, "A2")[0].score == 1
+
+
+class TestAmbiguousProject:
+    """A --force re-push leaves two live projects and no safe default."""
+
+    @pytest.fixture
+    def two_projects(self, pushed: Path) -> Path:
+        path = pushed / "run-a" / "annotation" / "outputs" / MANIFEST_FILENAME
+        manifest = AnnotationManifest.load(path)
+        manifest.project_id = 99
+        manifest.project_ids = [42, 99]
+        manifest.save(path)
+        return pushed
+
+    def test_several_recorded_projects_refuse_to_pull(self, two_projects: Path) -> None:
+        client = FakeClient([])
+        with pytest.raises(ValueError, match="--project-id"):
+            run_pull_annotation("run-a", client=client, base_dir=two_projects)
+        assert client.exported == []
+
+    def test_the_error_lists_every_recorded_id(self, two_projects: Path) -> None:
+        with pytest.raises(ValueError, match="42, 99"):
+            run_pull_annotation("run-a", client=FakeClient([]), base_dir=two_projects)
+
+    def test_an_explicit_project_id_resolves_the_ambiguity(self, two_projects: Path) -> None:
+        client = FakeClient([_task(0, [_annotation(7, "5 - Preserva.")])])
+        summary = run_pull_annotation("run-a", client=client, base_dir=two_projects, project_id=42)
+        assert client.exported == [42]
+        assert summary.project_id == 42
+
+    def test_a_file_export_is_never_ambiguous(self, two_projects: Path, tmp_path: Path) -> None:
+        export_path = tmp_path / "export.json"
+        export_path.write_text(
+            json.dumps([_task(0, [_annotation(7, "5 - Preserva.")])]), encoding="utf-8"
+        )
+        summary = run_pull_annotation("run-a", export_file=export_path, base_dir=two_projects)
+        assert summary.annotators == {"A1": 1}
+
+
+class TestDuplicateRatings:
+    def test_the_same_annotator_rating_a_pair_twice_raises(self, pushed: Path) -> None:
+        export = [_task(0, [_annotation(7, "5 - Preserva."), _annotation(7, "2 - Troca.")])]
+        with pytest.raises(ValueError, match="src-a:0"):
+            run_pull_annotation("run-a", client=FakeClient(export), base_dir=pushed)
+
+    def test_the_error_names_the_annotator(self, pushed: Path) -> None:
+        export = [_task(0, [_annotation(7, "5 - Preserva."), _annotation(7, "2 - Troca.")])]
+        with pytest.raises(ValueError, match="A1"):
+            run_pull_annotation("run-a", client=FakeClient(export), base_dir=pushed)
+
+    def test_two_annotators_on_the_same_pair_are_fine(self, pushed: Path) -> None:
+        export = [_task(0, [_annotation(7, "5 - Preserva."), _annotation(9, "2 - Troca.")])]
+        summary = run_pull_annotation("run-a", client=FakeClient(export), base_dir=pushed)
+        assert summary.annotators == {"A1": 1, "A2": 1}
+
+
 class TestDesyncAndErrors:
+    def test_json_min_export_names_the_export_type(self, pushed: Path) -> None:
+        """JSON_MIN drops `data`, so the join key is simply absent."""
+        export = [{"id": 100, "score": "5 - Preserva.", "annotations": []}]
+        with pytest.raises(ValueError, match="JSON_MIN"):
+            run_pull_annotation("run-a", client=FakeClient(export), base_dir=pushed)
+
     def test_unknown_task_id_is_a_hard_failure(self, pushed: Path) -> None:
         export = [_task(99, [_annotation(7, "5 - Preserva.")])]
         with pytest.raises(KeyError, match="99"):

--- a/tests/shared/annotation/test_pull.py
+++ b/tests/shared/annotation/test_pull.py
@@ -1,0 +1,223 @@
+"""Pull anonymizes annotators and refuses to guess on a desynced project."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from arandu.shared.annotation.build import MANIFEST_FILENAME
+from arandu.shared.annotation.pull import (
+    ANNOTATOR_MAP_FILENAME,
+    LABELS_DIRNAME,
+    anonymize,
+    run_pull_annotation,
+)
+from arandu.shared.annotation.schemas import AnnotationLabel, AnnotationManifest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _annotation(user_id: int, choice: str, rationale: str | None = None) -> dict[str, Any]:
+    result: list[dict[str, Any]] = [
+        {"from_name": "score", "type": "choices", "value": {"choices": [choice]}}
+    ]
+    if rationale is not None:
+        result.append(
+            {"from_name": "rationale", "type": "textarea", "value": {"text": [rationale]}}
+        )
+    return {
+        "completed_by": user_id,
+        "created_at": "2026-09-01T10:00:00Z",
+        "result": result,
+    }
+
+
+def _task(task_id: int, annotations: list[dict[str, Any]]) -> dict[str, Any]:
+    return {"id": 100 + task_id, "data": {"task_id": task_id}, "annotations": annotations}
+
+
+class FakeClient:
+    def __init__(self, export: list[dict[str, Any]]) -> None:
+        self.export = export
+        self.exported: list[int] = []
+
+    def create_project(self, title: str, label_config: str) -> int:  # pragma: no cover
+        raise AssertionError("pull must not create projects")
+
+    def import_tasks(self, project_id: int, tasks: list[dict[str, Any]]) -> int:  # pragma: no cover
+        raise AssertionError("pull must not import tasks")
+
+    def export_annotations(self, project_id: int) -> list[dict[str, Any]]:
+        self.exported.append(project_id)
+        return self.export
+
+
+@pytest.fixture
+def pushed(tmp_path: Path) -> Path:
+    outputs = tmp_path / "run-a" / "annotation" / "outputs"
+    outputs.mkdir(parents=True)
+    AnnotationManifest(
+        pipeline_id="run-a",
+        seed=5,
+        total_items=3,
+        per_cell=15,
+        pool_sha256="c" * 64,
+        ruler_sha256="d" * 64,
+        task_map={"0": "src-a:0", "1": "src-a:4", "2": "src-b:2"},
+        project_id=42,
+        project_ids=[42],
+    ).save(outputs / MANIFEST_FILENAME)
+    return tmp_path
+
+
+def _labels(base: Path, annotator: str) -> list[AnnotationLabel]:
+    path = base / "run-a" / "annotation" / "outputs" / LABELS_DIRNAME / f"{annotator}.jsonl"
+    with path.open(encoding="utf-8") as fh:
+        return [AnnotationLabel.model_validate_json(line) for line in fh if line.strip()]
+
+
+class TestAnonymize:
+    def test_assigns_a_prefixed_id_per_user_in_sorted_order(self) -> None:
+        assert anonymize([77, 3, 51]) == {3: "A1", 51: "A2", 77: "A3"}
+
+    def test_is_stable_across_calls(self) -> None:
+        assert anonymize([77, 3]) == anonymize([3, 77])
+
+
+class TestPull:
+    def test_writes_one_jsonl_per_annotator(self, pushed: Path) -> None:
+        export = [
+            _task(0, [_annotation(7, "5 - Preserva."), _annotation(9, "4 - Apaga.")]),
+            _task(1, [_annotation(7, "3 - Acrescenta.")]),
+        ]
+        run_pull_annotation("run-a", client=FakeClient(export), base_dir=pushed)
+        assert len(_labels(pushed, "A1")) == 2
+        assert len(_labels(pushed, "A2")) == 1
+
+    def test_joins_task_id_back_to_pair_id(self, pushed: Path) -> None:
+        export = [_task(1, [_annotation(7, "3 - Acrescenta.")])]
+        run_pull_annotation("run-a", client=FakeClient(export), base_dir=pushed)
+        assert _labels(pushed, "A1")[0].pair_id == "src-a:4"
+
+    def test_parses_the_leading_integer_of_the_choice_label(self, pushed: Path) -> None:
+        export = [_task(0, [_annotation(7, "4 - Preserva o sentido, mas apaga.")])]
+        run_pull_annotation("run-a", client=FakeClient(export), base_dir=pushed)
+        assert _labels(pushed, "A1")[0].score == 4
+
+    def test_optional_rationale_round_trips(self, pushed: Path) -> None:
+        export = [_task(0, [_annotation(7, "2 - Troca o motivo.", rationale="trocou o motivo")])]
+        run_pull_annotation("run-a", client=FakeClient(export), base_dir=pushed)
+        assert _labels(pushed, "A1")[0].rationale == "trocou o motivo"
+
+    def test_absent_rationale_is_none(self, pushed: Path) -> None:
+        export = [_task(0, [_annotation(7, "5 - Preserva.")])]
+        run_pull_annotation("run-a", client=FakeClient(export), base_dir=pushed)
+        assert _labels(pushed, "A1")[0].rationale is None
+
+    def test_partial_annotation_is_accepted_and_counted(self, pushed: Path) -> None:
+        export = [_task(0, [_annotation(7, "5 - Preserva.")]), _task(1, []), _task(2, [])]
+        summary = run_pull_annotation("run-a", client=FakeClient(export), base_dir=pushed)
+        assert summary.annotators == {"A1": 1}
+        assert summary.total_items == 3
+
+    def test_uses_the_project_id_from_the_manifest(self, pushed: Path) -> None:
+        client = FakeClient([])
+        run_pull_annotation("run-a", client=client, base_dir=pushed)
+        assert client.exported == [42]
+
+
+class TestAnonymity:
+    def test_annotator_map_is_written_outside_the_labels_dir(self, pushed: Path) -> None:
+        export = [_task(0, [_annotation(7, "5 - Preserva.")])]
+        run_pull_annotation("run-a", client=FakeClient(export), base_dir=pushed)
+        outputs = pushed / "run-a" / "annotation" / "outputs"
+        assert (outputs / ANNOTATOR_MAP_FILENAME).exists()
+        assert not (outputs / LABELS_DIRNAME / ANNOTATOR_MAP_FILENAME).exists()
+
+    def test_no_email_or_user_id_appears_in_any_label_file(self, pushed: Path) -> None:
+        export = [
+            _task(
+                0,
+                [
+                    {
+                        **_annotation(7, "5 - Preserva."),
+                        "completed_by": {"id": 7, "email": "alguem@exemplo.org"},
+                    }
+                ],
+            )
+        ]
+        run_pull_annotation("run-a", client=FakeClient(export), base_dir=pushed)
+        raw = (pushed / "run-a" / "annotation" / "outputs" / LABELS_DIRNAME / "A1.jsonl").read_text(
+            encoding="utf-8"
+        )
+        assert "alguem@exemplo.org" not in raw
+        assert "completed_by" not in raw
+
+
+class TestDesyncAndErrors:
+    def test_unknown_task_id_is_a_hard_failure(self, pushed: Path) -> None:
+        export = [_task(99, [_annotation(7, "5 - Preserva.")])]
+        with pytest.raises(KeyError, match="99"):
+            run_pull_annotation("run-a", client=FakeClient(export), base_dir=pushed)
+
+    def test_unparseable_score_fails_rather_than_guessing(self, pushed: Path) -> None:
+        export = [_task(0, [_annotation(7, "muito bom")])]
+        with pytest.raises(ValueError, match="score"):
+            run_pull_annotation("run-a", client=FakeClient(export), base_dir=pushed)
+
+    def test_unpushed_run_names_the_push_command(self, tmp_path: Path) -> None:
+        outputs = tmp_path / "run-a" / "annotation" / "outputs"
+        outputs.mkdir(parents=True)
+        AnnotationManifest(
+            pipeline_id="run-a",
+            seed=5,
+            total_items=1,
+            per_cell=15,
+            pool_sha256="c" * 64,
+            ruler_sha256="d" * 64,
+            task_map={"0": "src-a:0"},
+        ).save(outputs / MANIFEST_FILENAME)
+        with pytest.raises(ValueError, match="emic-annotation-push"):
+            run_pull_annotation("run-a", client=FakeClient([]), base_dir=tmp_path)
+
+    def test_missing_build_names_the_build_command(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError, match="emic-annotation-build"):
+            run_pull_annotation("absent", client=FakeClient([]), base_dir=tmp_path)
+
+
+class TestFileExport:
+    def test_reads_a_downloaded_export_without_touching_the_network(
+        self, pushed: Path, tmp_path: Path
+    ) -> None:
+        export_path = tmp_path / "export.json"
+        export_path.write_text(
+            json.dumps([_task(0, [_annotation(7, "5 - Preserva.")])]), encoding="utf-8"
+        )
+        summary = run_pull_annotation("run-a", export_file=export_path, base_dir=pushed)
+        assert summary.annotators == {"A1": 1}
+
+    def test_file_export_works_on_an_unpushed_run(self, tmp_path: Path) -> None:
+        outputs = tmp_path / "run-a" / "annotation" / "outputs"
+        outputs.mkdir(parents=True)
+        AnnotationManifest(
+            pipeline_id="run-a",
+            seed=5,
+            total_items=1,
+            per_cell=15,
+            pool_sha256="c" * 64,
+            ruler_sha256="d" * 64,
+            task_map={"0": "src-a:0"},
+        ).save(outputs / MANIFEST_FILENAME)
+        export_path = tmp_path / "export.json"
+        export_path.write_text(
+            json.dumps([_task(0, [_annotation(7, "5 - Preserva.")])]), encoding="utf-8"
+        )
+        summary = run_pull_annotation("run-a", export_file=export_path, base_dir=tmp_path)
+        assert summary.project_id == 0
+
+    def test_requires_a_client_or_a_file(self, pushed: Path) -> None:
+        with pytest.raises(ValueError, match="export_file"):
+            run_pull_annotation("run-a", base_dir=pushed)

--- a/tests/shared/annotation/test_pull.py
+++ b/tests/shared/annotation/test_pull.py
@@ -209,6 +209,31 @@ class TestSkippedAnnotations:
         summary = run_pull_annotation("run-a", client=FakeClient(export), base_dir=pushed)
         assert summary.skipped == 1
 
+    def test_an_annotation_with_only_a_rationale_is_a_skip(self, pushed: Path) -> None:
+        """`required="true"` is client-side only, and the API bypasses it entirely."""
+        export = [
+            _task(
+                0,
+                [
+                    {
+                        "completed_by": 7,
+                        "created_at": "2026-09-01T10:00:00Z",
+                        "result": [
+                            {
+                                "from_name": "rationale",
+                                "type": "textarea",
+                                "value": {"text": ["sem nota"]},
+                            }
+                        ],
+                    }
+                ],
+            ),
+            _task(1, [_annotation(9, "4 - Apaga.")]),
+        ]
+        summary = run_pull_annotation("run-a", client=FakeClient(export), base_dir=pushed)
+        assert summary.skipped == 1
+        assert summary.annotators == {"A1": 1}
+
     def test_a_present_but_empty_score_region_still_raises(self, pushed: Path) -> None:
         """A malformed rating is the measurement going missing; it must not pass."""
         export = [
@@ -303,6 +328,64 @@ class TestAmbiguousProject:
         assert summary.annotators == {"A1": 1}
 
 
+class TestStaleLabelFiles:
+    """`labels/` must reflect exactly one pull, never a mix of two."""
+
+    def _labels_dir(self, base: Path) -> Path:
+        return base / "run-a" / "annotation" / "outputs" / LABELS_DIRNAME
+
+    def test_a_narrower_second_pull_removes_the_first_pulls_files(self, pushed: Path) -> None:
+        wide = [_task(0, [_annotation(7, "5 - Preserva."), _annotation(9, "4 - Apaga.")])]
+        run_pull_annotation("run-a", client=FakeClient(wide), base_dir=pushed)
+        assert (self._labels_dir(pushed) / "A2.jsonl").exists()
+
+        narrow = [_task(1, [_annotation(7, "3 - Acrescenta.")])]
+        run_pull_annotation("run-a", client=FakeClient(narrow), base_dir=pushed)
+
+        assert (self._labels_dir(pushed) / "A1.jsonl").exists()
+        assert not (self._labels_dir(pushed) / "A2.jsonl").exists()
+
+    def test_removed_files_are_counted_in_the_summary(self, pushed: Path) -> None:
+        wide = [_task(0, [_annotation(7, "5 - Preserva."), _annotation(9, "4 - Apaga.")])]
+        run_pull_annotation("run-a", client=FakeClient(wide), base_dir=pushed)
+
+        narrow = [_task(1, [_annotation(7, "3 - Acrescenta.")])]
+        summary = run_pull_annotation("run-a", client=FakeClient(narrow), base_dir=pushed)
+
+        assert summary.stale_removed == 1
+
+    def test_a_pull_that_writes_the_same_files_removes_nothing(self, pushed: Path) -> None:
+        export = [_task(0, [_annotation(7, "5 - Preserva.")])]
+        run_pull_annotation("run-a", client=FakeClient(export), base_dir=pushed)
+        summary = run_pull_annotation("run-a", client=FakeClient(export), base_dir=pushed)
+
+        assert summary.stale_removed == 0
+        assert (self._labels_dir(pushed) / "A1.jsonl").exists()
+
+    def test_the_annotator_map_survives(self, pushed: Path) -> None:
+        """It lives one level up and pins the aliases; deleting it would unpin them."""
+        wide = [_task(0, [_annotation(12, "5 - Preserva."), _annotation(30, "4 - Apaga.")])]
+        run_pull_annotation("run-a", client=FakeClient(wide), base_dir=pushed)
+
+        narrow = [_task(1, [_annotation(12, "3 - Acrescenta.")])]
+        run_pull_annotation("run-a", client=FakeClient(narrow), base_dir=pushed)
+
+        assert _annotator_map(pushed) == {"12": "A1", "30": "A2"}
+
+    def test_non_jsonl_files_in_the_labels_dir_are_left_alone(self, pushed: Path) -> None:
+        labels_dir = self._labels_dir(pushed)
+        labels_dir.mkdir(parents=True)
+        (labels_dir / "NOTES.md").write_text("nota do pesquisador", encoding="utf-8")
+
+        run_pull_annotation(
+            "run-a",
+            client=FakeClient([_task(0, [_annotation(7, "5 - Preserva.")])]),
+            base_dir=pushed,
+        )
+
+        assert (labels_dir / "NOTES.md").exists()
+
+
 class TestDuplicateRatings:
     def test_the_same_annotator_rating_a_pair_twice_raises(self, pushed: Path) -> None:
         export = [_task(0, [_annotation(7, "5 - Preserva."), _annotation(7, "2 - Troca.")])]
@@ -390,3 +473,25 @@ class TestFileExport:
     def test_requires_a_client_or_a_file(self, pushed: Path) -> None:
         with pytest.raises(ValueError, match="export_file"):
             run_pull_annotation("run-a", base_dir=pushed)
+
+    def test_a_file_and_a_project_id_together_are_refused(
+        self, pushed: Path, tmp_path: Path
+    ) -> None:
+        """Silently discarding the operator's project choice is not an option."""
+        export_path = tmp_path / "export.json"
+        export_path.write_text(
+            json.dumps([_task(0, [_annotation(7, "5 - Preserva.")])]), encoding="utf-8"
+        )
+        with pytest.raises(ValueError, match="--project-id"):
+            run_pull_annotation("run-a", export_file=export_path, base_dir=pushed, project_id=99)
+
+    def test_the_refusal_happens_before_anything_is_written(
+        self, pushed: Path, tmp_path: Path
+    ) -> None:
+        export_path = tmp_path / "export.json"
+        export_path.write_text(
+            json.dumps([_task(0, [_annotation(7, "5 - Preserva.")])]), encoding="utf-8"
+        )
+        with pytest.raises(ValueError):
+            run_pull_annotation("run-a", export_file=export_path, base_dir=pushed, project_id=99)
+        assert not (pushed / "run-a" / "annotation" / "outputs" / LABELS_DIRNAME).exists()

--- a/tests/shared/annotation/test_push.py
+++ b/tests/shared/annotation/test_push.py
@@ -7,7 +7,12 @@ from typing import TYPE_CHECKING, Any
 
 import pytest
 
-from arandu.shared.annotation.build import CONFIG_FILENAME, MANIFEST_FILENAME, TASKS_FILENAME
+from arandu.shared.annotation.build import (
+    CONFIG_FILENAME,
+    INSTRUCTION_FILENAME,
+    MANIFEST_FILENAME,
+    TASKS_FILENAME,
+)
 from arandu.shared.annotation.client import LabelStudioError
 from arandu.shared.annotation.push import run_push_annotation
 from arandu.shared.annotation.schemas import AnnotationManifest
@@ -48,6 +53,7 @@ def built(tmp_path: Path) -> Path:
     outputs = tmp_path / "run-a" / "annotation" / "outputs"
     outputs.mkdir(parents=True)
     (outputs / CONFIG_FILENAME).write_text("<View/>", encoding="utf-8")
+    (outputs / INSTRUCTION_FILENAME).write_text("<h1>A régua</h1>", encoding="utf-8")
     (outputs / TASKS_FILENAME).write_text(
         json.dumps([{"data": {"task_id": 0, "segment": "s", "question": "q", "answer": "a"}}]),
         encoding="utf-8",
@@ -124,7 +130,38 @@ class TestSkipButton:
     def test_create_disables_the_skip_button(self, built: Path) -> None:
         client = FakeClient()
         run_push_annotation("run-a", client=client, base_dir=built)
-        assert client.settings[0] == {"show_skip_button": False}
+        assert client.settings[0] is not None
+        assert client.settings[0]["show_skip_button"] is False
+
+
+class TestInstruction:
+    """The full ruler travels as the project's instructions, not on the canvas."""
+
+    def test_create_sends_the_instruction_html_from_disk(self, built: Path) -> None:
+        client = FakeClient()
+        run_push_annotation("run-a", client=client, base_dir=built)
+        assert client.settings[0] is not None
+        assert client.settings[0]["expert_instruction"] == "<h1>A régua</h1>"
+
+    def test_create_turns_the_instruction_button_on(self, built: Path) -> None:
+        client = FakeClient()
+        run_push_annotation("run-a", client=client, base_dir=built)
+        assert client.settings[0] is not None
+        assert client.settings[0]["show_instruction"] is True
+
+    def test_push_renders_nothing_itself(self, built: Path) -> None:
+        """Push transports only what the build wrote; the artifact is the authority."""
+        outputs = built / "run-a" / "annotation" / "outputs"
+        (outputs / INSTRUCTION_FILENAME).write_text("<p>substituído</p>", encoding="utf-8")
+        client = FakeClient()
+        run_push_annotation("run-a", client=client, base_dir=built)
+        assert client.settings[0] is not None
+        assert client.settings[0]["expert_instruction"] == "<p>substituído</p>"
+
+    def test_a_missing_instruction_names_the_build_command(self, built: Path) -> None:
+        (built / "run-a" / "annotation" / "outputs" / INSTRUCTION_FILENAME).unlink()
+        with pytest.raises(FileNotFoundError, match="emic-annotation-build"):
+            run_push_annotation("run-a", client=FakeClient(), base_dir=built)
 
 
 class TestAtomicity:

--- a/tests/shared/annotation/test_push.py
+++ b/tests/shared/annotation/test_push.py
@@ -1,0 +1,126 @@
+"""Push creates exactly one project per build, and records it."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from arandu.shared.annotation.build import CONFIG_FILENAME, MANIFEST_FILENAME, TASKS_FILENAME
+from arandu.shared.annotation.push import run_push_annotation
+from arandu.shared.annotation.schemas import AnnotationManifest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class FakeClient:
+    """In-memory :class:`LabelStudioClient`."""
+
+    def __init__(self, next_id: int = 42) -> None:
+        self.next_id = next_id
+        self.created: list[tuple[str, str]] = []
+        self.imported: list[tuple[int, list[dict[str, Any]]]] = []
+
+    def create_project(self, title: str, label_config: str) -> int:
+        self.created.append((title, label_config))
+        project_id = self.next_id
+        self.next_id += 1
+        return project_id
+
+    def import_tasks(self, project_id: int, tasks: list[dict[str, Any]]) -> int:
+        self.imported.append((project_id, tasks))
+        return len(tasks)
+
+    def export_annotations(self, project_id: int) -> list[dict[str, Any]]:
+        return []
+
+
+@pytest.fixture
+def built(tmp_path: Path) -> Path:
+    outputs = tmp_path / "run-a" / "annotation" / "outputs"
+    outputs.mkdir(parents=True)
+    (outputs / CONFIG_FILENAME).write_text("<View/>", encoding="utf-8")
+    (outputs / TASKS_FILENAME).write_text(
+        json.dumps([{"data": {"task_id": 0, "segment": "s", "question": "q", "answer": "a"}}]),
+        encoding="utf-8",
+    )
+    AnnotationManifest(
+        pipeline_id="run-a",
+        seed=5,
+        total_items=1,
+        per_cell=15,
+        pool_sha256="c" * 64,
+        ruler_sha256="d" * 64,
+        task_map={"0": "src-a:0"},
+    ).save(outputs / MANIFEST_FILENAME)
+    return tmp_path
+
+
+def _manifest(base: Path) -> AnnotationManifest:
+    return AnnotationManifest.load(base / "run-a" / "annotation" / "outputs" / MANIFEST_FILENAME)
+
+
+class TestPush:
+    def test_creates_the_project_and_imports_the_tasks(self, built: Path) -> None:
+        client = FakeClient()
+        project_id = run_push_annotation("run-a", client=client, base_dir=built)
+        assert project_id == 42
+        assert client.created[0][1] == "<View/>"
+        expected_task = {"data": {"task_id": 0, "segment": "s", "question": "q", "answer": "a"}}
+        assert client.imported == [(42, [expected_task])]
+
+    def test_records_the_project_id_in_the_manifest(self, built: Path) -> None:
+        run_push_annotation("run-a", client=FakeClient(), base_dir=built)
+        manifest = _manifest(built)
+        assert manifest.project_id == 42
+        assert manifest.project_ids == [42]
+
+    def test_default_title_carries_the_run_id(self, built: Path) -> None:
+        client = FakeClient()
+        run_push_annotation("run-a", client=client, base_dir=built)
+        assert "run-a" in client.created[0][0]
+
+    def test_explicit_title_wins(self, built: Path) -> None:
+        client = FakeClient()
+        run_push_annotation("run-a", client=client, base_dir=built, title="Validade êmica")
+        assert client.created[0][0] == "Validade êmica"
+
+
+class TestDuplicateProtection:
+    def test_second_push_refuses_and_names_the_project(self, built: Path) -> None:
+        run_push_annotation("run-a", client=FakeClient(), base_dir=built)
+        with pytest.raises(ValueError, match="42"):
+            run_push_annotation("run-a", client=FakeClient(), base_dir=built)
+
+    def test_second_push_creates_nothing(self, built: Path) -> None:
+        run_push_annotation("run-a", client=FakeClient(), base_dir=built)
+        second = FakeClient(next_id=99)
+        with pytest.raises(ValueError):
+            run_push_annotation("run-a", client=second, base_dir=built)
+        assert second.created == []
+
+    def test_force_creates_another_and_records_both(self, built: Path) -> None:
+        run_push_annotation("run-a", client=FakeClient(), base_dir=built)
+        second = run_push_annotation(
+            "run-a", client=FakeClient(next_id=99), base_dir=built, force=True
+        )
+        manifest = _manifest(built)
+        assert second == 99
+        assert manifest.project_id == 99
+        assert manifest.project_ids == [42, 99]
+
+
+class TestErrors:
+    def test_missing_build_names_the_build_command(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError, match="emic-annotation-build"):
+            run_push_annotation("absent", client=FakeClient(), base_dir=tmp_path)
+
+    def test_task_count_mismatch_with_the_manifest_fails(self, built: Path) -> None:
+        path = built / "run-a" / "annotation" / "outputs" / MANIFEST_FILENAME
+        manifest = AnnotationManifest.load(path)
+        manifest.total_items = 120
+        manifest.save(path)
+        with pytest.raises(ValueError, match="120"):
+            run_push_annotation("run-a", client=FakeClient(), base_dir=built)

--- a/tests/shared/annotation/test_push.py
+++ b/tests/shared/annotation/test_push.py
@@ -163,6 +163,16 @@ class TestAcceptedCount:
         with pytest.raises(ValueError, match="42"):
             run_push_annotation("run-a", client=FakeClient(accepted=0), base_dir=built)
 
+    def test_the_message_names_the_recovery_and_its_cost(self, built: Path) -> None:
+        """The project id is already recorded, so the remedy is not obvious."""
+        with pytest.raises(ValueError) as excinfo:
+            run_push_annotation("run-a", client=FakeClient(accepted=0), base_dir=built)
+        message = str(excinfo.value)
+        assert "already recorded" in message
+        assert "--force" in message
+        assert "--project-id" in message
+        assert "fresh run id" in message
+
 
 class TestErrors:
     def test_missing_build_names_the_build_command(self, tmp_path: Path) -> None:

--- a/tests/shared/annotation/test_push.py
+++ b/tests/shared/annotation/test_push.py
@@ -40,12 +40,20 @@ class FakeClient:
         self.next_id += 1
         return project_id
 
-    def import_tasks(self, project_id: int, tasks: list[dict[str, Any]]) -> int:
+    def import_tasks(self, project_id: int, tasks: list[dict[str, Any]]) -> int | None:
         self.imported.append((project_id, tasks))
         return len(tasks) if self.accepted is None else self.accepted
 
     def export_annotations(self, project_id: int) -> list[dict[str, Any]]:
         return []
+
+
+class _NoCountClient(FakeClient):
+    """Answers the import with a job envelope carrying no ``task_count``."""
+
+    def import_tasks(self, project_id: int, tasks: list[dict[str, Any]]) -> int | None:
+        self.imported.append((project_id, tasks))
+        return None
 
 
 @pytest.fixture
@@ -209,6 +217,28 @@ class TestAcceptedCount:
         assert "--force" in message
         assert "--project-id" in message
         assert "fresh run id" in message
+
+
+class TestUnreportedCount:
+    """An import the instance did not count is not an import that succeeded."""
+
+    def test_an_unreported_count_is_refused(self, built: Path) -> None:
+        with pytest.raises(ValueError, match="reported no task count"):
+            run_push_annotation("run-a", client=_NoCountClient(), base_dir=built)
+
+    def test_the_message_names_the_check_and_the_cost_of_re_pushing(self, built: Path) -> None:
+        with pytest.raises(ValueError) as excinfo:
+            run_push_annotation("run-a", client=_NoCountClient(), base_dir=built)
+        message = str(excinfo.value)
+        assert "compare its task count" in message
+        assert "--force" in message
+        assert "--project-id" in message
+
+    def test_the_project_stays_recorded_so_the_ui_check_is_possible(self, built: Path) -> None:
+        """The tasks may well be there; the operator needs the id to go look."""
+        with pytest.raises(ValueError):
+            run_push_annotation("run-a", client=_NoCountClient(), base_dir=built)
+        assert _manifest(built).project_id == 42
 
 
 class TestErrors:

--- a/tests/shared/annotation/test_push.py
+++ b/tests/shared/annotation/test_push.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 import pytest
 
 from arandu.shared.annotation.build import CONFIG_FILENAME, MANIFEST_FILENAME, TASKS_FILENAME
+from arandu.shared.annotation.client import LabelStudioError
 from arandu.shared.annotation.push import run_push_annotation
 from arandu.shared.annotation.schemas import AnnotationManifest
 
@@ -18,20 +19,25 @@ if TYPE_CHECKING:
 class FakeClient:
     """In-memory :class:`LabelStudioClient`."""
 
-    def __init__(self, next_id: int = 42) -> None:
+    def __init__(self, next_id: int = 42, *, accepted: int | None = None) -> None:
         self.next_id = next_id
+        self.accepted = accepted
         self.created: list[tuple[str, str]] = []
+        self.settings: list[dict[str, Any] | None] = []
         self.imported: list[tuple[int, list[dict[str, Any]]]] = []
 
-    def create_project(self, title: str, label_config: str) -> int:
+    def create_project(
+        self, title: str, label_config: str, *, settings: dict[str, Any] | None = None
+    ) -> int:
         self.created.append((title, label_config))
+        self.settings.append(settings)
         project_id = self.next_id
         self.next_id += 1
         return project_id
 
     def import_tasks(self, project_id: int, tasks: list[dict[str, Any]]) -> int:
         self.imported.append((project_id, tasks))
-        return len(tasks)
+        return len(tasks) if self.accepted is None else self.accepted
 
     def export_annotations(self, project_id: int) -> list[dict[str, Any]]:
         return []
@@ -110,6 +116,52 @@ class TestDuplicateProtection:
         assert second == 99
         assert manifest.project_id == 99
         assert manifest.project_ids == [42, 99]
+
+
+class TestSkipButton:
+    """A skip writes a rating-free annotation, so the button is turned off."""
+
+    def test_create_disables_the_skip_button(self, built: Path) -> None:
+        client = FakeClient()
+        run_push_annotation("run-a", client=client, base_dir=built)
+        assert client.settings[0] == {"show_skip_button": False}
+
+
+class TestAtomicity:
+    """The project id is recorded before the import, never after."""
+
+    def test_failed_import_still_records_the_project_id(self, built: Path) -> None:
+        class ImportFails(FakeClient):
+            def import_tasks(self, project_id: int, tasks: list[dict[str, Any]]) -> int:
+                raise LabelStudioError("timed out after 60s")
+
+        with pytest.raises(LabelStudioError):
+            run_push_annotation("run-a", client=ImportFails(), base_dir=built)
+        assert _manifest(built).project_id == 42
+
+    def test_a_re_push_after_a_failed_import_is_refused(self, built: Path) -> None:
+        class ImportFails(FakeClient):
+            def import_tasks(self, project_id: int, tasks: list[dict[str, Any]]) -> int:
+                raise LabelStudioError("timed out after 60s")
+
+        with pytest.raises(LabelStudioError):
+            run_push_annotation("run-a", client=ImportFails(), base_dir=built)
+        second = FakeClient(next_id=43)
+        with pytest.raises(ValueError, match="42"):
+            run_push_annotation("run-a", client=second, base_dir=built)
+        assert second.created == []
+
+
+class TestAcceptedCount:
+    """Silently importing fewer tasks is unrated pairs that nobody can tell apart."""
+
+    def test_short_import_raises_naming_both_counts(self, built: Path) -> None:
+        with pytest.raises(ValueError, match="accepted 0 of the 1"):
+            run_push_annotation("run-a", client=FakeClient(accepted=0), base_dir=built)
+
+    def test_short_import_names_the_project(self, built: Path) -> None:
+        with pytest.raises(ValueError, match="42"):
+            run_push_annotation("run-a", client=FakeClient(accepted=0), base_dir=built)
 
 
 class TestErrors:

--- a/tests/shared/annotation/test_ruler.py
+++ b/tests/shared/annotation/test_ruler.py
@@ -1,0 +1,88 @@
+"""The ruler loader is the mechanical form of the anthropologist gate."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+import yaml
+
+from arandu.shared.annotation.ruler import (
+    RULER_PATH,
+    RulerNotSignedOffError,
+    load_ruler,
+    require_signed_off,
+    ruler_sha256,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write_ruler(tmp_path: Path, *, signed_off: bool) -> Path:
+    path = tmp_path / "ruler.pt.yaml"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        yaml.safe_dump(
+            {
+                "signed_off": signed_off,
+                "gate": "anthropologist-validation-of-readings",
+                "scale": [{"score": 5, "label": "Preserva o sentido."}],
+            },
+            allow_unicode=True,
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+class TestLoadRuler:
+    def test_default_path_points_at_the_shipped_ruler(self) -> None:
+        assert RULER_PATH.name == "ruler.pt.yaml"
+        assert RULER_PATH.parent.name == "emic_validity"
+        assert RULER_PATH.exists()
+
+    def test_loads_the_shipped_ruler(self) -> None:
+        ruler = load_ruler()
+        assert ruler["signed_off"] is True
+        assert [entry["score"] for entry in ruler["scale"]] == [5, 4, 3, 2, 1]
+
+    def test_missing_file_names_the_path(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError, match=r"ruler\.pt\.yaml"):
+            load_ruler(tmp_path / "absent" / "ruler.pt.yaml")
+
+
+class TestSignOffGate:
+    def test_signed_off_ruler_passes(self, tmp_path: Path) -> None:
+        require_signed_off(load_ruler(_write_ruler(tmp_path, signed_off=True)))
+
+    def test_unsigned_ruler_raises_and_names_the_gate(self, tmp_path: Path) -> None:
+        ruler = load_ruler(_write_ruler(tmp_path, signed_off=False))
+        with pytest.raises(RulerNotSignedOffError) as excinfo:
+            require_signed_off(ruler)
+        assert "anthropologist-validation-of-readings" in str(excinfo.value)
+
+    def test_absent_flag_is_treated_as_unsigned(self, tmp_path: Path) -> None:
+        path = tmp_path / "ruler.pt.yaml"
+        path.write_text(yaml.safe_dump({"scale": []}), encoding="utf-8")
+        with pytest.raises(RulerNotSignedOffError):
+            require_signed_off(load_ruler(path))
+
+    def test_truthy_non_bool_is_not_accepted_as_signed(self, tmp_path: Path) -> None:
+        """`signed_off: "yes"` is a typo, not a signature."""
+        path = tmp_path / "ruler.pt.yaml"
+        path.write_text(yaml.safe_dump({"signed_off": "yes"}), encoding="utf-8")
+        with pytest.raises(RulerNotSignedOffError):
+            require_signed_off(load_ruler(path))
+
+
+class TestRulerHash:
+    def test_hash_is_stable_and_content_addressed(self, tmp_path: Path) -> None:
+        first = _write_ruler(tmp_path / "a", signed_off=True)
+        second = _write_ruler(tmp_path / "b", signed_off=True)
+        assert ruler_sha256(first) == ruler_sha256(second)
+
+    def test_hash_changes_with_content(self, tmp_path: Path) -> None:
+        signed = _write_ruler(tmp_path / "a", signed_off=True)
+        unsigned = _write_ruler(tmp_path / "b", signed_off=False)
+        assert ruler_sha256(signed) != ruler_sha256(unsigned)

--- a/tests/shared/annotation/test_schemas.py
+++ b/tests/shared/annotation/test_schemas.py
@@ -1,0 +1,94 @@
+"""Schemas for the annotation instrument, including the blinding contract."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+from pydantic import ValidationError
+
+from arandu.shared.annotation.schemas import (
+    AnnotationLabel,
+    AnnotationManifest,
+    AnnotationTask,
+)
+from arandu.shared.schemas import PipelineType
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _manifest(**overrides: object) -> AnnotationManifest:
+    base = {
+        "pipeline_id": "thesis-run-01",
+        "seed": 7,
+        "total_items": 2,
+        "per_cell": 15,
+        "pool_sha256": "a" * 64,
+        "ruler_sha256": "b" * 64,
+        "task_map": {"0": "src-a:3", "1": "src-b:11"},
+    }
+    base.update(overrides)
+    return AnnotationManifest(**base)  # type: ignore[arg-type]
+
+
+class TestPipelineType:
+    def test_annotation_stage_exists(self) -> None:
+        assert PipelineType.ANNOTATION.value == "annotation"
+
+
+class TestAnnotationTask:
+    def test_serializes_exactly_the_blinded_fields(self) -> None:
+        task = AnnotationTask(task_id=0, segment="s", question="q", answer="a")
+        assert set(task.model_dump().keys()) == {"task_id", "segment", "question", "answer"}
+
+    def test_rejects_unknown_fields(self) -> None:
+        """Extra keys are forbidden: a leak must be a crash, not a silent field."""
+        with pytest.raises(ValidationError):
+            AnnotationTask(task_id=0, segment="s", question="q", answer="a", bloom_level="analyze")
+
+    def test_to_label_studio_wraps_in_data(self) -> None:
+        task = AnnotationTask(task_id=4, segment="s", question="q", answer="a")
+        assert task.to_label_studio() == {
+            "data": {"task_id": 4, "segment": "s", "question": "q", "answer": "a"}
+        }
+
+
+class TestAnnotationManifest:
+    def test_round_trips_through_disk(self, tmp_path: Path) -> None:
+        path = tmp_path / "manifest.json"
+        _manifest().save(path)
+        assert AnnotationManifest.load(path) == _manifest()
+
+    def test_project_id_defaults_to_unpushed(self) -> None:
+        manifest = _manifest()
+        assert manifest.project_id is None
+        assert manifest.project_ids == []
+
+    def test_pair_id_for_resolves_the_join(self) -> None:
+        assert _manifest().pair_id_for(1) == "src-b:11"
+
+    def test_pair_id_for_unknown_task_raises(self) -> None:
+        with pytest.raises(KeyError):
+            _manifest().pair_id_for(99)
+
+    def test_task_map_is_never_written_to_label_studio_shape(self, tmp_path: Path) -> None:
+        """The join lives here and only here."""
+        path = tmp_path / "manifest.json"
+        _manifest().save(path)
+        assert "src-a:3" in json.loads(path.read_text(encoding="utf-8"))["task_map"].values()
+
+
+class TestAnnotationLabel:
+    def test_score_is_constrained_to_the_ordinal_range(self) -> None:
+        with pytest.raises(ValidationError):
+            AnnotationLabel(
+                pair_id="a:0", annotator_id="A1", score=6, rationale=None, timestamp="t"
+            )
+
+    def test_rationale_is_optional(self) -> None:
+        label = AnnotationLabel(
+            pair_id="a:0", annotator_id="A1", score=3, rationale=None, timestamp="t"
+        )
+        assert label.rationale is None

--- a/tests/shared/test_results_manager.py
+++ b/tests/shared/test_results_manager.py
@@ -12,6 +12,7 @@ import pytest
 
 from arandu.shared.results_manager import ResultsManager
 from arandu.shared.schemas import (
+    REDACTED_PLACEHOLDER,
     ConfigSnapshot,
     ExecutionEnvironment,
     HardwareInfo,
@@ -19,6 +20,7 @@ from arandu.shared.schemas import (
     PipelineType,
     RunMetadata,
     RunStatus,
+    is_secret_env_name,
 )
 
 if TYPE_CHECKING:
@@ -139,6 +141,88 @@ class TestConfigSnapshot:
         assert snapshot.config_values["workers"] == 4
         assert "ARANDU_MODEL_ID" in snapshot.environment_variables
         assert "OTHER_VAR" not in snapshot.environment_variables
+        assert snapshot.environment_variables["ARANDU_MODEL_ID"] == "env-model"
+
+
+class TestConfigSnapshotRedaction:
+    """A captured env var lands in run_metadata.json, so secrets never do."""
+
+    @pytest.fixture
+    def _config(self) -> type:
+        from pydantic import BaseModel
+
+        class TestConfig(BaseModel):
+            model_id: str = "test-model"
+
+        return TestConfig
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "ARANDU_LABEL_STUDIO_TOKEN",
+            "ARANDU_SOME_SECRET",
+            "ARANDU_DB_PASSWORD",
+            "ARANDU_OPENAI_API_KEY",
+            "ARANDU_GOOGLE_CREDENTIALS",
+            "ARANDU_lowercase_token",
+        ],
+    )
+    def test_credential_named_vars_are_redacted(
+        self, name: str, _config: type, mocker: MockerFixture
+    ) -> None:
+        mocker.patch.dict(os.environ, {name: "s3cr3t-value"}, clear=True)
+
+        snapshot = ConfigSnapshot.from_config(_config(), env_prefix="ARANDU_")
+
+        assert snapshot.environment_variables[name] == REDACTED_PLACEHOLDER
+        assert "s3cr3t-value" not in json.dumps(snapshot.model_dump(mode="json"))
+
+    def test_the_key_survives_redaction(self, _config: type, mocker: MockerFixture) -> None:
+        """The snapshot must still record that the variable was set."""
+        mocker.patch.dict(os.environ, {"ARANDU_LABEL_STUDIO_TOKEN": "abc"}, clear=True)
+
+        snapshot = ConfigSnapshot.from_config(_config(), env_prefix="ARANDU_")
+
+        assert "ARANDU_LABEL_STUDIO_TOKEN" in snapshot.environment_variables
+
+    def test_non_secret_vars_are_captured_verbatim(
+        self, _config: type, mocker: MockerFixture
+    ) -> None:
+        mocker.patch.dict(
+            os.environ,
+            {"ARANDU_LABEL_STUDIO_URL": "https://label.example.test", "ARANDU_WORKERS": "4"},
+            clear=True,
+        )
+
+        snapshot = ConfigSnapshot.from_config(_config(), env_prefix="ARANDU_")
+
+        assert snapshot.environment_variables["ARANDU_LABEL_STUDIO_URL"] == (
+            "https://label.example.test"
+        )
+        assert snapshot.environment_variables["ARANDU_WORKERS"] == "4"
+
+    def test_the_token_never_reaches_run_metadata_json(
+        self, tmp_path: Path, mocker: MockerFixture, mock_torch_cpu: MagicMock
+    ) -> None:
+        """The end-to-end path: an exported token must not land under results/."""
+        from pydantic import BaseModel
+
+        class TestConfig(BaseModel):
+            model_id: str = "test"
+
+        mocker.patch.dict(os.environ, {"ARANDU_LABEL_STUDIO_TOKEN": "s3cr3t-value"}, clear=True)
+
+        manager = ResultsManager(tmp_path, PipelineType.ANNOTATION, pipeline_id="run-a")
+        manager.create_run(TestConfig())
+
+        raw = (tmp_path / "run-a" / "annotation" / "run_metadata.json").read_text(encoding="utf-8")
+        assert "s3cr3t-value" not in raw
+        assert REDACTED_PLACEHOLDER in raw
+
+    def test_is_secret_env_name_is_case_insensitive(self) -> None:
+        assert is_secret_env_name("ARANDU_LABEL_STUDIO_TOKEN") is True
+        assert is_secret_env_name("arandu_label_studio_token") is True
+        assert is_secret_env_name("ARANDU_LABEL_STUDIO_URL") is False
 
 
 class TestRunMetadata:

--- a/tests/shared/test_results_manager.py
+++ b/tests/shared/test_results_manager.py
@@ -783,6 +783,7 @@ class TestPipelineType:
             "non_answerable",
             "emic_judge",
             "human_eval",
+            "annotation",
             "evaluation",
         }
         actual = {p.value for p in PipelineType}

--- a/uv.lock
+++ b/uv.lock
@@ -158,6 +158,7 @@ dependencies = [
     { name = "pt-core-news-sm" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "pyyaml" },
     { name = "rank-bm25" },
     { name = "rich" },
     { name = "sentencepiece" },
@@ -217,6 +218,7 @@ requires-dist = [
     { name = "pyarrow", marker = "extra == 'kg'", specifier = ">=15,<21" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
+    { name = "pyyaml", specifier = ">=6.0" },
     { name = "rank-bm25", specifier = ">=0.2.2" },
     { name = "rich", specifier = ">=13.0.0" },
     { name = "sentencepiece", specifier = ">=0.2.1" },
@@ -1535,7 +1537,7 @@ name = "nvidia-cublas-cu12"
 version = "12.4.5.8"
 source = { registry = "https://download.pytorch.org/whl/cu124" }
 wheels = [
-    { url = "https://download.pytorch.org/whl/cu124/nvidia_cublas_cu12-12.4.5.8-py3-none-manylinux2014_x86_64.whl", hash = "sha256:2fc8da60df463fdefa81e323eef2e36489e1c94335b5358bcb38360adf75ac9b" },
+    { url = "https://pypi.nvidia.com/nvidia-cublas-cu12/nvidia_cublas_cu12-12.4.5.8-py3-none-manylinux2014_x86_64.whl", hash = "sha256:2fc8da60df463fdefa81e323eef2e36489e1c94335b5358bcb38360adf75ac9b" },
 ]
 
 [[package]]
@@ -1543,7 +1545,7 @@ name = "nvidia-cuda-cupti-cu12"
 version = "12.4.127"
 source = { registry = "https://download.pytorch.org/whl/cu124" }
 wheels = [
-    { url = "https://download.pytorch.org/whl/cu124/nvidia_cuda_cupti_cu12-12.4.127-py3-none-manylinux2014_x86_64.whl", hash = "sha256:9dec60f5ac126f7bb551c055072b69d85392b13311fcc1bcda2202d172df30fb" },
+    { url = "https://pypi.nvidia.com/nvidia-cuda-cupti-cu12/nvidia_cuda_cupti_cu12-12.4.127-py3-none-manylinux2014_x86_64.whl", hash = "sha256:9dec60f5ac126f7bb551c055072b69d85392b13311fcc1bcda2202d172df30fb" },
 ]
 
 [[package]]
@@ -1551,7 +1553,7 @@ name = "nvidia-cuda-nvrtc-cu12"
 version = "12.4.127"
 source = { registry = "https://download.pytorch.org/whl/cu124" }
 wheels = [
-    { url = "https://download.pytorch.org/whl/cu124/nvidia_cuda_nvrtc_cu12-12.4.127-py3-none-manylinux2014_x86_64.whl", hash = "sha256:a178759ebb095827bd30ef56598ec182b85547f1508941a3d560eb7ea1fbf338" },
+    { url = "https://pypi.nvidia.com/nvidia-cuda-nvrtc-cu12/nvidia_cuda_nvrtc_cu12-12.4.127-py3-none-manylinux2014_x86_64.whl", hash = "sha256:a178759ebb095827bd30ef56598ec182b85547f1508941a3d560eb7ea1fbf338" },
 ]
 
 [[package]]
@@ -1559,7 +1561,7 @@ name = "nvidia-cuda-runtime-cu12"
 version = "12.4.127"
 source = { registry = "https://download.pytorch.org/whl/cu124" }
 wheels = [
-    { url = "https://download.pytorch.org/whl/cu124/nvidia_cuda_runtime_cu12-12.4.127-py3-none-manylinux2014_x86_64.whl", hash = "sha256:64403288fa2136ee8e467cdc9c9427e0434110899d07c779f25b5c068934faa5" },
+    { url = "https://pypi.nvidia.com/nvidia-cuda-runtime-cu12/nvidia_cuda_runtime_cu12-12.4.127-py3-none-manylinux2014_x86_64.whl", hash = "sha256:64403288fa2136ee8e467cdc9c9427e0434110899d07c779f25b5c068934faa5" },
 ]
 
 [[package]]
@@ -1581,7 +1583,7 @@ dependencies = [
     { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
-    { url = "https://download.pytorch.org/whl/cu124/nvidia_cufft_cu12-11.2.1.3-py3-none-manylinux2014_x86_64.whl", hash = "sha256:f083fc24912aa410be21fa16d157fed2055dab1cc4b6934a0e03cba69eb242b9" },
+    { url = "https://pypi.nvidia.com/nvidia-cufft-cu12/nvidia_cufft_cu12-11.2.1.3-py3-none-manylinux2014_x86_64.whl", hash = "sha256:f083fc24912aa410be21fa16d157fed2055dab1cc4b6934a0e03cba69eb242b9" },
 ]
 
 [[package]]
@@ -1589,7 +1591,7 @@ name = "nvidia-curand-cu12"
 version = "10.3.5.147"
 source = { registry = "https://download.pytorch.org/whl/cu124" }
 wheels = [
-    { url = "https://download.pytorch.org/whl/cu124/nvidia_curand_cu12-10.3.5.147-py3-none-manylinux2014_x86_64.whl", hash = "sha256:a88f583d4e0bb643c49743469964103aa59f7f708d862c3ddb0fc07f851e3b8b" },
+    { url = "https://pypi.nvidia.com/nvidia-curand-cu12/nvidia_curand_cu12-10.3.5.147-py3-none-manylinux2014_x86_64.whl", hash = "sha256:a88f583d4e0bb643c49743469964103aa59f7f708d862c3ddb0fc07f851e3b8b" },
 ]
 
 [[package]]
@@ -1602,7 +1604,7 @@ dependencies = [
     { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
-    { url = "https://download.pytorch.org/whl/cu124/nvidia_cusolver_cu12-11.6.1.9-py3-none-manylinux2014_x86_64.whl", hash = "sha256:19e33fa442bcfd085b3086c4ebf7e8debc07cfe01e11513cc6d332fd918ac260" },
+    { url = "https://pypi.nvidia.com/nvidia-cusolver-cu12/nvidia_cusolver_cu12-11.6.1.9-py3-none-manylinux2014_x86_64.whl", hash = "sha256:19e33fa442bcfd085b3086c4ebf7e8debc07cfe01e11513cc6d332fd918ac260" },
 ]
 
 [[package]]
@@ -1613,7 +1615,7 @@ dependencies = [
     { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
-    { url = "https://download.pytorch.org/whl/cu124/nvidia_cusparse_cu12-12.3.1.170-py3-none-manylinux2014_x86_64.whl", hash = "sha256:ea4f11a2904e2a8dc4b1833cc1b5181cde564edd0d5cd33e3c168eff2d1863f1" },
+    { url = "https://pypi.nvidia.com/nvidia-cusparse-cu12/nvidia_cusparse_cu12-12.3.1.170-py3-none-manylinux2014_x86_64.whl", hash = "sha256:ea4f11a2904e2a8dc4b1833cc1b5181cde564edd0d5cd33e3c168eff2d1863f1" },
 ]
 
 [[package]]
@@ -1621,7 +1623,7 @@ name = "nvidia-cusparselt-cu12"
 version = "0.6.2"
 source = { registry = "https://download.pytorch.org/whl/cu124" }
 wheels = [
-    { url = "https://download.pytorch.org/whl/cu124/nvidia_cusparselt_cu12-0.6.2-py3-none-manylinux2014_x86_64.whl", hash = "sha256:df2c24502fd76ebafe7457dbc4716b2fec071aabaed4fb7691a201cde03704d9" },
+    { url = "https://pypi.nvidia.com/nvidia-cusparselt-cu12/nvidia_cusparselt_cu12-0.6.2-py3-none-manylinux2014_x86_64.whl", hash = "sha256:df2c24502fd76ebafe7457dbc4716b2fec071aabaed4fb7691a201cde03704d9" },
 ]
 
 [[package]]
@@ -1629,8 +1631,7 @@ name = "nvidia-nccl-cu12"
 version = "2.21.5"
 source = { registry = "https://download.pytorch.org/whl/cu124" }
 wheels = [
-    { url = "https://download.pytorch.org/whl/cu124/nvidia_nccl_cu12-2.21.5-py3-none-manylinux2014_x86_64.whl", hash = "sha256:8579076d30a8c24988834445f8d633c697d42397e92ffc3f63fa26766d25e0a0" },
-    { url = "https://download.pytorch.org/whl/nvidia_nccl_cu12-2.21.5-py3-none-manylinux2014_x86_64.whl", hash = "sha256:8579076d30a8c24988834445f8d633c697d42397e92ffc3f63fa26766d25e0a0" },
+    { url = "https://pypi.nvidia.com/nvidia-nccl-cu12/nvidia_nccl_cu12-2.21.5-py3-none-manylinux2014_x86_64.whl", hash = "sha256:8579076d30a8c24988834445f8d633c697d42397e92ffc3f63fa26766d25e0a0" },
 ]
 
 [[package]]
@@ -1638,7 +1639,7 @@ name = "nvidia-nvjitlink-cu12"
 version = "12.4.127"
 source = { registry = "https://download.pytorch.org/whl/cu124" }
 wheels = [
-    { url = "https://download.pytorch.org/whl/cu124/nvidia_nvjitlink_cu12-12.4.127-py3-none-manylinux2014_x86_64.whl", hash = "sha256:06b3b9b25bf3f8af351d664978ca26a16d2c5127dbd53c0497e28d1fb9611d57" },
+    { url = "https://pypi.nvidia.com/nvidia-nvjitlink-cu12/nvidia_nvjitlink_cu12-12.4.127-py3-none-manylinux2014_x86_64.whl", hash = "sha256:06b3b9b25bf3f8af351d664978ca26a16d2c5127dbd53c0497e28d1fb9611d57" },
 ]
 
 [[package]]
@@ -1646,7 +1647,7 @@ name = "nvidia-nvtx-cu12"
 version = "12.4.127"
 source = { registry = "https://download.pytorch.org/whl/cu124" }
 wheels = [
-    { url = "https://download.pytorch.org/whl/cu124/nvidia_nvtx_cu12-12.4.127-py3-none-manylinux2014_x86_64.whl", hash = "sha256:781e950d9b9f60d8241ccea575b32f5105a5baf4c2351cab5256a24869f12a1a" },
+    { url = "https://pypi.nvidia.com/nvidia-nvtx-cu12/nvidia_nvtx_cu12-12.4.127-py3-none-manylinux2014_x86_64.whl", hash = "sha256:781e950d9b9f60d8241ccea575b32f5105a5baf4c2351cab5256a24869f12a1a" },
 ]
 
 [[package]]
@@ -3065,8 +3066,9 @@ wheels = [
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://download.pytorch.org/whl/cu124" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466" }
 wheels = [
-    { url = "https://download.pytorch.org/whl/typing_extensions-4.15.0-py3-none-any.whl" },
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Implementa o instrumento de anotação êmica: os três comandos que levam a amostra estratificada de 120 pares para o Label Studio e trazem de volta as notas dos três antropólogos.

- `arandu emic-annotation-build --id <run> --seed N` — offline e determinístico. Lê `sample.jsonl` e a régua assinada, escreve `labeling_config.xml` + `tasks.json` + `manifest.json` em `results/<id>/annotation/outputs/`. Sem rede e sem segredo, então dá para auditar blindagem e âncoras antes de qualquer coisa chegar numa pessoa.
- `arandu emic-annotation-push --id <run>` — cria o projeto no Label Studio a partir do que o build escreveu e importa as tarefas.
- `arandu emic-annotation-pull --id <run> [-f export.json]` — busca as anotações, anonimiza os anotadores e escreve um JSONL por anotador.

Novo pacote `arandu.shared.annotation` (`ruler`, `labeling_config`, `schemas`, `build`, `settings`, `client`, `push`, `pull`), novo módulo `arandu/cli/annotation.py`, e o estágio `PipelineType.ANNOTATION`.

## As propriedades que o instrumento tem de garantir

Cada uma é travada por teste, porque nenhuma delas é recuperável depois que a anotação começa.

- **Fidelidade da régua.** As âncoras que os humanos leem saem de `prompts/judge/criteria/emic_validity/ruler.pt.yaml`, a mesma fonte que alimenta o prompt do juiz. Se as duas réguas divergirem, o kappa ponderado passa a medir divergência de tradução em vez de concordância.
- **Blindagem.** O anotador vê `segment`, `question` e `answer`, e nada mais. `AnnotationTask` usa `extra="forbid"`, então tentar passar `bloom_level`, `emic_score` ou `pair_id` é erro de validação na construção, não vazamento silencioso. Um teste confere o texto cru de `tasks.json`, não só as chaves parseadas.
- **`pair_id` fora da plataforma.** Ele é `sourcefileid:índice`, então enviá-lo deixaria um anotador atento agrupar pares da mesma entrevista e ler a estratificação. O join `task_id -> pair_id` vive só no nosso `manifest.json`.
- **Determinismo.** Mesma seed e mesma amostra reproduzem `tasks.json` byte a byte, por ordenação sobre SHA-256(`seed:pair_id`), estável entre versões de Python.
- **Anonimato.** O export traz `completed_by` numérico, então o mapeamento vai do inteiro direto para `A1`/`A2`/`A3` e o email nunca é pedido à API. O `annotator_map.json` fica **ao lado** de `labels/`, nunca dentro, porque `labels/` é o que alimenta a análise de concordância.
- **Contenção do segredo.** O token é `SecretStr`, nunca é escrito sob `results/` e nunca é logado, nem truncado.

## A trava do gate

O `build` recusa rodar enquanto `ruler.pt.yaml` não tiver `signed_off: true`, citando o gate `anthropologist-validation-of-readings`. Só o booleano `True` abre: flag ausente ou string `"yes"` levantam. Um typo não pode abrir o gate.

## O que a revisão da branch inteira encontrou

As sete unidades passaram individualmente. A revisão do conjunto achou 1 Critical e 5 Important, todos nas costuras entre elas. Todos corrigidos, cada um com teste de regressão verificado falhando sem a correção:

- **O botão Skip do Label Studio vem ligado por padrão** e o `push` não desligava nada (`required="true"` bloqueia Submit, não Skip). Um pulo gera anotação com `was_cancelled: true` e `result` vazio, e o parser abortava **todo** pull seguinte. Um clique de um anotador quebrava a coleta de todos. Corrigido nos dois lados: `show_skip_button: False` na criação do projeto, e o `pull` tratando pulo como "ainda não avaliado" e contando separado.
- **O `push` não era atômico.** O `project_id` só era salvo depois do import, então timeout no import deixava o projeto vivo com o manifest em `None`, desarmando a guarda de duplicata justamente no caso em que ela importa.
- **A contagem de tarefas aceitas era descartada.** 118 de 120 lia como sucesso e depois como "dois pares não avaliados".
- **Os aliases não eram estáveis entre pulls**, embora a docstring e a documentação prometessem que eram. Um pull de progresso com 2 anotadores e outro depois com 3 reescreviam `A1.jsonl` com os labels de outra pessoa. Agora o mapa existente é lido e preservado.
- **`--force` gravava `project_ids` que nada lia.** Pull depois de re-push reportava "nenhuma anotação" enquanto avaliações reais ficavam no projeto abandonado. Agora levanta listando todos os ids e exige `--project-id`.
- **A guarda de rebuild não cobria o caminho `-f`**, deixando `labels/` casado com um `task_map` velho sem nada marcando a divergência.

Além disso: `task_id` desconhecido aborta o pull inteiro em vez de pular a linha, e todos os ids são resolvidos antes de qualquer escrita, então dessincronia não deixa um `labels/` meio escrito. Nota impossível de parsear levanta em vez de chutar, porque aquela nota é a medida que o estudo reporta.

## Desvio do desenho original

O spec previa `<Rating>` com estrelas. Isto usa `<Choices choice="single-radio" shuffle="false">` com a frase da âncora escrita em cada opção. A objeção registrada era ao **shuffle** (embaralhar escala ordinal destrói o significado), não ao `Choices`. Com estrelas o anotador precisa mapear contagem de estrela para um parágrafo em outro lugar da página, que é exatamente o passo de tradução que o protocolo existe para eliminar; o juiz não faz esse passo, porque o prompt põe a âncora ao lado do número.

## Test plan

- [x] Suíte completa: **1872 passed** (baseline 1732 antes desta branch)
- [x] `uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/`
- [x] Cada teste novo verificado falhando sem a sua correção
- [x] Fidelidade da régua verificada renderizando contra o `ruler.pt.yaml` assinado de verdade, não contra fixture
- [ ] **Dry run manual contra a instância real antes de convidar os anotadores.** Três suposições sobre a API não foram exercitadas: que o `GET /api/projects/{id}/export?exportType=JSON` síncrono ainda existe na 1.23 CE (em vez dos endpoints assíncronos de snapshot), que o default `download_all_tasks=false` é o desejado, e que o `import` devolve `task_count` em vez de envelope de job.
- [ ] Confirmar que `show_skip_button` pegou. O campo foi conferido na tag 1.23.0, mas se o nome estiver errado o DRF ignora chave desconhecida em silêncio. O tratamento de `was_cancelled` no `pull` cobre o caso de qualquer forma.

## Fora de escopo

Backup da instância (não é código e não é opcional: os labels são irrecuperáveis sem reconvocar os três antropólogos), texto do termo de consentimento, e o `emic-analysis` que consome os `labels/*.jsonl` daqui (o núcleo estatístico já existe do PR #122).
