### PR TITLE
feat(qa)!: stratify the human-eval sample by Bloom only, off the judge's critical path

### DIFF
--- a/docs/superpowers/specs/2026-08-19-bloom-only-sampling-design.md
+++ b/docs/superpowers/specs/2026-08-19-bloom-only-sampling-design.md
@@ -1,0 +1,143 @@
+# Amostra humana estratificada só por Bloom
+
+**Data:** 2026-08-19
+**Reverte:** o desenho amostral fechado em 2026-08-07 (banda êmica × Bloom)
+**Registro da decisão:** `~/.cortex/workspaces/FredDsR-arandu/sessions/emic-validity-protocol/tasks/bloom-only-sampling-DECISION.md`
+**Spec canônica do protocolo:** `sessions/emic-validity-protocol/spec.md` §5 (working doc, fora do repo)
+
+## 1. Objetivo
+
+Tirar o run do juiz êmico do caminho crítico da anotação, mudando a
+estratificação da amostra humana de **banda êmica × Bloom** (8 células × 15) para
+**só Bloom** (4 células × 30), e passando a montá-la a partir dos registros do
+CEP em vez das saídas do `emic-judge`. O total de 120 pares é preservado: é o
+compromisso assumido com os três antropólogos.
+
+## 2. Decisões
+
+| Decisão | Data | Motivo |
+| --- | --- | --- |
+| Estratificação **só por Bloom**, 4 × 30 = 120 | 2026-08-19 | A banda vinha do `emic_score`, o que colocava o run do juiz no caminho crítico. A fila do pcad materializou esse risco de cronograma. |
+| Amostra montada **só dos registros do CEP** | 2026-08-19 | `QAPairCEP` já carrega `bloom_level`; `is_valid` vem do `JudgeResultMixin`, que já era lido dali como cópia autoritativa. Nada mais era necessário do juiz. |
+| **`emic_score` sai do `SampleItem`** | 2026-08-19 | É o campo que devolveria a dependência pela porta dos fundos. Os scores entram na análise por junção em `pair_id`. |
+| **`cell_id` sai do `SampleItem`** | 2026-08-19 | Passaria a ser byte a byte igual a `bloom_level`. Dois campos com o mesmo valor divergem depois. |
+| `PER_CELL` de 10 para 30 | 2026-08-19 | O comando sem flag passa a produzir os 120 acordados. O default antigo (10 por célula, 8 células) produzia 80, não 40; os 40 só aparecem se se multiplicar as 4 células novas pelo `PER_CELL` antigo, misturando os dois desenhos. Os 120 acordados não eram alcançáveis sem flag antes de `--per-cell` existir. |
+| Mudança **no lugar**, sem flag de compatibilidade | 2026-08-19 | Uma flag `--stratify bloom\|band` manteria viva no código uma decisão revertida, dobraria a matriz de testes e preservaria a dependência do juiz no caminho de código que supostamente saiu. Não existe nenhum `sample.jsonl` construído para quebrar. |
+| Filtro `FRAME_BLOOM_LEVELS` **fica** | 2026-08-19 | `BloomLevel` admite seis valores; o corpus tem quatro. O filtro evita que um par `apply` abra uma quinta célula em silêncio. |
+| `--per-cell` absorvido, branch antiga fechada sem PR | 2026-08-19 | O commit `9507f852` foi escrito para 8 células e a prosa que ele corrigiu fica obsoleta com 4. |
+
+## 3. Custo aceito
+
+A amostra passa a **espelhar a população**. Como o frame é o conjunto aprovado
+pelos quatro canônicos, a população pende para o que seria a banda `limpa`, então
+a amostra fica dominada por casos fáceis e a concordância alta é em parte
+artefato do desenho. A ponta baixa da escala (1-2) fica com poucas observações, e
+é onde o coeficiente é mais sensível. **Vai declarado na seção de limitações**,
+junto do motivo.
+
+O kappa ponderado juiz × anotador não se perde: o `emic-judge` continua
+necessário e continua rodando, só deixa de alimentar a amostra. O que se perde é
+a garantia de cobertura da escala.
+
+Em troca, o desenho amostral deixa de estar acoplado ao instrumento sob teste:
+trocar modelo ou prompt do juiz êmico não invalida mais a amostra.
+
+## 4. Frame e pool
+
+A entrada passa de dois estágios para um. `run_build_sample_batch` varre
+`results/<id>/cep/outputs/*_cep_qa.json` e não abre mais
+`results/<id>/emic_judge/outputs/`. Ausência do diretório do CEP vira
+`FileNotFoundError` nomeando `arandu generate-cep-qa --id <run>`.
+
+Para cada registro, itera `qa_pairs` com o índice. O par entra no pool se passar
+por dois filtros, nesta ordem:
+
+1. `pair.is_valid is not True` → descartado, soma em `excluded_not_approved`. O
+   frame continua sendo o corpus aprovado pelo `judge-qa`, lido da cópia
+   autoritativa no registro.
+2. `pair.bloom_level not in FRAME_BLOOM_LEVELS` → descartado, soma em
+   `excluded_bloom` por nível.
+
+`pair_id` segue `f"{record.source_file_id}:{pair_index}"`, idêntico ao atual, que
+é o que mantém possível a junção com as saídas do juiz. A guarda de `pair_id`
+duplicado fica.
+
+## 5. Células e seleção
+
+`BANDS`, `DUBIOUS_MAX_SCORE` e `band_for()` saem de `sampling.py`.
+`all_cell_ids()` devolve os quatro níveis de Bloom do frame, e a célula de um par
+**é** o seu `bloom_level`, sem composição.
+
+O mecanismo de seleção não muda: ordenação determinística por
+`SHA-256(f"{seed}:{pair_id}")` dentro de cada célula, `per_cell` primeiros. É o
+que garante reprodutibilidade a partir do seed e estabilidade entre versões de
+Python. Sai a sobreamostragem 50/50, que existia só para balancear bandas.
+
+`InsufficientCellError` continua falhando por desenho, nomeando a célula e as
+contagens. O perfil de risco muda: a célula candidata a estourar deixa de ser
+`duvidosa` e passa a ser o nível de Bloom mais raro. **Isso agora é verificável
+antes de qualquer anotador**, porque depende só do CEP. A população de referência
+do `test-kg-04` (Remember 433, Understand 644, Analyze 644, Evaluate 689) sugere
+folga confortável para 30, mas com uma ressalva: o frame é o subconjunto
+**aprovado pelo juiz**, não o corpus gerado, então esses números só valem como
+folga se já forem posteriores ao `judge-qa`; caso contrário sobrestimam a
+folga pela taxa de aprovação. Quem decide a viabilidade é o nível de Bloom
+mais raro depois da aprovação, e é exatamente isso que a medição descrita a
+seguir nesta seção verifica antes de convidar anotadores.
+
+A medição sobre o `thesis-run-01` **não roda no ambiente de desenvolvimento**: os
+registros do CEP desse run vivem na máquina que executa o pipeline, e é lá que
+todo o fluxo de anotação roda. Então ela é o primeiro passo **da execução**, não
+da implementação: sai do `build-human-eval-sample` naquela máquina, e é o gate
+antes de convidar anotadores. Os testes desta mudança não dependem dela, porque
+usam fixtures.
+
+## 6. Esquema dos artefatos
+
+`SampleItem` fica com `pair_id`, `source_file_id`, `pair_index`, `segment`,
+`question`, `answer`, `bloom_level` e `slot_id` (`0..per_cell-1`). Perde
+`emic_score` e `cell_id`.
+
+`SampleManifest`:
+
+- perde `excluded_none_score`: nenhum score é lido, então nada pode ser nulo;
+- mantém `excluded_not_approved` com **significado documentado como diferente**:
+  passa a contar todo par não aprovado do corpus, não só os pontuados, então a
+  magnitude sobe e as contagens dos dois desenhos não são comparáveis;
+- `cell_counts` e `population_by_cell` passam a ser mapas de 4 chaves, e as chaves
+  **são os próprios níveis de Bloom** (`remember`, `understand`, `analyze`,
+  `evaluate`), não mais `"{bloom}:{banda}"`;
+- `pool_sha256` mantém a construção, mas o digest não atravessa os dois desenhos,
+  porque o modelo do pool mudou;
+- `input_source` no `run_metadata.json` passa a apontar para o diretório do CEP.
+
+`HumanEvalSampleConfig` (`seed`, `per_cell`) fica como está.
+
+## 7. CLI
+
+`--per-cell` exposto, mínimo 1, default `PER_CELL` (30), e o comando ecoa o
+tamanho resultante antes de construir.
+
+## 8. Testes
+
+TDD, testes antes, em `tests/shared/human_eval/`:
+
+- **O teste que trava a decisão:** um run **sem** o diretório `emic_judge/`
+  constrói a amostra normalmente. É a regressão que quebra se alguém
+  reintroduzir a dependência.
+- Pool montado só do CEP; par não aprovado descartado e contado; Bloom fora do
+  frame descartado e contado por nível.
+- `per_cell=30` → 120 itens, com balanceamento por célula e faixa de `slot_id`
+  conferidos, não só o total.
+- `InsufficientCellError` nomeando a célula curta.
+- Mesmo seed → saída idêntica; payload alterado → `pool_sha256` diferente.
+- Saem os testes de banda (`band_for`, sobreamostragem 50/50).
+
+## 9. Fora de escopo
+
+- **Capítulo de metodologia da dissertação** (`FredDsR-dissertacao-tex`) afirma
+  estratificação por banda e precisa ser corrigido antes da entrega. Outro repo,
+  outra sessão, registrado como follow-up na task de decisão.
+- **CLI `emic-analysis`** (junção dos scores por `pair_id` e cálculo dos
+  coeficientes) continua diferido. Esta mudança não o cria; só garante que o
+  `pair_id` que ele vai precisar continua no `sample.jsonl`.

--- a/docs/user-guide/cli-reference.md
+++ b/docs/user-guide/cli-reference.md
@@ -455,9 +455,10 @@ arandu emic-judge --id project-001 --scope all
 (`remember`, `understand`, `analyze`, `evaluate`) x `--per-cell` (default 30) =
 120 pairs. The frame is the corpus `judge-qa` approved, read from the CEP
 record's own verdict, so a `judge-qa` re-run is picked up instead of leaving the
-frame pinned to a stale snapshot. Pairs the judge rejected are dropped and
-counted in the manifest's `excluded_not_approved`; `apply` / `create` pairs are
-dropped and counted per level in `excluded_bloom`.
+frame pinned to a stale snapshot. Pairs the judge did not approve are
+dropped and counted in the manifest's `excluded_not_approved`, which covers
+both the pairs it rejected and the pairs it never scored; `apply` / `create`
+pairs are dropped and counted per level in `excluded_bloom`.
 
 The builder does **not** read the `emic_judge` stage. It used to, because the old
 design stratified primarily by emic band (`duvidosa` <=3 / `limpa` >=4), which

--- a/docs/user-guide/cli-reference.md
+++ b/docs/user-guide/cli-reference.md
@@ -405,7 +405,7 @@ reported.
 | Command | Description |
 |---------|-------------|
 | `emic-judge` | Score a run's CEP pairs for emic validity (ordinal 1-5) |
-| `build-human-eval-sample` | Build the stratified human-comparison sample for a run |
+| `build-human-eval-sample` | Build the Bloom-stratified human-comparison sample (4 cells x 30 = 120) from a run's CEP records |
 | `emic-annotation-build` | Build the Label Studio artifacts (labeling config, blinded tasks, manifest) for a run's sample |
 | `emic-annotation-push` | Create the Label Studio project from the built artifacts and import the tasks |
 | `emic-annotation-pull` | Fetch the annotations back and write one JSONL per anonymized annotator |
