### PR TITLE
chore(scripts): add general scripts

### DIFF
--- a/scripts/_khop_revalidate_prep.py
+++ b/scripts/_khop_revalidate_prep.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""One-off khop re-validation prep (runs INSIDE a root container on the cluster).
+
+Backs up then clears ONLY the khop_passage / khop_triple state of the
+mini-dry-run-qwen run so a resume re-runs khop with the new linker while the
+non-khop arms (atlas_rag, bm25, null) stay as an untouched control. Backup at
+results/mini-dry-run-qwen/_khop_v1_backup/ makes it reversible. Paths are the
+in-container /app/results mount.
+"""
+
+from __future__ import annotations
+
+import glob
+import json
+import os
+import shutil
+
+R = "/app/results/mini-dry-run-qwen"
+BK = os.path.join(R, "_khop_v1_backup")
+ARMS = ("khop_passage", "khop_triple")
+STAGES = ("retrieve/outputs", "answers/outputs", "judge_answers/outputs")
+CKPTS = (
+    "retrieve/**/retrieve_checkpoint.json",
+    "answers/**/answer_checkpoint.json",
+    "judge_answers/**/judge_answers_checkpoint.json",
+)
+
+
+def _keep(key: str) -> bool:
+    return not any(key.startswith(f"{arm}::") for arm in ARMS)
+
+
+def main() -> None:
+    os.makedirs(BK, exist_ok=True)
+
+    for stage in STAGES:
+        for arm in ARMS:
+            src = os.path.join(R, stage, arm)
+            if os.path.isdir(src):
+                dst = os.path.join(BK, stage, arm)
+                os.makedirs(os.path.dirname(dst), exist_ok=True)
+                if not os.path.exists(dst):
+                    shutil.copytree(src, dst)
+                shutil.rmtree(src)
+                print(f"backed up + removed  {src}")
+
+    for pattern in CKPTS:
+        for cp in glob.glob(os.path.join(R, pattern), recursive=True):
+            shutil.copy2(cp, os.path.join(BK, os.path.basename(cp) + ".bak"))
+            data = json.load(open(cp))
+            before = len(data.get("completed_files", []))
+            if isinstance(data.get("completed_files"), list):
+                data["completed_files"] = [k for k in data["completed_files"] if _keep(k)]
+            if isinstance(data.get("failed_files"), dict):
+                data["failed_files"] = {k: v for k, v in data["failed_files"].items() if _keep(k)}
+            json.dump(data, open(cp, "w"), indent=2)
+            print(f"stripped {cp}: {before} -> {len(data['completed_files'])} completed")
+
+    print("PREP_DONE")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/audit_near_threshold_qa.py
+++ b/scripts/audit_near_threshold_qa.py
@@ -1,0 +1,211 @@
+"""Near-threshold QA-judge audit protocol.
+
+Surfaces CEP QA pairs that the LLM-as-a-Judge REJECTED but only barely: the
+pair would have passed if a single criterion had scored one anchor step higher.
+With the anchored 5-point scale {1.0, 0.75, 0.5, 0.25, 0.0} and a 0.625
+threshold, the closest failing anchor is 0.5 (margin 0.125). Pairs whose ONLY
+sub-threshold criterion scored 0.5 are the prime candidates for "good example
+excluded by too-strict filtering" and are the focus of this audit.
+
+Protocol (what this script encodes):
+  1. Load every ``*_cep_qa.json`` under the input dir; read each pair's
+     ``validation.stage_results.*.criterion_scores`` (continuous criteria only;
+     ordinal criteria run in score mode and never gate, so they are ignored).
+  2. A pair FAILED iff ``validation.passed is False``. For each failed pair,
+     collect its failing criteria (``score < threshold``) and the margin
+     (``threshold - score``).
+  3. Classify each failed pair:
+       - ``sole_near_miss``  : exactly ONE failing criterion, scored 0.5
+                               (margin == 0.125). Strongest recovery candidate.
+       - ``all_near_miss``   : >1 failing criteria but ALL scored 0.5.
+       - ``has_severe``      : at least one failing criterion <= 0.25 (a real
+                               miss, not a borderline call).
+  4. Rank ``sole_near_miss`` pairs by the strength of their PASSING criteria
+     (higher mean = "strong pair, one borderline criterion"), so the best
+     wrongly-excluded examples surface first.
+  5. Report: counts by class, the gate-keeping criterion distribution, the
+     per-Bloom-level breakdown, and the top-N candidate pairs verbatim (question,
+     answer, the single failing criterion + its rationale, the passing scores)
+     for human review.
+
+The output is a human-review worklist, NOT an automated re-label: a person
+decides whether each surfaced pair is genuinely good. Recurring patterns (e.g.
+one criterion gate-keeping most near-misses) are evidence the threshold or that
+criterion's rubric may be mis-calibrated.
+
+Usage:
+    python scripts/audit_near_threshold_qa.py <cep_outputs_dir> [--top N] \
+        [--out report.md]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any
+
+NEAR_MARGIN = 0.125  # threshold(0.625) - closest failing anchor(0.5)
+
+
+def _iter_criteria(validation: dict[str, Any]) -> list[tuple[str, dict[str, Any]]]:
+    """Flatten all continuous criterion scores across stages.
+
+    Returns (name, criterion_dict) pairs, skipping ordinal criteria (which run
+    in score mode and do not gate) and criteria that errored.
+    """
+    out: list[tuple[str, dict[str, Any]]] = []
+    for _stage, step in (validation.get("stage_results") or {}).items():
+        for name, cs in (step.get("criterion_scores") or {}).items():
+            if cs.get("score") is None:  # ordinal or errored -> not a continuous gate
+                continue
+            out.append((name, cs))
+    return out
+
+
+def classify_pair(validation: dict[str, Any]) -> dict[str, Any] | None:
+    """Classify a FAILED pair by how close it was to passing.
+
+    Returns None if the pair passed or carries no usable continuous criteria.
+    """
+    if validation.get("passed") is not False:
+        return None
+    crits = _iter_criteria(validation)
+    if not crits:
+        return None
+
+    failing = [(n, c) for n, c in crits if c["score"] < c["threshold"]]
+    passing = [(n, c) for n, c in crits if c["score"] >= c["threshold"]]
+    if not failing:
+        return None  # passed flag false but no continuous criterion failed; skip
+
+    worst = min(c["score"] for _n, c in failing)
+    margins = {n: round(c["threshold"] - c["score"], 4) for n, c in failing}
+    has_severe = worst <= 0.25 + 1e-9
+    all_near = all(m <= NEAR_MARGIN + 1e-9 for m in margins.values())
+
+    if len(failing) == 1 and all_near:
+        cls = "sole_near_miss"
+    elif all_near:
+        cls = "all_near_miss"
+    elif has_severe:
+        cls = "has_severe"
+    else:
+        cls = "other"
+
+    pass_mean = sum(c["score"] for _n, c in passing) / len(passing) if passing else 0.0
+    return {
+        "cls": cls,
+        "failing": [(n, c["score"], c["threshold"], c.get("rationale", "")) for n, c in failing],
+        "passing": [(n, c["score"]) for n, c in passing],
+        "pass_mean": round(pass_mean, 4),
+        "gate": failing[0][0] if len(failing) == 1 else "+".join(sorted(n for n, _ in failing)),
+    }
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("input_dir", type=Path)
+    ap.add_argument("--top", type=int, default=20, help="Top-N sole-near-miss examples to dump.")
+    ap.add_argument("--out", type=Path, default=None, help="Write markdown report here.")
+    args = ap.parse_args()
+
+    files = sorted(args.input_dir.glob("*_cep_qa.json"))
+    total_pairs = judged = passed = 0
+    by_cls: Counter[str] = Counter()
+    sole_gate: Counter[str] = Counter()
+    sole_by_bloom: Counter[str] = Counter()
+    gate_by_bloom: dict[str, Counter[str]] = defaultdict(Counter)
+    candidates: list[dict[str, Any]] = []
+
+    for f in files:
+        data = json.loads(f.read_text(encoding="utf-8"))
+        for p in data.get("qa_pairs", []):
+            total_pairs += 1
+            v = p.get("validation")
+            if not v:
+                continue
+            judged += 1
+            if v.get("passed") is True:
+                passed += 1
+                continue
+            info = classify_pair(v)
+            if info is None:
+                continue
+            by_cls[info["cls"]] += 1
+            bloom = p.get("bloom_level", "?")
+            if info["cls"] == "sole_near_miss":
+                sole_gate[info["gate"]] += 1
+                sole_by_bloom[bloom] += 1
+                gate_by_bloom[info["gate"]][bloom] += 1
+                candidates.append(
+                    {
+                        "file": f.name,
+                        "bloom": bloom,
+                        "question": p.get("question", ""),
+                        "answer": p.get("answer", ""),
+                        "gate": info["gate"],
+                        "gate_score": info["failing"][0][1],
+                        "gate_rationale": info["failing"][0][3],
+                        "passing": info["passing"],
+                        "pass_mean": info["pass_mean"],
+                    }
+                )
+
+    candidates.sort(key=lambda c: c["pass_mean"], reverse=True)
+    failed = judged - passed
+
+    lines: list[str] = []
+    w = lines.append
+    w("# Near-threshold QA-judge audit — thesis-run-01\n")
+    w(f"- Files: **{len(files)}** | pairs: **{total_pairs}** | judged: **{judged}** "
+      f"| passed: **{passed}** ({passed / judged * 100:.1f}%) | failed: **{failed}**\n")
+    w("## Failed-pair classification\n")
+    w("| Class | Count | % of failed |")
+    w("|---|---|---|")
+    for cls in ("sole_near_miss", "all_near_miss", "has_severe", "other"):
+        n = by_cls.get(cls, 0)
+        w(f"| {cls} | {n} | {n / failed * 100:.1f}% |" if failed else f"| {cls} | {n} | - |")
+    recoverable = by_cls.get("sole_near_miss", 0)
+    w(f"\n**{recoverable} pairs ({recoverable / failed * 100:.1f}% of failures)** failed on a "
+      "SINGLE criterion that scored 0.5 (one anchor below the 0.625 gate) — the prime "
+      "over-strict-exclusion candidates.\n")
+
+    w("## Gate-keeping criterion (sole near-miss fails)\n")
+    w("| Criterion | Pairs gated |")
+    w("|---|---|")
+    for name, n in sole_gate.most_common():
+        w(f"| {name} | {n} |")
+
+    w("\n## Sole near-miss by Bloom level\n")
+    w("| Bloom | Pairs |")
+    w("|---|---|")
+    for bloom, n in sole_by_bloom.most_common():
+        w(f"| {bloom} | {n} |")
+
+    w(f"\n## Recovery candidates by gate criterion (top {args.top} each, strongest first)\n")
+    w("Review each criterion's near-misses as a cohort: a criterion whose 0.5 "
+      "rationales repeatedly penalise *correct, faithful, well-formed* answers is "
+      "over-strict; one that catches real defects (fabrication, context-dependence) "
+      "is working.\n")
+    for gate in [g for g, _ in sole_gate.most_common()]:
+        group = [c for c in candidates if c["gate"] == gate]
+        w(f"### Gate: `{gate}` — {len(group)} sole near-miss pairs\n")
+        for i, c in enumerate(group[: args.top], 1):
+            passing_str = ", ".join(f"{n}={s}" for n, s in c["passing"])
+            w(f"**{i}. [{c['bloom']}]** (others: {passing_str})")
+            w(f"- **Q:** {c['question']}")
+            w(f"- **A:** {c['answer']}")
+            w(f"- **{gate}=0.5 rationale:** {c['gate_rationale']}")
+            w(f"- _source: {c['file']}_\n")
+
+    report = "\n".join(lines)
+    if args.out:
+        args.out.write_text(report, encoding="utf-8")
+        print(f"Wrote {args.out}")
+    print(report[:4000])
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/cap_cep_pairs.py
+++ b/scripts/cap_cep_pairs.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Cap each cep `*_cep_qa.json` file's qa_pairs to a Bloom-stratified sample.
+
+One-off dry-run helper: the per-chunk Bloom ladder generated 670 QA pairs across
+4 transcripts (Barra-Celia I alone = 370), which would make judge-qa + the whole
+downstream chain run for days. Trim to a small, Bloom-balanced sample per file so
+the dry-run stays a fast plumbing shakeout. The full 670-pair set is backed up to
+`cep/outputs_full670/` so it can be restored for the real test-kg-04 run.
+
+Usage:
+    python3 scripts/cap_cep_pairs.py <pipeline_id> [cap_per_file]
+"""
+
+from __future__ import annotations
+
+import json
+import random
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+SEED = 42
+
+
+def main() -> None:
+    pipeline_id = sys.argv[1] if len(sys.argv) > 1 else "mini-dry-run-qwen"
+    cap = int(sys.argv[2]) if len(sys.argv) > 2 else 12
+
+    out_dir = Path("results") / pipeline_id / "cep" / "outputs"
+    backup_dir = Path("results") / pipeline_id / "cep" / "outputs_full670"
+    backup_dir.mkdir(parents=True, exist_ok=True)
+
+    rng = random.Random(SEED)
+    total_before = total_after = 0
+
+    for f in sorted(out_dir.glob("*_cep_qa.json")):
+        record = json.loads(f.read_text(encoding="utf-8"))
+        pairs = record.get("qa_pairs", [])
+        total_before += len(pairs)
+
+        backup = backup_dir / f.name
+        if not backup.exists():
+            backup.write_text(json.dumps(record, ensure_ascii=False, indent=2), encoding="utf-8")
+
+        if len(pairs) <= cap:
+            total_after += len(pairs)
+            print(f"  {f.name[:22]}: {len(pairs)} (kept all)")
+            continue
+
+        # Bloom-stratified round-robin so the cross-cut stays representative.
+        groups: dict[str, list] = defaultdict(list)
+        for p in pairs:
+            groups[p.get("bloom_level", "?")].append(p)
+        for g in groups.values():
+            rng.shuffle(g)
+
+        levels = sorted(groups)
+        capped: list = []
+        i = 0
+        while len(capped) < cap and any(groups[lv] for lv in levels):
+            lv = levels[i % len(levels)]
+            if groups[lv]:
+                capped.append(groups[lv].pop())
+            i += 1
+
+        record["qa_pairs"] = capped
+        # Keep doc-level counters consistent with the trimmed pair list.
+        # QARecordCEP enforces total_pairs == len(qa_pairs) on load; a stale
+        # total_pairs makes the judge CLI silently skip the whole file.
+        record["total_pairs"] = len(capped)
+        record["validated_pairs"] = sum(1 for p in capped if p.get("is_valid"))
+        record["validation_rate"] = (
+            record["validated_pairs"] / len(capped) if capped else 0.0
+        )
+        f.write_text(json.dumps(record, ensure_ascii=False, indent=2), encoding="utf-8")
+        total_after += len(capped)
+        dist = defaultdict(int)
+        for p in capped:
+            dist[p.get("bloom_level", "?")] += 1
+        print(f"  {f.name[:22]}: {len(pairs)} -> {len(capped)}  {dict(dist)}")
+
+    print(f"TOTAL: {total_before} -> {total_after}  (backup: {backup_dir})")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/export_cep_pairs_markdown.py
+++ b/scripts/export_cep_pairs_markdown.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""Export every cep QA pair to a readable markdown for emic-validity review.
+
+Walks ``results/<pipeline_id>/cep/outputs/*_cep_qa.json`` and renders one
+markdown document grouped by **source interview -> chunk -> QA pair**. For each
+chunk the source segment (``context``) is printed once, followed by every pair
+generated from it: question, answer, reasoning trace and tacit inference (when
+present), plus the judge evaluation scores and rationale.
+
+Purpose: support the anthropological validation of emic readings (the
+`anthropologist-validation-of-readings` gate). Unlike the blinded annotation
+instrument, this dump exposes everything (bloom level, scores, reasoning) so
+the reviewer can analyse the full corpus at once.
+
+Reads raw JSON rather than ``QARecordCEP`` so legacy on-disk ``validation``
+formats still render (matches the sibling ``cap_cep_pairs.py`` approach).
+
+Usage:
+    python3 scripts/export_cep_pairs_markdown.py [pipeline_id] [--output PATH] [--valid-only]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any
+
+from arandu.utils.logger import print_error, print_info, print_success
+
+CRITERIA = ("faithfulness", "bloom_calibration", "informativeness", "self_containedness")
+
+
+def _short_id(filename: str) -> str:
+    """Return the gdrive-id prefix of a ``*_cep_qa.json`` filename."""
+    return filename.removesuffix("_cep_qa.json")
+
+
+def _fmt_score(value: Any) -> str:
+    """Format a numeric score to 2 decimals, or ``-`` when missing."""
+    if isinstance(value, (int, float)):
+        return f"{value:.2f}"
+    return "-"
+
+
+def _extract_validation(validation: dict[str, Any] | None) -> dict[str, Any]:
+    """Pull overall/criterion scores and rationale from a ``validation`` dict.
+
+    Tolerates the flat legacy layout (criteria as top-level keys) and the
+    nested ``criterion_scores`` layout. Returns a normalised dict with the four
+    named criteria, ``overall`` and ``rationale``.
+
+    Args:
+        validation: The raw ``validation`` payload from a QA pair, or None.
+
+    Returns:
+        Normalised score dict; values are None when unavailable.
+    """
+    out: dict[str, Any] = dict.fromkeys(CRITERIA)
+    out["overall"] = None
+    out["rationale"] = None
+    if not validation:
+        return out
+
+    nested = validation.get("criterion_scores") or {}
+    for crit in CRITERIA:
+        if crit in validation and isinstance(validation[crit], (int, float)):
+            out[crit] = validation[crit]
+        elif crit in nested and isinstance(nested[crit], dict):
+            out[crit] = nested[crit].get("score")
+    out["overall"] = validation.get("overall_score")
+    out["rationale"] = validation.get("judge_rationale")
+    return out
+
+
+def _render_pair(pair: dict[str, Any], index: int) -> list[str]:
+    """Render a single QA pair as markdown lines.
+
+    Args:
+        pair: A raw QA-pair dict from ``qa_pairs``.
+        index: 1-based position of the pair within its chunk.
+
+    Returns:
+        List of markdown lines (no trailing newline per line).
+    """
+    bloom = pair.get("bloom_level", "?")
+    qtype = pair.get("question_type", "?")
+    is_valid = pair.get("is_valid")
+    valid_mark = {True: "valido", False: "rejeitado", None: "nao-julgado"}[is_valid]
+    multi = ""
+    if pair.get("is_multi_hop"):
+        multi = f" | multi-hop ({pair.get('hop_count', '?')} hops)"
+
+    v = _extract_validation(pair.get("validation"))
+    lines = [
+        f"#### Par {index} - bloom: `{bloom}` | tipo: `{qtype}` | {valid_mark}{multi}",
+        "",
+        f"**Pergunta:** {pair.get('question', '').strip()}",
+        "",
+        f"**Resposta:** {pair.get('answer', '').strip()}",
+        "",
+    ]
+
+    tacit = pair.get("tacit_inference")
+    if tacit:
+        lines += [f"**Inferencia tacita:** {str(tacit).strip()}", ""]
+
+    reasoning = pair.get("reasoning_trace")
+    if reasoning:
+        lines += [f"**Raciocinio (geracao):** {str(reasoning).strip()}", ""]
+
+    score_line = (
+        f"**Avaliacao:** overall {_fmt_score(v['overall'])} | "
+        f"faithfulness {_fmt_score(v['faithfulness'])} | "
+        f"bloom_calibration {_fmt_score(v['bloom_calibration'])} | "
+        f"informativeness {_fmt_score(v['informativeness'])} | "
+        f"self_containedness {_fmt_score(v['self_containedness'])}"
+    )
+    lines += [score_line, ""]
+
+    if v["rationale"]:
+        lines += [
+            "<details><summary>Rationale do juiz</summary>",
+            "",
+            str(v["rationale"]).strip(),
+            "",
+            "</details>",
+            "",
+        ]
+    return lines
+
+
+def _render_source(record: dict[str, Any], valid_only: bool) -> tuple[list[str], int]:
+    """Render one source file (interview) as markdown lines, grouped by chunk.
+
+    Args:
+        record: The parsed ``*_cep_qa.json`` document.
+        valid_only: When True, skip pairs whose ``is_valid`` is not True.
+
+    Returns:
+        Tuple of (markdown lines, number of pairs rendered).
+    """
+    meta = record.get("source_metadata") or {}
+    participant = meta.get("participant_name") or "(sem nome)"
+    location = meta.get("location") or "(sem local)"
+    rec_date = meta.get("recording_date") or "?"
+    seq = meta.get("sequence_label") or ""
+    event = meta.get("event_context") or ""
+    short = _short_id(record.get("source_filename", "")) or record.get("source_file_id", "?")
+
+    pairs = record.get("qa_pairs", [])
+    if valid_only:
+        pairs = [p for p in pairs if p.get("is_valid") is True]
+    if not pairs:
+        return [], 0
+
+    header = f"## {participant} - {location}"
+    if seq:
+        header += f" ({seq})"
+    lines = [
+        header,
+        "",
+        f"_Fonte:_ `{short}` | _Data:_ {rec_date} | _Pares:_ {len(pairs)}",
+        "",
+    ]
+    if event:
+        lines += [f"_Contexto do evento:_ {event}", ""]
+
+    # Group pairs by their source chunk (``context``), preserving order.
+    chunks: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    order: list[str] = []
+    for p in pairs:
+        ctx = p.get("context", "")
+        if ctx not in chunks:
+            order.append(ctx)
+        chunks[ctx].append(p)
+
+    for chunk_idx, ctx in enumerate(order, start=1):
+        chunk_pairs = chunks[ctx]
+        lines += [f"### Chunk {chunk_idx} ({len(chunk_pairs)} pares)", ""]
+        quoted = "\n".join(f"> {ln}" for ln in ctx.strip().splitlines()) or "> (vazio)"
+        lines += [quoted, ""]
+        for i, p in enumerate(chunk_pairs, start=1):
+            lines += _render_pair(p, i)
+
+    lines += ["---", ""]
+    return lines, len(pairs)
+
+
+def main() -> None:
+    """CLI entry point: render all cep pairs of a run to a markdown file."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "pipeline_id", nargs="?", default="test-kg-04", help="Run id under results/"
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Output markdown path (default: under the run dir)",
+    )
+    parser.add_argument(
+        "--valid-only", action="store_true", help="Only include pairs with is_valid == True"
+    )
+    args = parser.parse_args()
+
+    out_dir = Path("results") / args.pipeline_id / "cep" / "outputs"
+    if not out_dir.is_dir():
+        print_error(f"No cep outputs found: {out_dir}")
+        raise SystemExit(1)
+
+    files = sorted(out_dir.glob("*_cep_qa.json"))
+    if not files:
+        print_error(f"No *_cep_qa.json files in {out_dir}")
+        raise SystemExit(1)
+
+    output = args.output or (Path("results") / args.pipeline_id / "cep" / "emic_pairs_review.md")
+
+    bloom_total: Counter[str] = Counter()
+    body: list[str] = []
+    total_pairs = 0
+    rendered_pairs = 0
+    for f in files:
+        try:
+            record = json.loads(f.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            print_error(f"  skip {f.name[:22]}: {exc}")
+            continue
+        total_pairs += len(record.get("qa_pairs", []))
+        for p in record.get("qa_pairs", []):
+            if args.valid_only and p.get("is_valid") is not True:
+                continue
+            bloom_total[p.get("bloom_level", "?")] += 1
+        src_lines, n = _render_source(record, args.valid_only)
+        body += src_lines
+        rendered_pairs += n
+
+    scope = "apenas pares validos" if args.valid_only else "todos os pares"
+    bloom_line = " | ".join(f"{lvl}: {bloom_total[lvl]}" for lvl in sorted(bloom_total))
+    head = [
+        f"# Pares CEP para revisao de validade emica - `{args.pipeline_id}`",
+        "",
+        f"Fontes: {len(files)} | Pares renderizados: {rendered_pairs} "
+        f"(de {total_pairs} gerados) | Escopo: {scope}",
+        "",
+        f"Distribuicao Bloom: {bloom_line}",
+        "",
+        "Cada fonte -> chunk (segmento de origem, citado uma vez) -> pares gerados, "
+        "com raciocinio e avaliacao do juiz.",
+        "",
+        "---",
+        "",
+    ]
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text("\n".join(head + body), encoding="utf-8")
+    print_info(f"Fontes: {len(files)} | pares: {rendered_pairs}/{total_pairs} | escopo: {scope}")
+    print_success(f"Markdown escrito em {output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/export_rag_answers_markdown.py
+++ b/scripts/export_rag_answers_markdown.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+"""Export every judged RAG answer to a readable markdown for manual review.
+
+Walks ``results/<pipeline_id>/judge_answers/outputs/<arm>/{cep,nonanswerable}/
+*.json`` and renders one markdown document grouped by **retriever arm ->
+answerability bucket -> answer record**. For each record the question is shown
+with the system answer (or the abstention), the retrieved passages it was given,
+and the judge's per-criterion scores (passage coverage, source recovery, answer
+correctness, faithfulness, abstention) with their rationales.
+
+This is the answer-stage sibling of ``export_cep_pairs_markdown.py``: where that
+script dumps the generated CEP benchmark, this one dumps how each retriever arm
+*answered* that benchmark and how the LLM-as-a-judge scored it, so the full
+per-arm behaviour (over-caution, hallucination, coverage) can be read at once
+alongside the aggregate ``analysis/outputs/tables.md``.
+
+Reads raw JSON rather than the pydantic record so legacy on-disk validation
+layouts still render (matches the sibling scripts' approach).
+
+Usage:
+    python3 scripts/export_rag_answers_markdown.py [pipeline_id] [--output PATH]
+        [--arm NAME] [--committed-only]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+from arandu.utils.logger import print_error, print_info, print_success
+
+# Buckets produced by the answer/judge stages, in display order.
+BUCKETS: tuple[tuple[str, str], ...] = (
+    ("cep", "Respondiveis (CEP)"),
+    ("nonanswerable", "Nao-respondiveis"),
+)
+
+# Passage payload preview length (chars) inside the collapsible passages block.
+_PASSAGE_PREVIEW = 280
+# Max retrieved passages listed per record (ranked); the rest are summarised.
+_MAX_PASSAGES_SHOWN = 5
+
+
+def _fmt_score(value: Any) -> str:
+    """Format a numeric score to 3 decimals, or ``-`` when missing."""
+    if isinstance(value, (int, float)):
+        return f"{value:.3f}"
+    return "-"
+
+
+def _iter_criteria(validation: dict[str, Any] | None) -> list[dict[str, Any]]:
+    """Flatten the judge ``stage_results`` into an ordered list of criteria.
+
+    Each stage holds a ``criterion_scores`` map of ``name -> {score, threshold,
+    rationale, ...}``. This walks every stage in insertion order and returns one
+    entry per criterion, tagged with its owning stage.
+
+    Args:
+        validation: The raw ``validation`` payload of an answer record, or None.
+
+    Returns:
+        List of dicts with keys ``stage``, ``name``, ``score``, ``threshold``,
+        ``rationale``.
+    """
+    out: list[dict[str, Any]] = []
+    if not validation:
+        return out
+    stages = validation.get("stage_results") or {}
+    for stage_name, stage in stages.items():
+        if not isinstance(stage, dict):
+            continue
+        scores = stage.get("criterion_scores") or {}
+        for crit_name, crit in scores.items():
+            if not isinstance(crit, dict):
+                continue
+            out.append(
+                {
+                    "stage": stage_name,
+                    "name": crit_name,
+                    "score": crit.get("score"),
+                    "threshold": crit.get("threshold"),
+                    "rationale": crit.get("rationale"),
+                }
+            )
+    return out
+
+
+def _render_passages(passages: list[dict[str, Any]]) -> list[str]:
+    """Render the retrieved passages as a collapsible markdown block.
+
+    Args:
+        passages: The ``passages`` list of an answer record.
+
+    Returns:
+        List of markdown lines (possibly empty when no passages).
+    """
+    if not passages:
+        return ["_Passagens recuperadas:_ nenhuma", ""]
+
+    ranked = sorted(passages, key=lambda p: p.get("rank", 0))
+    lines = [
+        f"<details><summary>Passagens recuperadas ({len(passages)})</summary>",
+        "",
+    ]
+    for p in ranked[:_MAX_PASSAGES_SHOWN]:
+        rank = p.get("rank", "?")
+        score = _fmt_score(p.get("score"))
+        chunk_id = p.get("chunk_id", "?")
+        payload = str(p.get("payload", "")).strip().replace("\n", " ")
+        if len(payload) > _PASSAGE_PREVIEW:
+            payload = payload[:_PASSAGE_PREVIEW].rstrip() + "..."
+        lines.append(f"- **#{rank}** (score {score}, `{chunk_id}`): {payload}")
+    if len(passages) > _MAX_PASSAGES_SHOWN:
+        lines.append(f"- _... mais {len(passages) - _MAX_PASSAGES_SHOWN} passagem(ns)_")
+    lines += ["", "</details>", ""]
+    return lines
+
+
+def _render_record(record: dict[str, Any], index: int) -> list[str]:
+    """Render a single judged answer record as markdown lines.
+
+    Args:
+        record: A raw judged-answer dict.
+        index: 1-based position of the record within its bucket.
+
+    Returns:
+        List of markdown lines.
+    """
+    abstained = bool(record.get("abstained"))
+    is_valid = record.get("is_valid")
+    valid_mark = {True: "valido", False: "rejeitado", None: "nao-julgado"}.get(
+        is_valid, "nao-julgado"
+    )
+    validation = record.get("validation") or {}
+    rejected_at = validation.get("rejected_at")
+    flow = "abstido" if abstained else "comprometido"
+    gate = f" | parou em: `{rejected_at}`" if rejected_at else ""
+
+    question = str(record.get("question", "")).strip()
+    lines = [
+        f"#### Q{index} - {flow} | {valid_mark}{gate}",
+        "",
+        f"**Pergunta:** {question}",
+        "",
+    ]
+
+    if abstained:
+        lines += ["**Resposta:** _(abstido)_", ""]
+    else:
+        lines += [f"**Resposta:** {str(record.get('answer_text', '')).strip()}", ""]
+
+    # Per-criterion judge scores (one compact line each), rationales collapsed.
+    criteria = _iter_criteria(validation)
+    if criteria:
+        score_bits = [
+            f"{c['name']} {_fmt_score(c['score'])}"
+            + (f"/thr {_fmt_score(c['threshold'])}" if c["threshold"] is not None else "")
+            for c in criteria
+        ]
+        lines += ["**Avaliacao:** " + " | ".join(score_bits), ""]
+        rationale_lines = [
+            f"- **{c['name']}** ({_fmt_score(c['score'])}): {str(c['rationale']).strip()}"
+            for c in criteria
+            if c["rationale"]
+        ]
+        if rationale_lines:
+            lines += [
+                "<details><summary>Rationale do juiz por criterio</summary>",
+                "",
+                *rationale_lines,
+                "",
+                "</details>",
+                "",
+            ]
+
+    lines += _render_passages(record.get("passages") or [])
+    return lines
+
+
+def _render_arm(arm: str, arm_dir: Path, committed_only: bool) -> tuple[list[str], dict[str, int]]:
+    """Render one retriever arm, grouped by answerability bucket.
+
+    Args:
+        arm: Arm directory name (e.g. ``khop_passage``).
+        arm_dir: Path to ``judge_answers/outputs/<arm>``.
+        committed_only: When True, skip records where the system abstained.
+
+    Returns:
+        Tuple of (markdown lines, stats dict with ``records``/``abstained``/
+        ``valid``).
+    """
+    body: list[str] = []
+    stats = Counter()
+    bucket_blocks: list[str] = []
+
+    for sub, label in BUCKETS:
+        files = sorted((arm_dir / sub).glob("*.json"))
+        records: list[dict[str, Any]] = []
+        for f in files:
+            try:
+                records.append(json.loads(f.read_text(encoding="utf-8")))
+            except (OSError, json.JSONDecodeError) as exc:
+                print_error(f"  skip {f.name[:28]}: {exc}")
+        rendered = [r for r in records if not (committed_only and r.get("abstained"))]
+        stats["records"] += len(rendered)
+        stats["abstained"] += sum(1 for r in rendered if r.get("abstained"))
+        stats["valid"] += sum(1 for r in rendered if r.get("is_valid") is True)
+        if not rendered:
+            continue
+        bucket_blocks += [f"### {label} ({len(rendered)})", ""]
+        for i, r in enumerate(rendered, start=1):
+            bucket_blocks += _render_record(r, i)
+
+    if not bucket_blocks:
+        return [], dict(stats)
+
+    body += [
+        f"## Arm: `{arm}`",
+        "",
+        f"_Registros:_ {stats['records']} | _Abstencoes:_ {stats['abstained']} "
+        f"| _Validos:_ {stats['valid']}",
+        "",
+        *bucket_blocks,
+        "---",
+        "",
+    ]
+    return body, dict(stats)
+
+
+def main() -> None:
+    """CLI entry point: render all judged RAG answers of a run to markdown."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "pipeline_id", nargs="?", default="mini-dry-run-qwen", help="Run id under results/"
+    )
+    parser.add_argument(
+        "--output", type=Path, default=None, help="Output markdown path (default: under run dir)"
+    )
+    parser.add_argument(
+        "--arm", default=None, help="Render only this retriever arm (e.g. khop_passage)"
+    )
+    parser.add_argument(
+        "--committed-only", action="store_true", help="Skip records where the system abstained"
+    )
+    args = parser.parse_args()
+
+    out_dir = Path("results") / args.pipeline_id / "judge_answers" / "outputs"
+    if not out_dir.is_dir():
+        print_error(f"No judge_answers outputs found: {out_dir}")
+        raise SystemExit(1)
+
+    arm_dirs = sorted(d for d in out_dir.iterdir() if d.is_dir())
+    if args.arm:
+        arm_dirs = [d for d in arm_dirs if d.name == args.arm]
+    if not arm_dirs:
+        print_error(f"No arm directories under {out_dir}")
+        raise SystemExit(1)
+
+    output = args.output or (
+        Path("results") / args.pipeline_id / "judge_answers" / "answers_review.md"
+    )
+
+    body: list[str] = []
+    totals: Counter[str] = Counter()
+    per_arm: list[str] = []
+    for arm_dir in arm_dirs:
+        arm_lines, stats = _render_arm(arm_dir.name, arm_dir, args.committed_only)
+        body += arm_lines
+        for key, val in stats.items():
+            totals[key] += val
+        per_arm.append(
+            f"{arm_dir.name}: {stats.get('records', 0)} reg "
+            f"({stats.get('abstained', 0)} absten., {stats.get('valid', 0)} val.)"
+        )
+
+    scope = "apenas respostas comprometidas" if args.committed_only else "todas as respostas"
+    head = [
+        f"# Respostas RAG julgadas - `{args.pipeline_id}`",
+        "",
+        f"Arms: {len(arm_dirs)} | Registros: {totals.get('records', 0)} "
+        f"| Abstencoes: {totals.get('abstained', 0)} | Validos: {totals.get('valid', 0)} "
+        f"| Escopo: {scope}",
+        "",
+        "Por arm: " + " | ".join(per_arm),
+        "",
+        "Cada arm -> bucket de respondibilidade -> registro (pergunta, resposta ou "
+        "abstencao, avaliacao do juiz por criterio, e passagens recuperadas).",
+        "",
+        "Metricas agregadas por arm em `analysis/outputs/tables.md`.",
+        "",
+        "---",
+        "",
+    ]
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text("\n".join(head + body), encoding="utf-8")
+    print_info(
+        f"Arms: {len(arm_dirs)} | registros: {totals.get('records', 0)} "
+        f"| abstencoes: {totals.get('abstained', 0)} | escopo: {scope}"
+    )
+    print_success(f"Markdown escrito em {output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/slurm/hourly_thesis_run_check.sh
+++ b/scripts/slurm/hourly_thesis_run_check.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SSH_HOST="fdsreckziegel@pcad.inf.ufrgs.br"
+REMOTE_DIR="~/etno-kgc-preprocessing"
+LOG_PATH="logs/thesis-run-01-hourly-monitor.log"
+JOB_IDS="798077,798078,798079,798080"
+TARGET_MINUTE=55
+INTERVAL_SECONDS=3600
+
+mkdir -p "$(dirname "$LOG_PATH")"
+
+run_check() {
+    local now output stop_reason=""
+    now="$(date -Is)"
+
+    output="$(
+        ssh "$SSH_HOST" "
+            cd $REMOTE_DIR || exit 1
+            printf 'TIME\t%s\n' \"\$(date -Is)\"
+            printf '\nSQUEUE\n'
+            squeue -u fdsreckziegel -o '%.10i %.12P %.30j %.10T %.10M %.10L %R'
+            printf '\nSACCT\n'
+            sacct -j $JOB_IDS --format=JobID,JobName%30,Partition,State,Start,End,Elapsed,ExitCode -X -P
+            printf '\nLOGS\n'
+            find logs -maxdepth 1 -type f \\
+                \\( -name '*798077*' -o -name '*798078*' -o -name '*798079*' -o -name '*798080*' \\) \\
+                | sort
+            printf '\nTAILS\n'
+            for f in \$(find logs -maxdepth 1 -type f \\
+                \\( -name '*798077*' -o -name '*798078*' -o -name '*798079*' -o -name '*798080*' \\) \\
+                | sort); do
+                printf '\n===== %s =====\n' \"\$f\"
+                tail -n 40 \"\$f\"
+            done
+        " 2>&1
+    )"
+
+    {
+        printf '\n===== LOCAL_CHECK %s =====\n' "$now"
+        printf '%s\n' "$output"
+    } >> "$LOG_PATH"
+
+    if printf '%s\n' "$output" | grep -Eq '^798080\|.*\|COMPLETED\|'; then
+        stop_reason="rag-analysis completed"
+    elif printf '%s\n' "$output" | grep -Eq '^(798077|798078|798079|798080)\|.*\|(FAILED|CANCELLED|TIMEOUT)\|'; then
+        stop_reason="terminal state detected"
+    fi
+
+    if [[ -n "$stop_reason" ]]; then
+        printf '\n===== MONITOR_STOP %s %s =====\n' "$(date -Is)" "$stop_reason" >> "$LOG_PATH"
+        notify-send "thesis-run-01 monitor" "$stop_reason" >/dev/null 2>&1 || true
+        return 1
+    fi
+
+    return 0
+}
+
+seconds_until_next_target() {
+    local minute second delay
+    minute="$(date +%M)"
+    second="$(date +%S)"
+    delay=$(( (10#$TARGET_MINUTE - 10#$minute) * 60 - 10#$second ))
+    if (( delay <= 0 )); then
+        delay=$(( delay + 3600 ))
+    fi
+    printf '%s\n' "$delay"
+}
+
+initial_delay="$(seconds_until_next_target)"
+printf '===== MONITOR_START %s next_check_in=%ss log=%s =====\n' \
+    "$(date -Is)" "$initial_delay" "$LOG_PATH" >> "$LOG_PATH"
+sleep "$initial_delay"
+
+while true; do
+    if ! run_check; then
+        break
+    fi
+    sleep "$INTERVAL_SECONDS"
+done

--- a/scripts/slurm/rag/_retrieve_khop_cpu.slurm
+++ b/scripts/slurm/rag/_retrieve_khop_cpu.slurm
@@ -1,0 +1,20 @@
+#!/bin/bash
+#SBATCH --job-name=arandu-rag-retrieve-khop
+#SBATCH --partition=tupi
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=8
+#SBATCH --time=4:00:00
+#SBATCH --output=logs/rag_retrieve_khop_%j.out
+#SBATCH --error=logs/rag_retrieve_khop_%j.err
+
+# One-off khop re-validation: re-run ONLY the khop arms, CPU-only. khop is pure
+# lexical + graph (no LLM, no embedder), so it needs neither Ollama nor a GPU —
+# runs on a CPU slot to skip GPU contention. The standard answer/judge-answers
+# wrappers handle khop automatically via resume (their checkpoints were stripped
+# of khop keys). No --gres=gpu:1 here.
+export RAG_CLI_ARGS="retrieve --id ${PIPELINE_ID} --arm khop_passage --arm khop_triple"
+export RAG_NEEDS_OLLAMA=false
+export RAG_SERVICE=arandu-rag-cpu
+export RAG_PROFILE=rag-cpu
+source "${SLURM_SUBMIT_DIR}/scripts/slurm/rag/rag_common.sh"

--- a/scripts/test_bm25_retriever.py
+++ b/scripts/test_bm25_retriever.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Smoke test for the BM25Retriever — builds a real on-disk index and queries it.
+
+Unlike the pytest suite (which uses ``tmp_path`` and discards artifacts), this
+script writes ``bm25.pkl`` + ``manifest.json`` to a directory you can inspect
+afterwards. Useful for sanity-checking the index layout, the manifest schema,
+and the SHA-256 integrity field on a real Portuguese fixture.
+
+Usage:
+    uv run python scripts/test_bm25_retriever.py
+    uv run python scripts/test_bm25_retriever.py --out /tmp/bm25_demo
+    uv run python scripts/test_bm25_retriever.py --language en
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+from pathlib import Path
+
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+
+from arandu.shared.chunking.resolver import ChunkResolver
+from arandu.shared.chunking.schemas import Chunk
+from arandu.shared.rag.retrievers.bm25 import (
+    INDEX_FILENAME,
+    MANIFEST_FILENAME,
+    BM25Retriever,
+)
+
+PT_CORPUS = [
+    "A enchente de 2024 alagou completamente a cidade de Itaqui.",
+    "Maria contou sobre a perda da casa e dos animais.",
+    "O rio Uruguai subiu três metros em poucas horas.",
+    "A enchente foi terrível e o rio Uruguai transbordou na madrugada.",
+    "Joao perdeu o gado e teve que recomeçar a vida em outra cidade.",
+]
+PT_QUERIES = ["enchente", "Maria animais", "rio Uruguai madrugada"]
+
+EN_CORPUS = [
+    "The 2024 flood completely submerged the town of Itaqui.",
+    "Maria spoke about losing her house and her animals.",
+    "The Uruguay river rose three meters in just a few hours.",
+    "The flood was terrible and the Uruguay river overflowed at dawn.",
+    "Joao lost his cattle and had to start a new life in another town.",
+]
+EN_QUERIES = ["flood", "Maria animals", "Uruguay river dawn"]
+
+SOURCE_ID = "src_demo_001"
+
+
+def build_chunks(sentences: list[str], chunker_id: str) -> tuple[list[Chunk], ChunkResolver]:
+    """Chunk-per-sentence over a single joined source document."""
+    full_text = " ".join(sentences)
+    chunks: list[Chunk] = []
+    pos = 0
+    for i, sent in enumerate(sentences):
+        chunks.append(
+            Chunk(
+                chunk_id=f"chk_{i:013d}",
+                source_file_id=SOURCE_ID,
+                chunker_id=chunker_id,
+                start_char=pos,
+                end_char=pos + len(sent),
+            )
+        )
+        pos += len(sent) + 1  # +1 for the joining space
+    resolver = ChunkResolver(text_loader=lambda _fid: full_text)
+    return chunks, resolver
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument(
+        "--out",
+        type=Path,
+        default=Path("scratch") / "bm25_demo",
+        help="Output directory for the index (default: scratch/bm25_demo).",
+    )
+    p.add_argument(
+        "--language", choices=("pt", "en"), default="pt", help="Tokenizer language."
+    )
+    p.add_argument(
+        "--top-k", type=int, default=3, help="Top-K passages to retrieve per query."
+    )
+    p.add_argument(
+        "--keep",
+        action="store_true",
+        help="Do not wipe the output directory before building.",
+    )
+    return p.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    console = Console()
+
+    sentences = PT_CORPUS if args.language == "pt" else EN_CORPUS
+    queries = PT_QUERIES if args.language == "pt" else EN_QUERIES
+    chunker_id = f"bm25_demo_{args.language}"
+    index_dir: Path = args.out / chunker_id / "bm25"
+
+    if index_dir.exists() and not args.keep:
+        console.print(f"[yellow]Wiping existing {index_dir}[/yellow]")
+        shutil.rmtree(index_dir)
+
+    chunks, resolver = build_chunks(sentences, chunker_id)
+
+    console.print(
+        Panel.fit(
+            f"corpus_size={len(chunks)}  language={args.language}  "
+            f"chunker_id={chunker_id}\nindex_dir={index_dir}",
+            title="BM25 demo — config",
+        )
+    )
+
+    console.print("\n[bold cyan]1. Building index[/bold cyan]")
+    BM25Retriever.build_index(
+        chunks=chunks,
+        resolver=resolver,
+        index_dir=index_dir,
+        chunker_id=chunker_id,
+        language=args.language,
+    )
+
+    # Show what landed on disk
+    files = sorted(index_dir.iterdir())
+    files_table = Table(title="Files written")
+    files_table.add_column("path", style="cyan")
+    files_table.add_column("size (bytes)", style="magenta", justify="right")
+    for f in files:
+        files_table.add_row(str(f.relative_to(args.out)), str(f.stat().st_size))
+    console.print(files_table)
+
+    # Show the manifest
+    manifest = json.loads((index_dir / MANIFEST_FILENAME).read_text())
+    console.print(
+        Panel(
+            json.dumps(manifest, indent=2, ensure_ascii=False),
+            title=f"{MANIFEST_FILENAME}",
+        )
+    )
+
+    console.print("\n[bold cyan]2. Loading retriever from disk[/bold cyan]")
+    retriever = BM25Retriever(
+        index_dir=index_dir, chunker_id=chunker_id, language=args.language
+    )
+    console.print(
+        f"  retriever_id = [bold green]{retriever.retriever_id}[/bold green]"
+    )
+
+    console.print("\n[bold cyan]3. Running queries[/bold cyan]")
+    for q in queries:
+        results = retriever.retrieve(q, top_k=args.top_k)
+        table = Table(title=f"query: {q!r}  (top_k={args.top_k})")
+        table.add_column("rank", justify="right")
+        table.add_column("score", justify="right")
+        table.add_column("chunk_id", style="cyan")
+        table.add_column("text", style="white")
+        for p in results:
+            # Walk back to the source text via the chunks list (chunk_id = index suffix).
+            idx = int(p.chunk_id.split("_")[-1])
+            snippet = sentences[idx]
+            table.add_row(
+                str(p.rank),
+                f"{p.score:.4f}",
+                p.chunk_id,
+                snippet if len(snippet) < 70 else snippet[:67] + "...",
+            )
+        console.print(table)
+
+    console.print(
+        f"\n[bold green]Done.[/bold green] Inspect artifacts at: [bold]{index_dir}[/bold]"
+    )
+    console.print(
+        f"  Clean up with: [dim]rm -rf {args.out}[/dim]"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_khop_seeding.py
+++ b/scripts/test_khop_seeding.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Old-vs-new k-hop seeding/retrieval distribution on the test-kg-04 KG (local).
+
+Isolates the linker change: this PR altered ONLY the entity link, so we hold the
+retriever's ego-graph + scoring fixed and swap just the seeding to compare OLD
+(bare-whitespace tokens + hard max_postings=200 cap) vs NEW (lemmatized +
+IDF-weighted top-K) on the test-kg-04 CEP questions. Pure lexical + graph — runs
+locally, no GPU/LLM. Usage:  uv run python scripts/test_khop_seeding.py
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import statistics
+import unicodedata
+from collections import Counter, defaultdict
+from pathlib import Path
+
+import networkx as nx
+
+from arandu.shared.rag.retrievers import _khop_common as kc
+from arandu.shared.rag.retrievers.khop_subgraph import KHopSubgraphRetriever
+
+KG_DIR = Path("results/test-kg-04/kg/outputs/atlas_output")
+KG_PATH = KG_DIR / "kg_graphml" / "transcriptions.json_graph.graphml"
+CEP = Path("results/test-kg-04/cep/outputs")
+PROBLEM_TERMS = ["enchente", "pesca", "trapiche", "Valverde", "rio", "bagre"]
+RETRIEVE_SAMPLE = 40   # full-retrieve is ego-graph-bound; sample for speed
+_TOKEN_RE = re.compile(r"\w+", flags=re.UNICODE)
+_OLD_CAP = 200
+
+
+# ---- OLD linker (reimplemented inline: whitespace tokens + hard cap) ---------
+def _old_tokens(text: str, *, filter_stopwords: bool) -> list[str]:
+    toks = _TOKEN_RE.findall(unicodedata.normalize("NFKC", text).casefold())
+    if filter_stopwords:
+        toks = [t for t in toks if t not in kc._STOPWORDS and len(t) >= kc._MIN_TOKEN_LEN]
+    return toks
+
+
+def _old_index(g: nx.DiGraph) -> dict[str, set[str]]:
+    idx: dict[str, set[str]] = defaultdict(set)
+    for node_id, attrs in g.nodes(data=True):
+        if attrs.get("type") in kc._LINKABLE_TYPES:
+            for t in _old_tokens(attrs.get("id", ""), filter_stopwords=False):
+                idx[t].add(node_id)
+    return idx
+
+
+def _old_link(question: str, idx: dict[str, set[str]]) -> set[str]:
+    seeds: set[str] = set()
+    for t in set(_old_tokens(question, filter_stopwords=True)):
+        postings = idx.get(t, ())
+        if len(postings) > _OLD_CAP:
+            continue
+        seeds.update(postings)
+    return seeds
+
+
+# ---- helpers -----------------------------------------------------------------
+def _questions() -> list[tuple[str, str]]:
+    """Return (question, bloom_level) over all test-kg-04 CEP pairs."""
+    out: list[tuple[str, str]] = []
+    for f in sorted(CEP.glob("*_cep_qa.json")):
+        for p in json.loads(f.read_text()).get("qa_pairs", []):
+            out.append((p["question"], p.get("bloom_level", "?")))
+    return out
+
+
+def _dist(counts: list[int]) -> str:
+    if not counts:
+        return "n=0"
+    s = sorted(counts)
+    pct = lambda q: s[min(len(s) - 1, int(q * len(s)))]  # noqa: E731
+    return (
+        f"min={s[0]} p50={statistics.median(s):.0f} mean={statistics.mean(s):.1f} "
+        f"p90={pct(0.9)} max={s[-1]}"
+    )
+
+
+def main() -> None:
+    g = nx.read_graphml(str(KG_PATH))
+    old_idx = _old_index(g)
+    r = KHopSubgraphRetriever(KG_DIR, top_k_seeds=50)  # new index built inside
+    qs = _questions()
+    print(f"KG: {g.number_of_nodes()} nodes | CEP questions: {len(qs)}\n")
+
+    # ---- SEED LEVEL (all questions) ----
+    old_seed_counts, new_seed_counts = [], []
+    old_empty = new_empty = 0
+    by_bloom_old: dict[str, list[int]] = defaultdict(list)
+    by_bloom_new: dict[str, list[int]] = defaultdict(list)
+    for q, bloom in qs:
+        o = len(_old_link(q, old_idx))
+        n = len(list(r._entity_link(q)))
+        old_seed_counts.append(o)
+        new_seed_counts.append(n)
+        old_empty += o == 0
+        new_empty += n == 0
+        by_bloom_old[bloom].append(o == 0)
+        by_bloom_new[bloom].append(n == 0)
+
+    print("=== SEED LEVEL (all questions) ===")
+    print(f"OLD empty-seed: {old_empty:4d} ({old_empty / len(qs):.1%})  dist {_dist(old_seed_counts)}")
+    print(f"NEW empty-seed: {new_empty:4d} ({new_empty / len(qs):.1%})  dist {_dist(new_seed_counts)}")
+    print("\nempty-seed fraction by Bloom level (OLD -> NEW):")
+    for bloom in sorted(by_bloom_new):
+        ob = by_bloom_old[bloom]
+        nb = by_bloom_new[bloom]
+        print(
+            f"  {bloom:11s} n={len(nb):4d}  {sum(ob) / len(ob):5.1%} -> {sum(nb) / len(nb):5.1%}"
+        )
+
+    # ---- RETRIEVAL LEVEL (NEW retriever, sample) ----
+    # NEW only: top_k_seeds=50 bounds the ego graph so this is fast. The OLD
+    # linker is unbounded (a common token seeds thousands of nodes -> ego-graph
+    # explosion), which is the very pathology being fixed; its retrieval-level
+    # cost is captured by the OLD empty-seed fraction above (empty seeds ->
+    # empty retrieval -> answerer abstains).
+    sample = qs[:: max(1, len(qs) // RETRIEVE_SAMPLE)][:RETRIEVE_SAMPLE]
+    new_results = [len(r.retrieve(q, top_k=10)) for q, _ in sample]
+    print(f"\n=== RETRIEVAL LEVEL (NEW retriever, sample of {len(sample)}) ===")
+    print(f"NEW empty-result: {new_results.count(0):3d} ({new_results.count(0)/len(sample):.1%})  passages/query {_dist(new_results)}")
+
+    # ---- PROBLEM TERMS ----
+    print("\n=== problem terms (seed counts, OLD -> NEW) ===")
+    for t in PROBLEM_TERMS:
+        print(f"  {t:12s} old={len(_old_link(t, old_idx)):5d}  new={len(list(r._entity_link(t))):4d}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/verify_cep_load.py
+++ b/scripts/verify_cep_load.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Verify every cep outputs/*_cep_qa.json loads through QARecordCEP.
+
+One-off dry-run helper, companion to cap_cep_pairs.py: a capped file with
+stale doc-level counters fails the judge CLI's schema load silently, so this
+check runs after any cap/restore to guarantee the judge will see all files.
+Exits non-zero when any file fails.
+
+Usage:
+    python3 scripts/verify_cep_load.py <pipeline_id>
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from arandu.qa.schemas import QARecordCEP
+
+
+def main() -> None:
+    pipeline_id = sys.argv[1] if len(sys.argv) > 1 else "mini-dry-run-qwen"
+    out_dir = Path("results") / pipeline_id / "cep" / "outputs"
+    failures = 0
+    for f in sorted(out_dir.glob("*_cep_qa.json")):
+        try:
+            record = QARecordCEP.model_validate_json(f.read_text(encoding="utf-8"))
+            print(f"  {f.name[:22]}: OK ({len(record.qa_pairs)} pairs)")
+        except Exception as exc:  # noqa: BLE001 — report-and-continue check
+            failures += 1
+            print(f"  {f.name[:22]}: FAIL {str(exc)[:160]}")
+    if failures:
+        sys.exit(1)
+    print("all files load OK")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This pull request adds several new utility scripts to the `scripts/` directory to support CEP QA pipeline development, data curation, and validation. The scripts focus on preparing, auditing, capping, and exporting CEP QA pairs for various stages of the workflow, with an emphasis on making dry runs faster, supporting anthropological review, and improving validation transparency.

The most important changes are:

### CEP QA Data Preparation and Curation

* Added `cap_cep_pairs.py` to cap the number of QA pairs per `*_cep_qa.json` file to a Bloom-stratified sample, backing up the full set for restoration later. This helps keep dry runs fast while maintaining representative sampling.
* Added `_khop_revalidate_prep.py` to back up and clear only the khop_passage and khop_triple state in the mini-dry-run-qwen run, making it possible to resume with a new linker while keeping other arms as controls.

### Validation and Audit Tools

* Added `audit_near_threshold_qa.py`, which audits failed QA pairs that narrowly missed the judge threshold, classifies them, and generates a markdown report to help identify over-strict criteria and possible mis-calibrations.

### Export and Review Support

* Added `export_cep_pairs_markdown.py` to export all CEP QA pairs into a readable, grouped markdown file for anthropological emic-validity review, supporting both legacy and current data formats.