@@ -437,16 +437,45 @@ false.
 
 **Typical Phase D chain**:
 ```bash
-# Score the corpus (long-running; on the cluster use scripts/slurm/emic/tupi.slurm)
-arandu emic-judge --id project-001 --scope all
-
-# Draw the stratified sample the annotators rate
+# Draw the stratified sample the annotators rate. Reads the CEP records only,
+# so it does not wait for the emic-judge run.
 arandu build-human-eval-sample --id project-001 --seed 42
+
+# Build and push the annotation instrument (see the three commands below)
+arandu emic-annotation-build --id project-001 --seed 20260819
+arandu emic-annotation-push --id project-001
+
+# Score the corpus (long-running; on the cluster use scripts/slurm/emic/tupi.slurm).
+# Runs in parallel with the annotation: its scores join back on pair_id at
+# analysis time.
+arandu emic-judge --id project-001 --scope all
 ```
 
-The sample builder keeps its frame on the judge-approved corpus even when
-`emic-judge` scored everything: pairs the judge rejected (or never judged) are
-dropped and counted in the manifest's `excluded_not_approved`.
+**Stratification is by Bloom level only** (revised 2026-08-19): 4 cells
+(`remember`, `understand`, `analyze`, `evaluate`) x `--per-cell` (default 30) =
+120 pairs. The frame is the corpus `judge-qa` approved, read from the CEP
+record's own verdict, so a `judge-qa` re-run is picked up instead of leaving the
+frame pinned to a stale snapshot. Pairs the judge rejected are dropped and
+counted in the manifest's `excluded_not_approved`; `apply` / `create` pairs are
+dropped and counted per level in `excluded_bloom`.
+
+The builder does **not** read the `emic_judge` stage. It used to, because the old
+design stratified primarily by emic band (`duvidosa` <=3 / `limpa` >=4), which
+put the judge run on the annotation critical path. The cost of dropping it: the
+draw within a cell is uniform, so the sample mirrors the approved population and
+easy pairs dominate, leaving the low end of the scale with few observations.
+
+**Options**:
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--id` | required | Pipeline ID. The `cep` stage must be populated and judged |
+| `--seed` | required | Seed for the deterministic selection; recorded in the manifest |
+| `--per-cell` | `30` | Pairs drawn per Bloom cell. 4 cells, so the total is 4x this |
+
+If a Bloom cell has fewer approved pairs than `--per-cell`, the build fails
+naming the cell and both counts. Cells are never back-filled from each other,
+because that would unbalance the design silently.
 
 ### `arandu emic-annotation-build`
 

--- a/docs/user-guide/cli-reference.md
+++ b/docs/user-guide/cli-reference.md
@@ -398,9 +398,10 @@ arandu rag-analysis project-001
 ## Emic Validity Commands (Phase D)
 
 These commands implement the emic-validity study (spec §5-§6): score the run's
-QA pairs with the ordinal `emic_validity` criterion, then draw the stratified
-sample the human annotators rate so inter-rater agreement with the judge can be
-reported.
+QA pairs with the ordinal `emic_validity` criterion, and draw the stratified
+sample the human annotators rate; the two run independently, and inter-rater
+agreement with the judge is reported by joining their outputs on `pair_id` at
+analysis time.
 
 | Command | Description |
 |---------|-------------|

--- a/src/arandu/cli/emic_judge.py
+++ b/src/arandu/cli/emic_judge.py
@@ -4,8 +4,9 @@ Runs the ``emic_validity`` ordinal criterion over the canonical-approved pairs
 of a populated run and writes per-source ordinal scores under
 ``results/<id>/emic_judge/outputs/<source>.json``. These scores are the study's
 measurement of emic validity; the human annotation round validates them by
-agreement (spec §6). They also band the stratified human-comparison sample, but
-that is a downstream use rather than their purpose.
+agreement (spec §6). The stratified human-comparison sample is drawn
+independently from the CEP records; these scores rejoin it at analysis time
+by joining on ``pair_id``, not by shaping which pairs are drawn.
 """
 
 from __future__ import annotations

--- a/src/arandu/cli/human_eval.py
+++ b/src/arandu/cli/human_eval.py
@@ -1,9 +1,8 @@
-"""CLI command: ``arandu build-human-eval-sample`` — stratified 80-pair sample (spec §5).
+"""CLI command: ``arandu build-human-eval-sample`` -- Bloom-stratified sample (spec §5).
 
-Builds the human-comparison study sample (4 Bloom x 2 emic bands x 10) from the
-emic-judge scores of a run, joining each pair's CEP payload, and writes
-``sample.jsonl`` + ``sample_manifest.json`` under
-``results/<id>/human_eval/outputs/``.
+Builds the human-comparison study sample (4 Bloom levels x ``--per-cell``) from a
+run's CEP records and writes ``sample.jsonl`` + ``sample_manifest.json`` under
+``results/<id>/human_eval/outputs/``. The emic-judge stage is not read.
 """
 
 from __future__ import annotations
@@ -14,6 +13,7 @@ from typing import Annotated
 import typer
 
 from arandu.shared.human_eval.batch import run_build_sample_batch
+from arandu.shared.human_eval.sampling import FRAME_BLOOM_LEVELS, PER_CELL
 from arandu.utils.logger import print_error, print_info, print_success, print_warning
 
 logger = logging.getLogger(__name__)
@@ -24,7 +24,7 @@ def build_human_eval_sample(
         str,
         typer.Option(
             "--id",
-            help=("Pipeline ID for the run. The emic_judge and cep stages must both be populated."),
+            help="Pipeline ID for the run. The cep stage must be populated and judged.",
         ),
     ],
     seed: Annotated[
@@ -34,21 +34,29 @@ def build_human_eval_sample(
             help="RNG seed for the deterministic selection (recorded in the manifest).",
         ),
     ],
+    per_cell: Annotated[
+        int,
+        typer.Option(
+            "--per-cell",
+            min=1,
+            help="Pairs drawn per Bloom cell. 4 cells, so the total is 4x this.",
+        ),
+    ] = PER_CELL,
 ) -> None:
-    """Build the stratified human-comparison sample (80 pairs) for a run.
+    """Build the Bloom-stratified human-comparison sample for a run.
 
-    Pools the canonical-approved pairs scored by ``arandu emic-judge``, bands
-    them by emic validity (duvidosa <=3 / limpa >=4), and draws 10 pairs from
-    each of the 8 cells (4 Bloom levels x 2 bands) with a fixed seed. The
-    emic score is the study's measurement of emic validity; this sample is
-    what the human annotators rate so agreement with it can be reported (spec
-    §6). Writes the sample + manifest under
-    ``results/<id>/human_eval/outputs/``.
+    Pools the pairs ``judge-qa`` approved from the run's CEP records, groups them
+    by Bloom level, and draws ``--per-cell`` from each of the four levels with a
+    fixed seed. The sample is what the human annotators rate, so agreement with
+    the emic judge's measurement can be reported (spec §6); the judge's scores
+    join back at analysis time on ``pair_id``, which is why this command does not
+    read the emic_judge stage and does not wait for that run.
     """
-    print_info(f"Run: {pipeline_id} | seed: {seed}")
+    total = per_cell * len(FRAME_BLOOM_LEVELS)
+    print_info(f"Run: {pipeline_id} | seed: {seed} | {per_cell}/cell x 4 cells = {total} pairs")
 
     try:
-        manifest = run_build_sample_batch(pipeline_id=pipeline_id, seed=seed)
+        manifest = run_build_sample_batch(pipeline_id=pipeline_id, seed=seed, per_cell=per_cell)
     except FileNotFoundError as exc:
         print_error(str(exc))
         raise typer.Exit(code=1) from exc
@@ -60,15 +68,14 @@ def build_human_eval_sample(
         raise typer.Exit(code=1) from exc
 
     excluded_bloom_total = sum(manifest.excluded_bloom.values())
-    if manifest.excluded_none_score or excluded_bloom_total or manifest.excluded_not_approved:
+    if excluded_bloom_total or manifest.excluded_not_approved:
         print_warning(
             f"Excluded from frame: {manifest.excluded_not_approved} not judge-approved "
-            f"pair(s), {manifest.excluded_none_score} null-score pair(s), "
-            f"{excluded_bloom_total} out-of-frame-Bloom pair(s) "
+            f"pair(s), {excluded_bloom_total} out-of-frame-Bloom pair(s) "
             f"({manifest.excluded_bloom or 'none'})."
         )
     print_success(
-        f"Built {manifest.total_items} pairs across {len(manifest.cell_counts)} cells "
+        f"Built {manifest.total_items} pairs across {len(manifest.cell_counts)} Bloom cells "
         f"({manifest.per_cell}/cell). Sample + manifest under "
         f"results/{pipeline_id}/human_eval/outputs/."
     )

--- a/src/arandu/shared/annotation/build.py
+++ b/src/arandu/shared/annotation/build.py
@@ -65,9 +65,9 @@ def _shuffle_key(seed: int, pair_id: str) -> str:
 def shuffle_order(pair_ids: list[str], seed: int) -> list[str]:
     """Return ``pair_ids`` in the deterministic presentation order.
 
-    The sample arrives grouped by stratification cell. Presenting it that way
-    would let the annotator calibrate within a block of same-band pairs, so the
-    order is broken here, at the source, with a recorded seed. Label Studio's own
+    The sample arrives grouped by Bloom cell. Presenting it that way would let
+    the annotator calibrate within a block of same-cell pairs, so the order is
+    broken here, at the source, with a recorded seed. Label Studio's own
     shuffle is per-annotator, random, and not recordable, which is why it is not
     used.
     """

--- a/src/arandu/shared/emic/batch.py
+++ b/src/arandu/shared/emic/batch.py
@@ -10,8 +10,9 @@ These scores are the study's **measurement** of emic validity, not a
 preliminary aid. The human annotation round (spec §6) rates a stratified
 subsample and reports agreement with them (Krippendorff alpha over the raters,
 weighted Cohen kappa of this judge against each annotator); it validates the
-measurement rather than replacing it. The same scores also band the stratified
-sample builder, but that is a downstream use, not their purpose.
+measurement rather than replacing it. The stratified sample is built
+independently from the CEP records, not from this run's output; these scores
+rejoin the human annotations at analysis time by joining on ``pair_id``.
 
 The criterion is built standalone via ``OrdinalLLMCriterion.from_config``; it
 is not wired into the ``judge-qa`` pipeline (that, with a filter threshold, is
@@ -161,7 +162,8 @@ def run_emic_judge_batch(
         # Resetting only the checkpoint would leave per-source outputs from a
         # prior run in outputs_dir. If the CEP stage was regenerated with a
         # different (e.g. smaller) corpus since, those orphaned files would be
-        # globbed as live scores by the stratified sample builder. Clear them.
+        # read as live scores when the analysis joins this directory against
+        # the human annotations on `pair_id`. Clear them.
         for stale in results_mgr.outputs_dir.glob("*.json"):
             stale.unlink()
     checkpoint = CheckpointManager(checkpoint_path)

--- a/src/arandu/shared/emic/schemas.py
+++ b/src/arandu/shared/emic/schemas.py
@@ -23,8 +23,11 @@ class EmicScore(BaseModel):
 
     Attributes:
         pair_index: Index of the pair within its source ``QARecordCEP``
-            (a stable per-source key for the sample builder).
-        bloom_level: The pair's Bloom level (carried for stratification).
+            (a stable per-source key that combines with ``source_file_id``
+            into the ``pair_id`` used to join this score against the human
+            annotations at analysis time).
+        bloom_level: The pair's Bloom level, carried so emic validity can be
+            broken down by Bloom level without re-joining the CEP records.
         emic_score: Ordinal label in ``{1..5}``, or ``None`` if the LLM call
             errored for this pair.
         rationale: The judge's short justification.
@@ -32,8 +35,9 @@ class EmicScore(BaseModel):
         is_valid: The pair's ``judge-qa`` verdict at scoring time: ``True``
             approved, ``False`` rejected, ``None`` never judged. Carried so
             emic validity can be cross-tabulated against approval without
-            re-joining the CEP records, and so the sample builder can restrict
-            its frame to approved pairs even when the run scored everything.
+            re-joining the CEP records. The human-comparison sample restricts
+            its own frame to approved pairs independently, from the CEP
+            records directly.
     """
 
     pair_index: int = Field(..., ge=0)

--- a/src/arandu/shared/human_eval/__init__.py
+++ b/src/arandu/shared/human_eval/__init__.py
@@ -1,4 +1,4 @@
-"""Human-comparison study: stratified 80-pair sample builder (spec §5)."""
+"""Human-comparison study: Bloom-stratified 120-pair sample builder (spec §5)."""
 
 from arandu.shared.human_eval.batch import run_build_sample_batch
 from arandu.shared.human_eval.sampling import InsufficientCellError, PoolEntry, build_sample

--- a/src/arandu/shared/human_eval/batch.py
+++ b/src/arandu/shared/human_eval/batch.py
@@ -1,10 +1,14 @@
 """Batch orchestrator for ``arandu build-human-eval-sample`` (spec §5).
 
-Builds the in-frame pool from the emic-judge outputs (dropping null-score
-and out-of-frame-Bloom pairs), joins each pair's CEP payload (segment +
-question + answer), runs the deterministic stratified sampler, and persists the
-80-pair sample + a provenance manifest under
-``results/<id>/human_eval/outputs/``.
+Builds the in-frame pool from the CEP records (keeping the pairs ``judge-qa``
+approved, dropping out-of-frame Bloom levels), runs the deterministic
+Bloom-stratified sampler, and persists the 120-pair sample + a provenance
+manifest under ``results/<id>/human_eval/outputs/``.
+
+Revised 2026-08-19: the pool used to be built from the emic-judge scores, which
+put that run on the annotation critical path. Only the emic band needed it, and
+the band is gone. See
+``docs/superpowers/specs/2026-08-19-bloom-only-sampling-design.md``.
 """
 
 from __future__ import annotations
@@ -15,7 +19,6 @@ from typing import TYPE_CHECKING
 
 from arandu.qa.schemas import QARecordCEP
 from arandu.shared.config import ResultsConfig
-from arandu.shared.emic.schemas import EmicSourceScores
 from arandu.shared.human_eval.sampling import (
     FRAME_BLOOM_LEVELS,
     PER_CELL,
@@ -42,8 +45,7 @@ def _pool_sha256(pool: list[PoolEntry]) -> str:
 
     Canonical JSON per entry, sorted, so the digest is order-independent and
     changes if any payload text (segment/question/answer) drifts -- not just the
-    ids/scores -- letting an auditor detect a CEP regeneration under the same
-    pair ids.
+    ids -- letting an auditor detect a CEP regeneration under the same pair ids.
     """
     lines = sorted(e.model_dump_json() for e in pool)
     return hashlib.sha256("\n".join(lines).encode("utf-8")).hexdigest()
@@ -59,105 +61,75 @@ def run_build_sample_batch(
     """Build the stratified human-comparison sample for ``pipeline_id``.
 
     Args:
-        pipeline_id: Run identifier. Both the ``emic_judge`` and ``cep``
-            stages must be populated.
+        pipeline_id: Run identifier. The ``cep`` stage must be populated and
+            judged; the ``emic_judge`` stage is NOT read.
         seed: RNG seed for the deterministic selection (recorded in the run
             metadata and the manifest).
         base_dir: Override the project ``results/`` root.
-        per_cell: Pairs to draw per cell (default 10 -> 80 total).
+        per_cell: Pairs to draw per cell (default 30 -> 120 total).
 
     Returns:
         The :class:`SampleManifest` describing the build.
 
     Raises:
-        FileNotFoundError: If the emic_judge or cep stage outputs are absent.
+        FileNotFoundError: If the cep stage outputs are absent.
         ValueError: If a stratification cell has fewer than ``per_cell`` pairs,
-            or a referenced CEP pair cannot be resolved.
+            if no approved in-frame pair exists at all, or if two CEP records
+            share a ``source_file_id`` and collide a ``pair_id``.
     """
     base = base_dir if base_dir is not None else ResultsConfig().base_dir
-    emic_outputs = base / pipeline_id / PipelineType.EMIC_JUDGE.value / "outputs"
     cep_outputs = base / pipeline_id / PipelineType.CEP.value / "outputs"
-    if not emic_outputs.exists():
-        raise FileNotFoundError(
-            f"Emic-judge outputs not found for pipeline_id {pipeline_id!r}: {emic_outputs}. "
-            f"Run `arandu emic-judge --id {pipeline_id}` first."
-        )
     if not cep_outputs.exists():
         raise FileNotFoundError(
             f"CEP outputs not found for pipeline_id {pipeline_id!r}: {cep_outputs}. "
-            f"The sample payload (segment/question/answer) is joined from the CEP records."
+            f"Run `arandu generate-cep-qa --id {pipeline_id}` first. The emic-judge stage "
+            f"is not needed to build the sample."
         )
 
     pool: list[PoolEntry] = []
     seen_pair_ids: set[str] = set()
-    excluded_none = 0
     excluded_not_approved = 0
     excluded_bloom: dict[str, int] = {}
-    for emic_path in sorted(emic_outputs.glob("*_cep_qa.json")):
-        scores = EmicSourceScores.load(emic_path)
-        cep_path = cep_outputs / emic_path.name
-        if not cep_path.exists():
-            raise ValueError(
-                f"Emic scores reference {emic_path.name} but the matching CEP record "
-                f"{cep_path} is missing; cannot build the annotation payload."
-            )
+    for cep_path in sorted(cep_outputs.glob("*_cep_qa.json")):
         record = QARecordCEP.load(cep_path)
-        for score in scores.scores:
-            if score.pair_index >= len(record.qa_pairs):
-                raise ValueError(
-                    f"pair_index {score.pair_index} out of range for {cep_path.name} "
-                    f"({len(record.qa_pairs)} pairs); emic/cep stages are out of sync."
-                )
-            pair = record.qa_pairs[score.pair_index]
-
-            # An `emic-judge --scope all` run scores rejected and never-judged
-            # pairs too, so the emic outputs are NOT a pool of approved pairs.
-            # The agreement study's frame is the approved corpus (spec §5), so
-            # drop anything the judge did not approve before banding.
-            #
-            # Read the verdict off the CEP record, not off `score.is_valid`:
-            # that field is a snapshot taken when the emic judge ran, so a
-            # `judge-qa` re-run (e.g. a threshold change) would leave the frame
-            # pinned to the old verdicts, sampling pairs the corpus now rejects
-            # and excluding ones it now approves. The record loaded above is the
-            # authoritative copy. `score.is_valid` remains the provenance record
-            # of what the emic run saw.
+        for pair_index, pair in enumerate(record.qa_pairs):
+            # The study's frame is the corpus judge-qa approved. The verdict is
+            # read from the CEP record, which is the authoritative copy: a
+            # judge-qa re-run (e.g. a threshold change) is picked up here rather
+            # than leaving the frame pinned to a stale snapshot.
             if pair.is_valid is not True:
                 excluded_not_approved += 1
                 continue
-            if score.emic_score is None:
-                excluded_none += 1
+            if pair.bloom_level not in FRAME_BLOOM_LEVELS:
+                excluded_bloom[pair.bloom_level] = excluded_bloom.get(pair.bloom_level, 0) + 1
                 continue
-            if score.bloom_level not in FRAME_BLOOM_LEVELS:
-                excluded_bloom[score.bloom_level] = excluded_bloom.get(score.bloom_level, 0) + 1
-                continue
-            pair_id = f"{scores.source_file_id}:{score.pair_index}"
+            pair_id = f"{record.source_file_id}:{pair_index}"
             if pair_id in seen_pair_ids:
                 raise ValueError(
-                    f"Duplicate pair_id {pair_id!r} while pooling {emic_path.name}; the "
-                    f"emic_judge outputs likely contain a stale or duplicate file for this "
-                    f"source. Clean results/{pipeline_id}/emic_judge/outputs/ and re-run."
+                    f"Duplicate pair_id {pair_id!r} while pooling {cep_path.name}; two CEP "
+                    f"records share source_file_id {record.source_file_id!r}, so the join key "
+                    f"the annotations resolve through is not unique. Clean "
+                    f"results/{pipeline_id}/cep/outputs/ and re-run."
                 )
             seen_pair_ids.add(pair_id)
             pool.append(
                 PoolEntry(
                     pair_id=pair_id,
-                    source_file_id=scores.source_file_id,
-                    pair_index=score.pair_index,
+                    source_file_id=record.source_file_id,
+                    pair_index=pair_index,
                     segment=pair.context,
                     question=pair.question,
                     answer=pair.answer,
-                    bloom_level=score.bloom_level,
-                    emic_score=score.emic_score,
+                    bloom_level=pair.bloom_level,
                 )
             )
 
     if not pool:
         raise ValueError(
             f"No in-frame approved pairs found for {pipeline_id!r} "
-            f"({excluded_not_approved} not judge-approved, {excluded_none} null-score, "
+            f"({excluded_not_approved} not judge-approved, "
             f"{sum(excluded_bloom.values())} out-of-frame-Bloom excluded). Check that "
-            f"`arandu judge-qa` + `arandu emic-judge` ran and produced approved, scored, "
+            f"`arandu generate-cep-qa` + `arandu judge-qa` ran and produced approved, "
             f"in-frame ({', '.join(FRAME_BLOOM_LEVELS)}) pairs."
         )
 
@@ -167,7 +139,7 @@ def run_build_sample_batch(
     results_mgr = ResultsManager(base, PipelineType.HUMAN_EVAL, pipeline_id=pipeline_id)
     results_mgr.create_run(
         HumanEvalSampleConfig(seed=seed, per_cell=per_cell),
-        input_source=str(emic_outputs),
+        input_source=str(cep_outputs),
     )
 
     # build_sample may raise InsufficientCellError (a ValueError); let it
@@ -186,7 +158,6 @@ def run_build_sample_batch(
         per_cell=per_cell,
         cell_counts=dict.fromkeys(all_cell_ids(), per_cell),
         population_by_cell=population,
-        excluded_none_score=excluded_none,
         excluded_not_approved=excluded_not_approved,
         excluded_bloom=excluded_bloom,
         pool_sha256=pool_hash,
@@ -198,12 +169,11 @@ def run_build_sample_batch(
 
     logger.info(
         "Built human-eval sample: %d items across %d cells (pool=%d, excluded "
-        "not-approved=%d, none=%d, bloom=%d).",
+        "not-approved=%d, bloom=%d).",
         len(items),
         len(manifest.cell_counts),
         len(pool),
         excluded_not_approved,
-        excluded_none,
         sum(excluded_bloom.values()),
     )
     return manifest

--- a/src/arandu/shared/human_eval/sampling.py
+++ b/src/arandu/shared/human_eval/sampling.py
@@ -1,10 +1,14 @@
-"""Deterministic stratified sampler for the human-comparison study (spec §5).
+"""Deterministic Bloom-stratified sampler for the human-comparison study (spec §5).
 
-Pure selection logic with no I/O: given an in-frame pool of approved pairs
-(each carrying its emic-judge ordinal score and annotation payload), build
-the 80-pair sample stratified as 4 Bloom levels x 2 emic bands x 10 pairs.
-Frame construction (dropping null-score and out-of-frame-Bloom pairs, joining
-the CEP payload) happens upstream in ``batch.py``.
+Pure selection logic with no I/O: given an in-frame pool of judge-approved pairs
+carrying the annotation payload, build the 120-pair sample stratified as 4 Bloom
+levels x 30 pairs. Frame construction (dropping non-approved and out-of-frame
+Bloom pairs, reading the CEP payload) happens upstream in ``batch.py``.
+
+Revised 2026-08-19: stratification was 4 Bloom x 2 emic bands x 15. The band came
+from the emic judge's score, which put that run on the annotation critical path;
+it was removed and the sample is now built from the CEP records alone. See
+``docs/superpowers/specs/2026-08-19-bloom-only-sampling-design.md``.
 """
 
 from __future__ import annotations
@@ -21,11 +25,10 @@ if TYPE_CHECKING:
 
 # The four Bloom levels the agreement study stratifies over (spec §5). The CEP
 # generator can also emit ``apply`` / ``create``; those are out-of-frame and
-# dropped during pool construction (see batch.py).
+# dropped during pool construction (see batch.py), never made into a fifth cell.
 FRAME_BLOOM_LEVELS: tuple[str, ...] = ("remember", "understand", "analyze", "evaluate")
-BANDS: tuple[str, ...] = ("duvidosa", "limpa")
-PER_CELL: int = 10
-DUBIOUS_MAX_SCORE: int = 3  # emic_score <= 3 -> duvidosa; >= 4 -> limpa
+#: Pairs drawn per cell. 4 cells x 30 = the 120 pairs the annotators accepted.
+PER_CELL: int = 30
 
 
 class PoolEntry(BaseModel):
@@ -39,7 +42,7 @@ class PoolEntry(BaseModel):
         question: The generated question.
         answer: The generated answer.
         bloom_level: Bloom level; must be one of :data:`FRAME_BLOOM_LEVELS`.
-        emic_score: Ordinal emic score {1..5} (banding key; never None here).
+            This is the stratification cell.
     """
 
     pair_id: str
@@ -49,34 +52,36 @@ class PoolEntry(BaseModel):
     question: str
     answer: str
     bloom_level: str
-    emic_score: int = Field(..., ge=1, le=5)
-
-
-def band_for(emic_score: int) -> str:
-    """Return the emic band for an ordinal score (``duvidosa`` <=3, ``limpa`` >=4)."""
-    return "duvidosa" if emic_score <= DUBIOUS_MAX_SCORE else "limpa"
-
-
-def cell_id_for(bloom_level: str, band: str) -> str:
-    """Return the ``"{bloom_level}:{band}"`` cell key."""
-    return f"{bloom_level}:{band}"
 
 
 def all_cell_ids() -> list[str]:
-    """Return the 8 cell ids in a stable order (Bloom x band)."""
-    return [cell_id_for(bloom, band) for bloom in FRAME_BLOOM_LEVELS for band in BANDS]
+    """Return the 4 cell ids in frame order.
+
+    A cell *is* a Bloom level. There is no composite key any more, so there is
+    also no ``cell_id_for`` helper: use the entry's ``bloom_level`` directly.
+    """
+    return list(FRAME_BLOOM_LEVELS)
 
 
 def population_by_cell(pool: Iterable[PoolEntry]) -> dict[str, int]:
-    """Count in-frame pool entries per cell (all 8 cells present, zero-filled)."""
+    """Count in-frame pool entries per cell (all 4 cells present, zero-filled).
+
+    Args:
+        pool: In-frame entries. Every ``bloom_level`` must be in
+            :data:`FRAME_BLOOM_LEVELS`; filtering is the caller's job and an
+            out-of-frame level raises ``KeyError`` rather than inventing a cell.
+
+    Returns:
+        Count per Bloom level, every level present.
+    """
     counts = dict.fromkeys(all_cell_ids(), 0)
     for entry in pool:
-        counts[cell_id_for(entry.bloom_level, band_for(entry.emic_score))] += 1
+        counts[entry.bloom_level] += 1
     return counts
 
 
 class InsufficientCellError(ValueError):
-    """Raised when a stratification cell has fewer than ``PER_CELL`` pairs."""
+    """Raised when a stratification cell has fewer than ``per_cell`` pairs."""
 
 
 def _selection_key(seed: int, pair_id: str) -> str:
@@ -91,25 +96,28 @@ def _selection_key(seed: int, pair_id: str) -> str:
 
 
 def build_sample(pool: list[PoolEntry], seed: int, *, per_cell: int = PER_CELL) -> list[SampleItem]:
-    """Build the stratified sample deterministically.
+    """Build the Bloom-stratified sample deterministically.
 
-    Bands each pool entry, groups into the 8 cells (4 Bloom x 2 bands), and
-    deterministically draws ``per_cell`` from each by ordering the cell's
-    entries on a seeded SHA-256 key (:func:`_selection_key`) and taking the
-    first ``per_cell``. The ordering depends only on the seed and each pair's
-    id, so the result is independent of input/file order AND of other cells'
-    sizes, and is stable across Python versions: same seed + same pool always
-    yields the same sample. ``duvidosa`` is over-sampled to 50/50 against
-    ``limpa`` regardless of population skew.
+    Groups the pool into the 4 Bloom cells and deterministically draws
+    ``per_cell`` from each by ordering the cell's entries on a seeded SHA-256 key
+    (:func:`_selection_key`) and taking the first ``per_cell``. The ordering
+    depends only on the seed and each pair's id, so the result is independent of
+    input/file order AND of other cells' sizes, and is stable across Python
+    versions: same seed + same pool always yields the same sample.
+
+    Within a cell the draw is uniform, so the sample mirrors that cell's
+    population. This is the accepted cost of dropping the emic band, which used
+    to over-sample the ``duvidosa`` half to 50/50: the frame is the approved
+    corpus, so easy pairs dominate and agreement is high partly by construction.
 
     Args:
-        pool: In-frame approved pairs (Bloom in :data:`FRAME_BLOOM_LEVELS`,
-            non-null score). Frame filtering is the caller's responsibility.
+        pool: In-frame approved pairs (Bloom in :data:`FRAME_BLOOM_LEVELS`).
+            Frame filtering is the caller's responsibility.
         seed: Selection seed; recorded in the manifest for reproducibility.
-        per_cell: Pairs to draw per cell (default 10 -> 80 total).
+        per_cell: Pairs to draw per cell (default :data:`PER_CELL` -> 120 total).
 
     Returns:
-        ``8 * per_cell`` :class:`SampleItem` objects, grouped by cell in
+        ``4 * per_cell`` :class:`SampleItem` objects, grouped by cell in
         :func:`all_cell_ids` order with ``slot_id`` 0..per_cell-1 per cell
         (slot order is the deterministic selection-key rank).
 
@@ -119,16 +127,17 @@ def build_sample(pool: list[PoolEntry], seed: int, *, per_cell: int = PER_CELL) 
     """
     by_cell: dict[str, list[PoolEntry]] = {cid: [] for cid in all_cell_ids()}
     for entry in pool:
-        by_cell[cell_id_for(entry.bloom_level, band_for(entry.emic_score))].append(entry)
+        by_cell[entry.bloom_level].append(entry)
 
     items: list[SampleItem] = []
     for cell_id in all_cell_ids():
         entries = by_cell[cell_id]
         if len(entries) < per_cell:
             raise InsufficientCellError(
-                f"Cell {cell_id!r} has only {len(entries)} approved pair(s) but {per_cell} "
-                f"are required. Remediate by approving more pairs (larger CEP/judge pool) "
-                f"or revisiting the emic bands; cells are never back-filled from other cells."
+                f"Bloom cell {cell_id!r} has only {len(entries)} approved pair(s) but "
+                f"{per_cell} are required. Remediate by approving more pairs (larger "
+                f"CEP/judge pool) or by lowering --per-cell; cells are never back-filled "
+                f"from other cells, because that would silently unbalance the design."
             )
         # pair_id is the tiebreaker so the order is total even on a (vanishingly
         # unlikely) key collision.
@@ -143,8 +152,6 @@ def build_sample(pool: list[PoolEntry], seed: int, *, per_cell: int = PER_CELL) 
                     question=entry.question,
                     answer=entry.answer,
                     bloom_level=entry.bloom_level,
-                    emic_score=entry.emic_score,
-                    cell_id=cell_id,
                     slot_id=slot_id,
                 )
             )

--- a/src/arandu/shared/human_eval/sampling.py
+++ b/src/arandu/shared/human_eval/sampling.py
@@ -5,9 +5,11 @@ carrying the annotation payload, build the 120-pair sample stratified as 4 Bloom
 levels x 30 pairs. Frame construction (dropping non-approved and out-of-frame
 Bloom pairs, reading the CEP payload) happens upstream in ``batch.py``.
 
-Revised 2026-08-19: stratification was 4 Bloom x 2 emic bands x 15. The band came
-from the emic judge's score, which put that run on the annotation critical path;
-it was removed and the sample is now built from the CEP records alone. See
+Revised 2026-08-19: stratification was 4 Bloom levels x 2 emic bands,
+defaulting to 10 pairs per cell (the agreed protocol asked for 15 per cell,
+but the CLI had no ``--per-cell`` flag yet to set it). The band came from the
+emic judge's score, which put that run on the annotation critical path; it
+was removed and the sample is now built from the CEP records alone. See
 ``docs/superpowers/specs/2026-08-19-bloom-only-sampling-design.md``.
 """
 
@@ -124,6 +126,11 @@ def build_sample(pool: list[PoolEntry], seed: int, *, per_cell: int = PER_CELL) 
     Raises:
         InsufficientCellError: If any cell has fewer than ``per_cell`` entries;
             the message names the cell, its available count, and remediation.
+        KeyError: If a pool entry's ``bloom_level`` is not in
+            :data:`FRAME_BLOOM_LEVELS`. Frame filtering is the caller's
+            responsibility (see the ``pool`` argument); this function does not
+            defensively re-check it, so an out-of-frame level surfaces loudly
+            here instead of silently opening a fifth cell.
     """
     by_cell: dict[str, list[PoolEntry]] = {cid: [] for cid in all_cell_ids()}
     for entry in pool:

--- a/src/arandu/shared/human_eval/schemas.py
+++ b/src/arandu/shared/human_eval/schemas.py
@@ -20,26 +20,28 @@ class HumanEvalSampleConfig(BaseModel):
 
 
 class SampleItem(BaseModel):
-    """One pair selected into the 80-pair human-comparison sample.
+    """One pair selected into the human-comparison sample.
 
-    Carries the blinded annotation payload (segment + question + answer) plus
-    the stratification bookkeeping. Deliberately excludes ``tacit_inference``
-    and the canonical judge scores; further blinding (hiding ``bloom_level`` /
-    ``emic_score`` from the annotator) is the annotation instrument's
-    responsibility, not this artifact's.
+    Carries the blinded annotation payload (segment + question + answer) plus the
+    stratification bookkeeping. Deliberately excludes ``tacit_inference`` and the
+    canonical judge scores; further blinding (hiding ``bloom_level`` from the
+    annotator) is the annotation instrument's responsibility, not this artifact's.
+
+    Carries **no emic score**. The sample is built from the CEP records alone so
+    the emic-judge run stays off the annotation critical path; the judge's scores
+    join back at analysis time on ``pair_id``. Re-adding the field would restore
+    the dependency silently (revised 2026-08-19).
 
     Attributes:
-        pair_id: Stable canonical key ``"{source_file_id}:{pair_index}"``.
+        pair_id: Stable canonical key ``"{source_file_id}:{pair_index}"``. This is
+            the join key to the emic-judge outputs at analysis time.
         source_file_id: Source interview id (joins back to the CEP record).
         pair_index: Index into the source ``QARecordCEP.qa_pairs``.
         segment: Source transcript segment the QA pair was generated from.
         question: The generated question.
         answer: The generated answer.
-        bloom_level: Bloom level (stratification dimension).
-        emic_score: Ordinal emic-validity score {1..5} from the emic judge
-            (the measurement the annotators' ratings are compared against).
-        cell_id: ``"{bloom_level}:{band}"`` stratification cell.
-        slot_id: 0-based slot within the cell (0..9).
+        bloom_level: Bloom level. This is the stratification cell.
+        slot_id: 0-based slot within the cell (``0..per_cell-1``).
     """
 
     pair_id: str
@@ -49,8 +51,6 @@ class SampleItem(BaseModel):
     question: str
     answer: str
     bloom_level: str
-    emic_score: int = Field(..., ge=1, le=5)
-    cell_id: str
     slot_id: int = Field(..., ge=0)
 
 
@@ -60,19 +60,23 @@ class SampleManifest(BaseModel):
     Attributes:
         pipeline_id: Run identifier.
         seed: RNG seed (makes the selection reproducible).
-        total_items: Number of items in the sample (8 cells x per_cell).
+        total_items: Number of items in the sample (4 cells x per_cell).
         per_cell: Target pairs per cell.
-        cell_counts: Selected count per ``cell_id`` (each equals ``per_cell``).
-        population_by_cell: In-frame available count per ``cell_id`` (the pool
-            each cell was sampled from).
-        excluded_none_score: Approved pairs dropped for a null emic score.
-        excluded_not_approved: Scored pairs dropped because ``judge-qa`` did
-            not approve them (rejected or never judged). Non-zero whenever the
-            emic judge ran with ``--scope all``; the study's frame is the
-            approved corpus.
+        cell_counts: Selected count per Bloom level (each equals ``per_cell``).
+        population_by_cell: In-frame available count per Bloom level (the pool
+            each cell was sampled from). Keys are the Bloom levels themselves,
+            not the ``"{bloom}:{band}"`` composites used before 2026-08-19.
+        excluded_not_approved: Pairs dropped because ``judge-qa`` did not approve
+            them. **Not comparable to the pre-2026-08-19 counts:** the builder
+            used to walk the emic-judge outputs and could only count pairs the
+            judge had scored, whereas it now walks the CEP records and counts
+            every non-approved pair in the corpus, so the number is much larger
+            for the same run.
         excluded_bloom: Approved pairs dropped per out-of-frame Bloom level
             (``apply`` / ``create``), keyed by level.
-        pool_sha256: Hash of the in-frame pool keys + scores (provenance).
+        pool_sha256: Hash of the in-frame pool entries incl. payload
+            (provenance). Not comparable across the two designs either: the pool
+            model no longer carries ``emic_score``.
     """
 
     pipeline_id: str
@@ -81,7 +85,6 @@ class SampleManifest(BaseModel):
     per_cell: int
     cell_counts: dict[str, int]
     population_by_cell: dict[str, int]
-    excluded_none_score: int = 0
     excluded_not_approved: int = 0
     excluded_bloom: dict[str, int] = Field(default_factory=dict)
     pool_sha256: str

--- a/tests/cli/test_human_eval_cli.py
+++ b/tests/cli/test_human_eval_cli.py
@@ -21,14 +21,27 @@ runner = CliRunner()
 
 @pytest.fixture
 def batch(mocker: MockerFixture) -> MagicMock:
-    """Patch the batch so the CLI is tested without touching the filesystem."""
-    manifest = mocker.Mock(
-        spec=SampleManifest,
+    """Patch the batch so the CLI is tested without touching the filesystem.
+
+    Uses a real ``SampleManifest`` instead of ``mocker.Mock(spec=SampleManifest)``.
+    Pydantic v2 model fields are not class attributes, so ``spec=SampleManifest``
+    does not constrain them: ``Mock(spec=SampleManifest, excluded_none_score=3)``
+    is accepted without error even though that field no longer exists. A real
+    instance gives the same protection the spec was meant to provide (the CLI
+    only reads attributes off it, and a removed field still raises
+    ``AttributeError``), without also accepting attributes pydantic would
+    reject.
+    """
+    manifest = SampleManifest(
+        pipeline_id="run1",
+        seed=42,
         total_items=120,
         per_cell=30,
         cell_counts={"remember": 30, "understand": 30, "analyze": 30, "evaluate": 30},
+        population_by_cell={"remember": 433, "understand": 644, "analyze": 644, "evaluate": 689},
         excluded_not_approved=0,
         excluded_bloom={},
+        pool_sha256="0" * 64,
     )
     return mocker.patch("arandu.cli.human_eval.run_build_sample_batch", return_value=manifest)
 

--- a/tests/cli/test_human_eval_cli.py
+++ b/tests/cli/test_human_eval_cli.py
@@ -9,6 +9,7 @@ from typer.testing import CliRunner
 
 from arandu.cli.app import app
 from arandu.shared.human_eval.sampling import PER_CELL
+from arandu.shared.human_eval.schemas import SampleManifest
 
 if TYPE_CHECKING:
     from unittest.mock import MagicMock
@@ -22,6 +23,7 @@ runner = CliRunner()
 def batch(mocker: MockerFixture) -> MagicMock:
     """Patch the batch so the CLI is tested without touching the filesystem."""
     manifest = mocker.Mock(
+        spec=SampleManifest,
         total_items=120,
         per_cell=30,
         cell_counts={"remember": 30, "understand": 30, "analyze": 30, "evaluate": 30},
@@ -59,8 +61,20 @@ class TestBuildHumanEvalSample:
         batch.assert_not_called()
 
     def test_echoes_the_resulting_size_before_building(self, batch: MagicMock) -> None:
-        result = runner.invoke(app, ["build-human-eval-sample", "--id", "run1", "--seed", "42"])
-        assert "120" in result.stdout
+        """The pre-build echo must be detectable even if post-build output changes.
+
+        This test invokes with --per-cell 7, which produces 7*4=28 pairs in the
+        pre-build echo. The mock's total_items stays 120, so print_success cannot
+        produce 28 -- only the pre-build echo can. This prevents a regression where
+        removing the print_info line would go undetected because the test would
+        still pass on the 120 from print_success.
+        """
+        result = runner.invoke(
+            app,
+            ["build-human-eval-sample", "--id", "run1", "--seed", "42", "--per-cell", "7"],
+        )
+        assert result.exit_code == 0
+        assert "28" in result.stdout
 
     def test_insufficient_cell_exits_one(self, batch: MagicMock) -> None:
         """Only the exit code is asserted: `print_error` writes to `stderr_console`.

--- a/tests/cli/test_human_eval_cli.py
+++ b/tests/cli/test_human_eval_cli.py
@@ -1,0 +1,75 @@
+"""Tests for the ``arandu build-human-eval-sample`` command."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from typer.testing import CliRunner
+
+from arandu.cli.app import app
+from arandu.shared.human_eval.sampling import PER_CELL
+
+if TYPE_CHECKING:
+    from unittest.mock import MagicMock
+
+    from pytest_mock import MockerFixture
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def batch(mocker: MockerFixture) -> MagicMock:
+    """Patch the batch so the CLI is tested without touching the filesystem."""
+    manifest = mocker.Mock(
+        total_items=120,
+        per_cell=30,
+        cell_counts={"remember": 30, "understand": 30, "analyze": 30, "evaluate": 30},
+        excluded_not_approved=0,
+        excluded_bloom={},
+    )
+    return mocker.patch("arandu.cli.human_eval.run_build_sample_batch", return_value=manifest)
+
+
+class TestBuildHumanEvalSample:
+    def test_is_registered(self) -> None:
+        result = runner.invoke(app, ["--help"])
+        assert result.exit_code == 0
+        assert "build-human-eval-sample" in result.stdout
+
+    def test_per_cell_defaults_to_the_module_constant(self, batch: MagicMock) -> None:
+        result = runner.invoke(app, ["build-human-eval-sample", "--id", "run1", "--seed", "42"])
+        assert result.exit_code == 0
+        assert batch.call_args.kwargs["per_cell"] == PER_CELL
+
+    def test_per_cell_is_forwarded(self, batch: MagicMock) -> None:
+        result = runner.invoke(
+            app,
+            ["build-human-eval-sample", "--id", "run1", "--seed", "42", "--per-cell", "10"],
+        )
+        assert result.exit_code == 0
+        assert batch.call_args.kwargs["per_cell"] == 10
+
+    def test_per_cell_rejects_zero(self, batch: MagicMock) -> None:
+        result = runner.invoke(
+            app,
+            ["build-human-eval-sample", "--id", "run1", "--seed", "42", "--per-cell", "0"],
+        )
+        assert result.exit_code != 0
+        batch.assert_not_called()
+
+    def test_echoes_the_resulting_size_before_building(self, batch: MagicMock) -> None:
+        result = runner.invoke(app, ["build-human-eval-sample", "--id", "run1", "--seed", "42"])
+        assert "120" in result.stdout
+
+    def test_insufficient_cell_exits_one(self, batch: MagicMock) -> None:
+        """Only the exit code is asserted: `print_error` writes to `stderr_console`.
+
+        Same shape as `test_desync_exits_one` in `tests/cli/test_annotation_cli.py`.
+        Asserting the message on `result.stdout` only works while Click's
+        `mix_stderr` default folds the streams together, which Click 8.2 drops.
+        """
+        batch.side_effect = ValueError("Bloom cell 'evaluate' has only 4 approved pair(s)")
+        result = runner.invoke(app, ["build-human-eval-sample", "--id", "run1", "--seed", "42"])
+        assert result.exit_code == 1
+        assert batch.called

--- a/tests/shared/annotation/test_build.py
+++ b/tests/shared/annotation/test_build.py
@@ -44,8 +44,6 @@ def _item(index: int) -> SampleItem:
         question=f"pergunta {index}",
         answer=f"resposta {index}",
         bloom_level=("remember", "understand", "analyze", "evaluate")[index % 4],
-        emic_score=(index % 5) + 1,
-        cell_id=f"{('remember', 'understand', 'analyze', 'evaluate')[index % 4]}:limpa",
         slot_id=index,
     )
 

--- a/tests/shared/annotation/test_build.py
+++ b/tests/shared/annotation/test_build.py
@@ -100,6 +100,32 @@ class TestShuffleOrder:
         ids = [f"s:{i}" for i in range(20)]
         assert shuffle_order(ids, seed=3) != ids
 
+    def test_order_is_pinned_to_the_published_mechanism(self) -> None:
+        """Golden vector over the exact permutation, not just its shape.
+
+        The manifest records a seed and promises the presentation order is
+        reproducible from it. Same-seed-twice cannot detect a changed mechanism:
+        a different digest or a reordered sort key is still deterministic and
+        still seed-dependent, so every other test here survives swapping one in,
+        while annotators would silently see a different order. This vector is
+        the tripwire.
+
+        Regenerate these ids only as a deliberate decision, never to make a red
+        test green: a change here means the published presentation order
+        changed.
+        """
+        ids = [f"s:{i}" for i in range(8)]
+        assert shuffle_order(ids, seed=2026) == [
+            "s:5",
+            "s:6",
+            "s:0",
+            "s:2",
+            "s:1",
+            "s:3",
+            "s:7",
+            "s:4",
+        ]
+
 
 class TestSignOffGate:
     def test_unsigned_ruler_refuses_to_build(self, sample_run: Path, tmp_path: Path) -> None:

--- a/tests/shared/human_eval/test_batch.py
+++ b/tests/shared/human_eval/test_batch.py
@@ -1,4 +1,4 @@
-"""Tests for the human-eval sample batch (spec §5)."""
+"""Tests for the human-eval sample batch (spec §5, revised 2026-08-19)."""
 
 from __future__ import annotations
 
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING
 import pytest
 
 from arandu.qa.schemas import QAPairCEP, QARecordCEP
-from arandu.shared.emic.schemas import EmicScore, EmicSourceScores
 from arandu.shared.human_eval.batch import run_build_sample_batch
 from arandu.shared.human_eval.schemas import SampleItem, SampleManifest
 from arandu.shared.judge.schemas import JudgePipelineResult
@@ -19,25 +18,25 @@ if TYPE_CHECKING:
 FRAME = ("remember", "understand", "analyze", "evaluate")
 
 
-def _frame_specs(per_cell: int) -> list[tuple[str, int | None]]:
-    """``per_cell`` duvidosa (score 2) + ``per_cell`` limpa (score 5) for each Bloom."""
-    specs: list[tuple[str, int | None]] = []
+def _frame_specs(per_cell: int) -> list[str]:
+    """``per_cell`` approved pairs for each Bloom level in the frame."""
+    specs: list[str] = []
     for bloom in FRAME:
-        specs += [(bloom, 2)] * per_cell
-        specs += [(bloom, 5)] * per_cell
+        specs += [bloom] * per_cell
     return specs
 
 
 def _write_source(
-    base: Path, pipeline_id: str, source_id: str, specs: list[tuple[str, int | None]]
+    base: Path,
+    pipeline_id: str,
+    source_id: str,
+    specs: list[str],
+    *,
+    approved: bool = True,
 ) -> None:
+    """Write one CEP record. No emic stage is written: the builder must not need it."""
     cep_outputs = base / pipeline_id / "cep" / "outputs"
-    emic_outputs = base / pipeline_id / "emic_judge" / "outputs"
     cep_outputs.mkdir(parents=True, exist_ok=True)
-    emic_outputs.mkdir(parents=True, exist_ok=True)
-
-    # The CEP record carries the authoritative judge-qa verdict; the frame is
-    # filtered on it, not on the snapshot in the emic outputs.
     pairs = [
         QAPairCEP(
             question=f"q{i}",
@@ -46,9 +45,9 @@ def _write_source(
             question_type="conceptual",
             confidence=0.9,
             bloom_level=bloom,
-            validation=JudgePipelineResult(stage_results={}, passed=True),
+            validation=JudgePipelineResult(stage_results={}, passed=approved),
         )
-        for i, (bloom, _score) in enumerate(specs)
+        for i, bloom in enumerate(specs)
     ]
     QARecordCEP(
         source_gdrive_id=source_id,
@@ -60,14 +59,6 @@ def _write_source(
         total_pairs=len(pairs),
     ).save(cep_outputs / f"{source_id}_cep_qa.json")
 
-    scores = [
-        EmicScore(pair_index=i, bloom_level=bloom, emic_score=score, rationale="r", is_valid=True)
-        for i, (bloom, score) in enumerate(specs)
-    ]
-    EmicSourceScores(
-        source_file_id=source_id, source_filename=f"{source_id}.mp4", scores=scores
-    ).save(emic_outputs / f"{source_id}_cep_qa.json")
-
 
 def _load_sample(base: Path, pipeline_id: str) -> list[SampleItem]:
     path = base / pipeline_id / "human_eval" / "outputs" / "sample.jsonl"
@@ -75,200 +66,122 @@ def _load_sample(base: Path, pipeline_id: str) -> list[SampleItem]:
 
 
 class TestRunBuildSampleBatch:
-    def test_happy_path_counts_and_manifest(self, tmp_path: Path) -> None:
+    def test_builds_with_no_emic_judge_stage_at_all(self, tmp_path: Path) -> None:
+        """The regression that keeps the emic judge off the critical path.
+
+        Nothing writes ``results/<id>/emic_judge/``, so a builder that still
+        reads it fails here rather than weeks later, in the queue.
+        """
         _write_source(tmp_path, "run1", "s1", _frame_specs(2))
+        assert not (tmp_path / "run1" / "emic_judge").exists()
 
         manifest = run_build_sample_batch("run1", seed=42, base_dir=tmp_path, per_cell=2)
 
-        assert manifest.total_items == 16  # 8 cells x 2
-        assert len(manifest.cell_counts) == 8
+        assert manifest.total_items == 8  # 4 cells x 2
+        assert set(manifest.cell_counts) == set(FRAME)
         assert all(c == 2 for c in manifest.cell_counts.values())
         assert manifest.seed == 42
-        assert manifest.pool_sha256  # provenance recorded
-
-        sample = _load_sample(tmp_path, "run1")
-        assert len(sample) == 16
-        # run finalized as COMPLETED
+        assert manifest.pool_sha256
+        assert len(_load_sample(tmp_path, "run1")) == 8
         meta = json.loads(
             (tmp_path / "run1" / "human_eval" / "run_metadata.json").read_text(encoding="utf-8")
         )
         assert meta["status"] == "completed"
 
-    def test_excludes_out_of_frame_bloom_and_null_score(self, tmp_path: Path) -> None:
-        specs = [*_frame_specs(2), ("apply", 5), ("create", 2), ("remember", None)]
+    def test_provenance_points_at_the_cep_stage(self, tmp_path: Path) -> None:
+        _write_source(tmp_path, "run_prov", "s1", _frame_specs(2))
+        run_build_sample_batch("run_prov", seed=1, base_dir=tmp_path, per_cell=2)
+        meta = json.loads(
+            (tmp_path / "run_prov" / "human_eval" / "run_metadata.json").read_text(encoding="utf-8")
+        )
+        assert meta["input_source"].endswith("cep/outputs")
+
+    def test_excludes_out_of_frame_bloom_and_counts_it(self, tmp_path: Path) -> None:
+        specs = [*_frame_specs(2), "apply", "create"]
         _write_source(tmp_path, "run2", "s1", specs)
 
         manifest = run_build_sample_batch("run2", seed=1, base_dir=tmp_path, per_cell=2)
 
-        assert manifest.total_items == 16  # exclusions don't change the sample size
-        assert manifest.excluded_none_score == 1
+        assert manifest.total_items == 8  # exclusions don't change the sample size
         assert manifest.excluded_bloom == {"apply": 1, "create": 1}
 
-    def test_frame_follows_the_live_cep_verdict_not_the_emic_snapshot(self, tmp_path: Path) -> None:
-        # An `emic-judge --scope all` run scores rejected pairs too, so the emic
-        # outputs are not a pool of approved pairs. The frame must come from the
-        # CEP record (the authoritative verdict), NOT from the is_valid snapshot
-        # frozen into the emic outputs -- otherwise a judge-qa re-run silently
-        # leaves the sample pinned to stale verdicts.
-        _write_source(tmp_path, "run_live", "s1", _frame_specs(3))
-        cep_path = next((tmp_path / "run_live" / "cep" / "outputs").glob("*_cep_qa.json"))
-        emic_path = next((tmp_path / "run_live" / "emic_judge" / "outputs").glob("*.json"))
+    def test_frame_is_the_judge_approved_corpus(self, tmp_path: Path) -> None:
+        _write_source(tmp_path, "run3", "s1", _frame_specs(2))
+        _write_source(tmp_path, "run3", "s2", _frame_specs(1), approved=False)
 
-        # The corpus rejects pair 0 while the emic snapshot still says approved.
-        record = QARecordCEP.load(cep_path)
-        record.qa_pairs[0].validation = JudgePipelineResult(stage_results={}, passed=False)
-        record.save(cep_path)
+        manifest = run_build_sample_batch("run3", seed=1, base_dir=tmp_path, per_cell=2)
 
-        manifest = run_build_sample_batch("run_live", seed=1, base_dir=tmp_path, per_cell=2)
-        assert manifest.excluded_not_approved == 1  # live verdict wins
-        assert manifest.total_items == 16
+        assert manifest.excluded_not_approved == 4  # s2's four rejected pairs
+        assert manifest.total_items == 8
+        assert all(i.source_file_id == "s1" for i in _load_sample(tmp_path, "run3"))
 
-        # And the converse: mutating only the emic snapshot must change nothing,
-        # because it is provenance, not the frame.
-        scores = EmicSourceScores.load(emic_path)
-        for score in scores.scores:
-            score.is_valid = False
-        scores.save(emic_path)
-
-        again = run_build_sample_batch("run_live", seed=1, base_dir=tmp_path, per_cell=2)
-        assert again.excluded_not_approved == 1
-        assert again.pool_sha256 == manifest.pool_sha256
-
-    def test_insufficient_approved_pairs_raises(self, tmp_path: Path) -> None:
-        # With too few approved pairs left in a cell the build fails loudly
-        # rather than silently shrinking the sample.
-        _write_source(tmp_path, "run_scope", "s1", _frame_specs(2))
-        cep_path = next((tmp_path / "run_scope" / "cep" / "outputs").glob("*_cep_qa.json"))
-        record = QARecordCEP.load(cep_path)
-        record.qa_pairs[0].validation = JudgePipelineResult(stage_results={}, passed=False)
-        record.save(cep_path)
-
-        with pytest.raises(ValueError, match="has only"):
-            run_build_sample_batch("run_scope", seed=1, base_dir=tmp_path, per_cell=2)
+    def test_population_by_cell_is_keyed_by_bloom_level(self, tmp_path: Path) -> None:
+        _write_source(tmp_path, "run_pop", "s1", _frame_specs(3))
+        manifest = run_build_sample_batch("run_pop", seed=1, base_dir=tmp_path, per_cell=2)
+        assert manifest.population_by_cell == dict.fromkeys(FRAME, 3)
 
     def test_payload_is_blinded(self, tmp_path: Path) -> None:
-        _write_source(tmp_path, "run3", "s1", _frame_specs(2))
-        run_build_sample_batch("run3", seed=1, base_dir=tmp_path, per_cell=2)
-        item = _load_sample(tmp_path, "run3")[0]
-        assert item.segment and item.question and item.answer  # payload present
-        assert item.pair_id == f"{item.source_file_id}:{item.pair_index}"
-        # SampleItem deliberately carries no tacit_inference / canonical scores
+        _write_source(tmp_path, "run4", "s1", _frame_specs(2))
+        run_build_sample_batch("run4", seed=1, base_dir=tmp_path, per_cell=2)
+        item = _load_sample(tmp_path, "run4")[0]
         dumped = item.model_dump()
+        assert "emic_score" not in dumped
+        assert "cell_id" not in dumped
         assert "tacit_inference" not in dumped
-        assert "weighted_score" not in dumped
+        assert dumped["segment"].startswith("segment ")
 
-    def test_insufficient_cell_raises_and_marks_failed(self, tmp_path: Path) -> None:
-        # remember:limpa gets only 1 limpa pair while per_cell=2.
-        specs = _frame_specs(2)
-        specs.remove(("remember", 5))  # drop one of the two remember-limpa pairs
-        _write_source(tmp_path, "run4", "s1", specs)
-
-        with pytest.raises(ValueError, match="remember:limpa"):
-            run_build_sample_batch("run4", seed=1, base_dir=tmp_path, per_cell=2)
-
+    def test_insufficient_cell_raises_and_marks_the_run_failed(self, tmp_path: Path) -> None:
+        _write_source(tmp_path, "run5", "s1", _frame_specs(1))
+        with pytest.raises(ValueError, match="required"):
+            run_build_sample_batch("run5", seed=1, base_dir=tmp_path, per_cell=2)
         meta = json.loads(
-            (tmp_path / "run4" / "human_eval" / "run_metadata.json").read_text(encoding="utf-8")
+            (tmp_path / "run5" / "human_eval" / "run_metadata.json").read_text(encoding="utf-8")
         )
         assert meta["status"] == "failed"
 
     def test_reproducible_across_runs(self, tmp_path: Path) -> None:
-        _write_source(tmp_path, "run5", "s1", _frame_specs(5))  # slack so selection is non-trivial
-        run_build_sample_batch("run5", seed=7, base_dir=tmp_path, per_cell=2)
-        first = [(i.pair_id, i.cell_id, i.slot_id) for i in _load_sample(tmp_path, "run5")]
-        run_build_sample_batch("run5", seed=7, base_dir=tmp_path, per_cell=2)
-        second = [(i.pair_id, i.cell_id, i.slot_id) for i in _load_sample(tmp_path, "run5")]
-        assert first == second
+        _write_source(tmp_path, "a", "s1", _frame_specs(5))
+        _write_source(tmp_path, "b", "s1", _frame_specs(5))
+        run_build_sample_batch("a", seed=77, base_dir=tmp_path, per_cell=2)
+        run_build_sample_batch("b", seed=77, base_dir=tmp_path, per_cell=2)
+        assert [i.pair_id for i in _load_sample(tmp_path, "a")] == [
+            i.pair_id for i in _load_sample(tmp_path, "b")
+        ]
 
-    def test_missing_emic_stage_raises(self, tmp_path: Path) -> None:
-        with pytest.raises(FileNotFoundError, match="Emic-judge outputs not found"):
+    def test_missing_cep_stage_names_the_generate_command(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError, match="generate-cep-qa"):
             run_build_sample_batch("absent", seed=1, base_dir=tmp_path, per_cell=2)
 
-    def test_missing_cep_stage_raises(self, tmp_path: Path) -> None:
-        # emic outputs present, cep dir absent.
-        emic_outputs = tmp_path / "run6" / "emic_judge" / "outputs"
-        emic_outputs.mkdir(parents=True)
-        EmicSourceScores(
-            source_file_id="s1",
-            source_filename="s1.mp4",
-            scores=[
-                EmicScore(
-                    pair_index=0, bloom_level="remember", emic_score=2, rationale="r", is_valid=True
-                )
-            ],
-        ).save(emic_outputs / "s1_cep_qa.json")
-
-        with pytest.raises(FileNotFoundError, match="CEP outputs not found"):
+    def test_empty_pool_raises_cause_specific(self, tmp_path: Path) -> None:
+        _write_source(tmp_path, "run6", "s1", _frame_specs(2), approved=False)
+        with pytest.raises(ValueError, match="not judge-approved"):
             run_build_sample_batch("run6", seed=1, base_dir=tmp_path, per_cell=2)
 
-    def test_empty_pool_raises_cause_specific(self, tmp_path: Path) -> None:
-        # All approved pairs are out-of-frame Bloom or null-score -> empty frame.
-        _write_source(tmp_path, "run8", "s1", [("apply", 5), ("create", 2), ("remember", None)])
-        with pytest.raises(ValueError, match="No in-frame approved pairs"):
-            run_build_sample_batch("run8", seed=1, base_dir=tmp_path, per_cell=2)
-
     def test_duplicate_pair_id_raises(self, tmp_path: Path) -> None:
-        # Two emic files whose EmicSourceScores share the same source_file_id +
-        # pair_index collide on pair_id (e.g. a stale duplicate emic output).
-        emic_outputs = tmp_path / "run9" / "emic_judge" / "outputs"
-        cep_outputs = tmp_path / "run9" / "cep" / "outputs"
-        emic_outputs.mkdir(parents=True)
-        cep_outputs.mkdir(parents=True)
-        for name in ("a", "b"):
-            QARecordCEP(
-                source_gdrive_id="dup",
-                source_filename="dup.mp4",
-                transcription_text="t",
-                qa_pairs=[
-                    QAPairCEP(
-                        question="q",
-                        answer="a",
-                        context="seg",
-                        question_type="conceptual",
-                        confidence=0.9,
-                        bloom_level="remember",
-                        validation=JudgePipelineResult(stage_results={}, passed=True),
-                    )
-                ],
-                model_id="m",
-                provider="ollama",
-                total_pairs=1,
-            ).save(cep_outputs / f"{name}_cep_qa.json")
-            EmicSourceScores(
-                source_file_id="dup",
-                source_filename="dup.mp4",
-                scores=[
-                    EmicScore(
-                        pair_index=0,
-                        bloom_level="remember",
-                        emic_score=2,
-                        rationale="r",
-                        is_valid=True,
-                    )
-                ],
-            ).save(emic_outputs / f"{name}_cep_qa.json")
-
+        """Two CEP files sharing a source_file_id would collide the join key."""
+        _write_source(tmp_path, "run7", "s1", _frame_specs(2))
+        cep_outputs = tmp_path / "run7" / "cep" / "outputs"
+        record = QARecordCEP.load(cep_outputs / "s1_cep_qa.json")
+        record.save(cep_outputs / "s1_copy_cep_qa.json")
         with pytest.raises(ValueError, match="Duplicate pair_id"):
-            run_build_sample_batch("run9", seed=1, base_dir=tmp_path, per_cell=2)
+            run_build_sample_batch("run7", seed=1, base_dir=tmp_path, per_cell=2)
 
     def test_pool_hash_changes_when_payload_drifts(self, tmp_path: Path) -> None:
-        # Same pair ids/bloom/score but different CEP text -> different pool hash.
-        _write_source(tmp_path, "runA", "s1", _frame_specs(2))
-        h1 = run_build_sample_batch("runA", seed=1, base_dir=tmp_path, per_cell=2).pool_sha256
-        # Rewrite the CEP records with mutated payload text, same indices/blooms.
-        cep_outputs = tmp_path / "runA" / "cep" / "outputs"
-        for cep_file in cep_outputs.glob("*_cep_qa.json"):
-            rec = QARecordCEP.load(cep_file)
-            for p in rec.qa_pairs:
-                p.context = p.context + " (edited)"
-            rec.save(cep_file)
-        h2 = run_build_sample_batch("runA", seed=1, base_dir=tmp_path, per_cell=2).pool_sha256
-        assert h1 != h2
+        """The digest covers the payload, so a CEP regeneration is detectable."""
+        _write_source(tmp_path, "run8", "s1", _frame_specs(3))
+        first = run_build_sample_batch("run8", seed=1, base_dir=tmp_path, per_cell=2)
+
+        _write_source(tmp_path, "run9", "s1", _frame_specs(3))
+        cep_path = tmp_path / "run9" / "cep" / "outputs" / "s1_cep_qa.json"
+        record = QARecordCEP.load(cep_path)
+        record.qa_pairs[0].answer = "regenerated answer"
+        record.save(cep_path)
+        second = run_build_sample_batch("run9", seed=1, base_dir=tmp_path, per_cell=2)
+
+        assert first.pool_sha256 != second.pool_sha256
 
     def test_manifest_roundtrips(self, tmp_path: Path) -> None:
-        _write_source(tmp_path, "run7", "s1", _frame_specs(2))
-        run_build_sample_batch("run7", seed=3, base_dir=tmp_path, per_cell=2)
-        manifest = SampleManifest.load(
-            tmp_path / "run7" / "human_eval" / "outputs" / "sample_manifest.json"
-        )
-        assert manifest.seed == 3
-        assert sum(manifest.cell_counts.values()) == 16
+        _write_source(tmp_path, "run10", "s1", _frame_specs(2))
+        manifest = run_build_sample_batch("run10", seed=1, base_dir=tmp_path, per_cell=2)
+        path = tmp_path / "run10" / "human_eval" / "outputs" / "sample_manifest.json"
+        assert SampleManifest.load(path) == manifest

--- a/tests/shared/human_eval/test_sampling.py
+++ b/tests/shared/human_eval/test_sampling.py
@@ -124,14 +124,36 @@ class TestBuildSample:
     def test_insufficient_cell_message_names_the_counts(self) -> None:
         pool = [e for e in _pool(10) if e.bloom_level != "evaluate"]
         pool += [_entry(900 + k, "evaluate") for k in range(4)]
-        with pytest.raises(InsufficientCellError) as excinfo:
+        with pytest.raises(InsufficientCellError, match=r"only 4 .*but 5 are required"):
             build_sample(pool, seed=1, per_cell=5)
-        message = str(excinfo.value)
-        assert "4" in message
-        assert "5" in message
 
     def test_the_sample_item_carries_no_emic_score(self) -> None:
         """The regression that keeps the emic judge off the critical path."""
         sample = build_sample(_pool(5), seed=1, per_cell=5)
         assert "emic_score" not in sample[0].model_dump()
         assert "cell_id" not in sample[0].model_dump()
+
+    def test_selection_is_pinned_to_the_published_mechanism(self) -> None:
+        """Golden vector over the exact draw, not just its shape.
+
+        The manifest records a seed and promises the sample is reproducible from
+        it. Same-seed-twice cannot detect a changed mechanism: a different digest
+        or a reordered sort key is still deterministic and still seed-dependent,
+        so every other test here survives swapping one in, while the study would
+        silently report on a different 120 pairs. This vector is the tripwire.
+
+        Regenerate these ids only as a deliberate decision, never to make a red
+        test green: a change here means the published sample changed.
+        """
+        pool = _pool(4)
+        sample = build_sample(pool, seed=2026, per_cell=2)
+        assert [(i.pair_id, i.bloom_level, i.slot_id) for i in sample] == [
+            ("src:0", "remember", 0),
+            ("src:1", "remember", 1),
+            ("src:7", "understand", 0),
+            ("src:5", "understand", 1),
+            ("src:10", "analyze", 0),
+            ("src:11", "analyze", 1),
+            ("src:14", "evaluate", 0),
+            ("src:15", "evaluate", 1),
+        ]

--- a/tests/shared/human_eval/test_sampling.py
+++ b/tests/shared/human_eval/test_sampling.py
@@ -1,23 +1,21 @@
-"""Tests for the pure stratified sampler (spec §5)."""
+"""Tests for the pure Bloom-stratified sampler (spec §5, revised 2026-08-19)."""
 
 from __future__ import annotations
 
 import pytest
 
 from arandu.shared.human_eval.sampling import (
-    BANDS,
     FRAME_BLOOM_LEVELS,
+    PER_CELL,
     InsufficientCellError,
     PoolEntry,
-    band_for,
+    all_cell_ids,
     build_sample,
+    population_by_cell,
 )
 
-DUBIOUS_SCORE = 2
-CLEAN_SCORE = 5
 
-
-def _entry(idx: int, bloom: str, score: int) -> PoolEntry:
+def _entry(idx: int, bloom: str) -> PoolEntry:
     return PoolEntry(
         pair_id=f"src:{idx}",
         source_file_id="src",
@@ -26,116 +24,114 @@ def _entry(idx: int, bloom: str, score: int) -> PoolEntry:
         question=f"q {idx}",
         answer=f"a {idx}",
         bloom_level=bloom,
-        emic_score=score,
     )
 
 
-def _pool(per_cell_available: int) -> list[PoolEntry]:
-    """Build a pool with ``per_cell_available`` entries in each of the 8 cells."""
+def _pool(per_bloom: int) -> list[PoolEntry]:
+    """Build a pool with ``per_bloom`` entries in each of the 4 Bloom cells."""
     pool: list[PoolEntry] = []
     idx = 0
     for bloom in FRAME_BLOOM_LEVELS:
-        for score in (DUBIOUS_SCORE, CLEAN_SCORE):
-            for _ in range(per_cell_available):
-                pool.append(_entry(idx, bloom, score))
-                idx += 1
+        for _ in range(per_bloom):
+            pool.append(_entry(idx, bloom))
+            idx += 1
     return pool
 
 
-class TestBandFor:
-    @pytest.mark.parametrize(
-        ("score", "band"),
-        [(1, "duvidosa"), (3, "duvidosa"), (4, "limpa"), (5, "limpa")],
-    )
-    def test_boundary(self, score: int, band: str) -> None:
-        assert band_for(score) == band
+class TestCells:
+    def test_there_are_exactly_four_cells_and_they_are_the_bloom_levels(self) -> None:
+        assert all_cell_ids() == list(FRAME_BLOOM_LEVELS)
+        assert len(all_cell_ids()) == 4
+
+    def test_default_per_cell_yields_the_agreed_120(self) -> None:
+        """120 is the load the three annotators accepted; the default must produce it."""
+        assert PER_CELL * len(FRAME_BLOOM_LEVELS) == 120
+
+    def test_population_is_counted_per_bloom_and_zero_filled(self) -> None:
+        pool = [_entry(0, "remember"), _entry(1, "remember"), _entry(2, "analyze")]
+        assert population_by_cell(pool) == {
+            "remember": 2,
+            "understand": 0,
+            "analyze": 1,
+            "evaluate": 0,
+        }
 
 
 class TestBuildSample:
-    def test_stratification_exact_ten_per_cell(self) -> None:
-        sample = build_sample(_pool(15), seed=42)
-        assert len(sample) == 80  # 8 cells x 10
+    def test_stratification_is_balanced_across_the_four_cells(self) -> None:
+        sample = build_sample(_pool(40), seed=42, per_cell=30)
+        assert len(sample) == 120
         counts: dict[str, int] = {}
         for item in sample:
-            counts[item.cell_id] = counts.get(item.cell_id, 0) + 1
-        assert len(counts) == 8
-        assert all(c == 10 for c in counts.values())
-        # 50/50 band balance regardless of (here equal) population
-        duvidosa = sum(1 for i in sample if i.cell_id.endswith("duvidosa"))
-        limpa = sum(1 for i in sample if i.cell_id.endswith("limpa"))
-        assert duvidosa == 40
-        assert limpa == 40
+            counts[item.bloom_level] = counts.get(item.bloom_level, 0) + 1
+        assert counts == dict.fromkeys(FRAME_BLOOM_LEVELS, 30)
 
-    def test_slot_ids_zero_to_nine_per_cell(self) -> None:
-        sample = build_sample(_pool(15), seed=7)
+    def test_slot_ids_cover_the_range_once_per_cell(self) -> None:
+        sample = build_sample(_pool(10), seed=7, per_cell=5)
         by_cell: dict[str, list[int]] = {}
         for item in sample:
-            by_cell.setdefault(item.cell_id, []).append(item.slot_id)
+            by_cell.setdefault(item.bloom_level, []).append(item.slot_id)
+        assert len(by_cell) == 4
         for slots in by_cell.values():
-            assert sorted(slots) == list(range(10))
+            assert sorted(slots) == list(range(5))
 
-    def test_oversamples_dubious_against_skewed_population(self) -> None:
-        # Population skewed 20 limpa / 11 duvidosa per bloom, yet the sample is 50/50.
-        pool: list[PoolEntry] = []
-        idx = 0
-        for bloom in FRAME_BLOOM_LEVELS:
-            for _ in range(11):
-                pool.append(_entry(idx, bloom, DUBIOUS_SCORE))
-                idx += 1
-            for _ in range(20):
-                pool.append(_entry(idx, bloom, CLEAN_SCORE))
-                idx += 1
-        sample = build_sample(pool, seed=1)
-        assert sum(1 for i in sample if i.cell_id.endswith("duvidosa")) == 40
-        assert sum(1 for i in sample if i.cell_id.endswith("limpa")) == 40
+    def test_sample_mirrors_the_population_within_a_cell(self) -> None:
+        """No band means no oversampling: a cell is drawn from its own pool only."""
+        pool = _pool(8)
+        sample = build_sample(pool, seed=3, per_cell=8)
+        assert len(sample) == 32
+        assert {i.pair_id for i in sample} == {e.pair_id for e in pool}
 
     def test_reproducible_same_seed_same_pool(self) -> None:
-        pool = _pool(15)
-        a = build_sample(pool, seed=99)
-        b = build_sample(pool, seed=99)
-        assert [(i.pair_id, i.cell_id, i.slot_id) for i in a] == [
-            (i.pair_id, i.cell_id, i.slot_id) for i in b
+        pool = _pool(10)
+        a = build_sample(pool, seed=99, per_cell=5)
+        b = build_sample(pool, seed=99, per_cell=5)
+        assert [(i.pair_id, i.bloom_level, i.slot_id) for i in a] == [
+            (i.pair_id, i.bloom_level, i.slot_id) for i in b
         ]
 
     def test_order_independent_reproducibility(self) -> None:
-        pool = _pool(15)
-        shuffled = list(reversed(pool))
-        a = build_sample(pool, seed=5)
-        b = build_sample(shuffled, seed=5)
-        # Selection is sorted by pair_id first, so input order cannot change it.
+        pool = _pool(10)
+        a = build_sample(pool, seed=5, per_cell=5)
+        b = build_sample(list(reversed(pool)), seed=5, per_cell=5)
         assert {i.pair_id for i in a} == {i.pair_id for i in b}
 
     def test_different_seed_selects_different_pairs(self) -> None:
-        pool = _pool(30)  # plenty of slack so two seeds almost surely differ
-        a = {i.pair_id for i in build_sample(pool, seed=1)}
-        b = {i.pair_id for i in build_sample(pool, seed=2)}
+        pool = _pool(30)
+        a = {i.pair_id for i in build_sample(pool, seed=1, per_cell=5)}
+        b = {i.pair_id for i in build_sample(pool, seed=2, per_cell=5)}
         assert a != b
 
-    def test_insufficient_cell_raises_named_error(self) -> None:
-        pool = _pool(15)
-        # Drop one cell (analyze:limpa) down to 9 available.
-        pool = [
-            p
-            for p in pool
-            if not (p.bloom_level == "analyze" and band_for(p.emic_score) == "limpa")
-        ]
-        pool += [_entry(900 + k, "analyze", CLEAN_SCORE) for k in range(9)]
-        with pytest.raises(InsufficientCellError, match="analyze:limpa"):
-            build_sample(pool, seed=1)
-
-    def test_bands_constant_is_two(self) -> None:
-        assert BANDS == ("duvidosa", "limpa")
-
     def test_cell_selection_independent_of_other_cells(self) -> None:
-        # Per-cell deterministic selection: changing one cell's population must
-        # not perturb the selection of an unrelated cell (guards against the
-        # shared-RNG cross-cell coupling).
-        base = _pool(15)
-        extra = [_entry(1000 + k, "remember", DUBIOUS_SCORE) for k in range(20)]
-        a = {i.pair_id for i in build_sample(base, seed=3) if i.cell_id == "evaluate:limpa"}
+        base = _pool(10)
+        extra = [_entry(1000 + k, "remember") for k in range(20)]
+        a = {
+            i.pair_id for i in build_sample(base, seed=3, per_cell=5) if i.bloom_level == "evaluate"
+        }
         b = {
             i.pair_id
-            for i in build_sample([*base, *extra], seed=3)
-            if i.cell_id == "evaluate:limpa"
+            for i in build_sample([*base, *extra], seed=3, per_cell=5)
+            if i.bloom_level == "evaluate"
         }
         assert a == b
+
+    def test_insufficient_cell_raises_naming_the_bloom_level(self) -> None:
+        pool = [e for e in _pool(10) if e.bloom_level != "analyze"]
+        pool += [_entry(900 + k, "analyze") for k in range(4)]
+        with pytest.raises(InsufficientCellError, match="analyze"):
+            build_sample(pool, seed=1, per_cell=5)
+
+    def test_insufficient_cell_message_names_the_counts(self) -> None:
+        pool = [e for e in _pool(10) if e.bloom_level != "evaluate"]
+        pool += [_entry(900 + k, "evaluate") for k in range(4)]
+        with pytest.raises(InsufficientCellError) as excinfo:
+            build_sample(pool, seed=1, per_cell=5)
+        message = str(excinfo.value)
+        assert "4" in message
+        assert "5" in message
+
+    def test_the_sample_item_carries_no_emic_score(self) -> None:
+        """The regression that keeps the emic judge off the critical path."""
+        sample = build_sample(_pool(5), seed=1, per_cell=5)
+        assert "emic_score" not in sample[0].model_dump()
+        assert "cell_id" not in sample[0].model_dump()


### PR DESCRIPTION
Reverte o desenho amostral fechado em 2026-08-07 (estratificação primária por
banda êmica x secundária por Bloom) e adota a alternativa A que aquela decisão
havia descartado: **estratificação só por nível de Bloom**, 4 células x 30 = 120
pares, com a amostra montada **só dos registros do CEP**.

## Por que agora

A banda vinha do `emic_score`, então o run do juiz êmico ficava no caminho
crítico da anotação: sem os scores não havia amostra, e sem amostra o
instrumento (#158) não tinha o que processar. O run foi submetido ao pcad em
2026-08-17 e ficou na fila, materializando o risco de cronograma que em 07/08
ainda era hipotético. Tirar o juiz do caminho crítico era exatamente o benefício
que a alternativa A comprava.

O juiz **continua necessário e continua rodando**. Ele deixa de alimentar a
amostra e passa a ser lido na análise, juntando por `pair_id`. Anotação e run
correm em paralelo.

## Custo aceito

A amostra passa a **espelhar a população**. Como o frame é o corpus aprovado
pelo `judge-qa`, a população pende para o que seria a banda `limpa`, então a
amostra fica dominada por casos fáceis e a concordância alta é em parte artefato
do desenho. A ponta baixa da escala (1-2) fica com poucas observações, e é onde o
coeficiente é mais sensível. Isso está declarado na docstring do `build_sample`,
na referência de CLI, e precisa entrar na seção de limitações do texto.

Em troca, o desenho amostral deixa de estar acoplado ao instrumento sob teste:
trocar modelo ou prompt do juiz não o invalida mais.

## O que muda

- `sampling.py`: saem `BANDS`, `DUBIOUS_MAX_SCORE`, `band_for` e `cell_id_for`.
  A célula de um par **é** o seu `bloom_level`. `PER_CELL` passa de 10 para 30.
  O mecanismo determinístico de seleção (`SHA-256("{seed}:{pair_id}")`, primeiros
  `per_cell`) não muda.
- `batch.py`: o pool é montado varrendo `cep/outputs/*_cep_qa.json`. O estágio
  `emic_judge` não é lido. O frame continua sendo o corpus aprovado, lido do
  veredicto do próprio registro, que é a cópia autoritativa.
- `--per-cell` exposto no CLI (mínimo 1, default `PER_CELL`), absorvendo o
  trabalho do branch `feature/human-eval-sample-per-cell`, que foi escrito para
  8 células e pode ser fechado sem PR.

## BREAKING CHANGE

- `SampleItem` perde `emic_score` e `cell_id`. O `emic_score` é o campo que
  reintroduziria a dependência pela porta dos fundos; `cell_id` seria idêntico a
  `bloom_level`.
- `SampleManifest` perde `excluded_none_score`. `cell_counts` e
  `population_by_cell` passam a ser chaveados pelos níveis de Bloom em vez de
  `"{bloom}:{banda}"`.
- `excluded_not_approved` **não é comparável** entre os dois desenhos: antes
  contava pares pontuados, agora conta todo par não aprovado do corpus.
  `pool_sha256` também não atravessa, porque o modelo do pool mudou.

Nenhum `sample.jsonl` foi construído para o `thesis-run-01`, que é o motivo pelo
qual a quebra é aceitável agora.

## Verificação

- Suíte completa: **1944 passed** (1936 na main + 8 novos).
- Revisão em três camadas: uma por task, uma re-revisão por fix round, e uma
  revisão da branch inteira. 0 Critical, 3 Important e 7 Minor, todos
  endereçados.
- A revisão final provou por mutação que a garantia de determinismo não estava
  testada: trocar o digest de `_selection_key` deixava a suíte inteira verde.
  Foram adicionados golden vectors para o sorteio e para a ordem de apresentação
  do instrumento, ambos verificados como armadilhas reais.
- Os dois únicos achados Important de conteúdo vinham do plano, não da
  implementação: um assert que não detectava a remoção do que testava, e prosa
  de documentação menos precisa que a que substituiu.

## Antes de sortear a amostra real

Na máquina que tem o `thesis-run-01`, medir a população por célula: 30 por célula
sobre 4 células é conferível direto do CEP, antes de qualquer anotador. Se algum
nível de Bloom tiver menos de 30 pares aprovados, o build recusa nomeando a
célula, e reduzir `--per-cell` ou aceitar desbalanceamento é decisão do autor.

Confirmar também que não existe `sample.jsonl` de outro run com o desenho antigo:
os modelos não definem `extra`, então um artefato antigo valida em silêncio.

## Follow-up fora deste repo

O capítulo de metodologia em `FredDsR/dissertacao-tex` afirma estratificação por
banda e precisa ser corrigido antes da entrega. Registrado na task de decisão do
cortex.
