### PR TITLE
feat(emic): add descriptive analysis of the emic-judge scores

### DIFF
--- a/scripts/analyze_emic_scores.py
+++ b/scripts/analyze_emic_scores.py
@@ -1,0 +1,462 @@
+"""Descriptive analysis of the emic-validity judge's scores (read-only).
+
+Aggregates ``results/<id>/emic_judge/outputs/*.json`` into the tables the
+results chapter needs: the ordinal distribution over the whole corpus, the same
+distribution split by Bloom level, by ``judge-qa`` verdict and by source
+interview, plus a run-health block. This is the automatic measurement only; the
+human-annotation agreement (Krippendorff alpha, weighted Cohen kappa, AC2) is
+the separate ``emic-analysis`` work and is deliberately absent here.
+
+Pairs whose LLM call errored carry ``emic_score=None``. They are counted under
+run health and excluded from every mean, median and percentage, so a dead
+sidecar reads as a failure rather than as low emic validity.
+
+Run from the repo root:
+
+    uv run python -m scripts.analyze_emic_scores --id thesis-run-01
+    uv run python -m scripts.analyze_emic_scores --id thesis-run-01 --out emic.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, get_args
+
+from pydantic import ValidationError
+
+from arandu.shared.emic.schemas import EmicSourceScores
+from arandu.shared.schemas import BloomLevel
+from arandu.utils.console import console
+from arandu.utils.logger import print_error, print_success
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from arandu.shared.emic.schemas import EmicScore
+
+ANCHORS: tuple[int, ...] = (1, 2, 3, 4, 5)
+"""The ordinal emic-validity labels, in ruler order."""
+
+CANONICAL_BLOOM_ORDER: tuple[str, ...] = get_args(BloomLevel)
+STAGE = "emic_judge"
+UNKNOWN_SCOPE = "unknown"
+VERDICT_LABELS: dict[str, str] = {
+    "approved": "approved",
+    "rejected": "rejected",
+    "unjudged": "unjudged",
+}
+
+
+@dataclass(frozen=True)
+class Distribution:
+    """Summary of one set of ordinal scores.
+
+    Attributes:
+        n: Number of pairs carrying an ordinal score.
+        counts: Pairs per anchor, always keyed by every anchor in ``1..5``.
+        mean: Arithmetic mean, or ``None`` when ``n`` is 0.
+        median: Median, or ``None`` when ``n`` is 0.
+        p25: First quartile, or ``None`` when ``n`` is 0.
+        p75: Third quartile, or ``None`` when ``n`` is 0.
+        pct_ge_4: Share of scores at 4 or 5, or ``None`` when ``n`` is 0.
+    """
+
+    n: int
+    counts: dict[int, int]
+    mean: float | None
+    median: float | None
+    p25: float | None
+    p75: float | None
+    pct_ge_4: float | None
+
+
+@dataclass(frozen=True)
+class Health:
+    """Coverage and failure counters for the run being analysed.
+
+    Attributes:
+        scope: The run's scope (``all``, ``approved`` or ``unknown``).
+        sources_read: Output files parsed.
+        sources_unreadable: Output files that failed to parse.
+        pairs_total: Pairs found across the parsed files.
+        pairs_scored: Pairs carrying an ordinal score.
+        pairs_failed: Pairs whose LLM call errored.
+    """
+
+    scope: str
+    sources_read: int
+    sources_unreadable: int
+    pairs_total: int
+    pairs_scored: int
+    pairs_failed: int
+
+
+@dataclass(frozen=True)
+class SourceRow:
+    """One source interview's distribution.
+
+    Attributes:
+        file_id: Source interview id.
+        filename: Original media filename.
+        dist: The source's score distribution.
+    """
+
+    file_id: str
+    filename: str
+    dist: Distribution
+
+
+@dataclass(frozen=True)
+class EmicAnalysis:
+    """Everything the report renders.
+
+    Attributes:
+        health: Coverage and failure counters.
+        overall: Distribution over every scored pair.
+        by_bloom: Distribution per Bloom level, in canonical ladder order.
+        by_verdict: Distribution per ``judge-qa`` verdict bucket.
+        by_source: Per-source distributions, worst mean first.
+    """
+
+    health: Health
+    overall: Distribution
+    by_bloom: dict[str, Distribution]
+    by_verdict: dict[str, Distribution]
+    by_source: list[SourceRow]
+
+
+def distribution(values: Iterable[int]) -> Distribution:
+    """Summarise a set of ordinal scores.
+
+    Args:
+        values: Ordinal scores in ``1..5``. Errored pairs must be filtered out
+            by the caller; this function has no notion of a missing score.
+
+    Returns:
+        The :class:`Distribution`. An empty input yields zero counts and no
+        central tendency rather than a zero mean.
+    """
+    data = sorted(values)
+    counts = dict.fromkeys(ANCHORS, 0)
+    for value in data:
+        counts[value] = counts.get(value, 0) + 1
+    if not data:
+        return Distribution(0, counts, None, None, None, None, None)
+    if len(data) == 1:
+        only = float(data[0])
+        return Distribution(1, counts, only, only, only, only, float(data[0] >= 4))
+    p25, _, p75 = statistics.quantiles(data, n=4, method="inclusive")
+    return Distribution(
+        n=len(data),
+        counts=counts,
+        mean=statistics.fmean(data),
+        median=statistics.median(data),
+        p25=p25,
+        p75=p75,
+        pct_ge_4=sum(1 for value in data if value >= 4) / len(data),
+    )
+
+
+def _verdict_bucket(score: EmicScore) -> str:
+    """Map a pair's ``judge-qa`` verdict to its cross-tab row."""
+    if score.is_valid is None:
+        return "unjudged"
+    return "approved" if score.is_valid else "rejected"
+
+
+def _bloom_sort_key(level: str) -> tuple[int, str]:
+    """Order Bloom levels by the canonical ladder, unknown levels last."""
+    if level in CANONICAL_BLOOM_ORDER:
+        return (CANONICAL_BLOOM_ORDER.index(level), "")
+    return (len(CANONICAL_BLOOM_ORDER), level)
+
+
+def build_analysis(sources: list[EmicSourceScores], unreadable: int, scope: str) -> EmicAnalysis:
+    """Aggregate per-source scores into every table of the report.
+
+    Args:
+        sources: Parsed per-source score files.
+        unreadable: Output files that failed to parse, for the health block.
+        scope: The run's scope, as resolved by :func:`resolve_scope`.
+
+    Returns:
+        The assembled :class:`EmicAnalysis`.
+    """
+    scored: list[int] = []
+    failed = 0
+    total = 0
+    bloom_values: dict[str, list[int]] = {}
+    verdict_values: dict[str, list[int]] = {bucket: [] for bucket in VERDICT_LABELS}
+    rows: list[SourceRow] = []
+
+    for source in sources:
+        source_values: list[int] = []
+        for score in source.scores:
+            total += 1
+            # Register the level even for an errored pair: a Bloom level whose
+            # every pair failed must show up as n=0, not vanish from the table.
+            level_values = bloom_values.setdefault(score.bloom_level, [])
+            if score.emic_score is None:
+                failed += 1
+                continue
+            scored.append(score.emic_score)
+            source_values.append(score.emic_score)
+            level_values.append(score.emic_score)
+            verdict_values[_verdict_bucket(score)].append(score.emic_score)
+        rows.append(
+            SourceRow(
+                file_id=source.source_file_id,
+                filename=source.source_filename,
+                dist=distribution(source_values),
+            )
+        )
+
+    # A source whose every pair errored has no mean; sort it last rather than
+    # letting it masquerade as the worst-scoring interview.
+    rows.sort(key=lambda row: (row.dist.mean is None, row.dist.mean or 0.0, row.filename))
+
+    return EmicAnalysis(
+        health=Health(
+            scope=scope,
+            sources_read=len(sources),
+            sources_unreadable=unreadable,
+            pairs_total=total,
+            pairs_scored=len(scored),
+            pairs_failed=failed,
+        ),
+        overall=distribution(scored),
+        by_bloom={
+            level: distribution(bloom_values[level])
+            for level in sorted(bloom_values, key=_bloom_sort_key)
+        },
+        by_verdict={bucket: distribution(values) for bucket, values in verdict_values.items()},
+        by_source=rows,
+    )
+
+
+def load_source_scores(outputs_dir: Path) -> tuple[list[EmicSourceScores], int]:
+    """Read every per-source score file under ``outputs_dir``.
+
+    Args:
+        outputs_dir: ``results/<id>/emic_judge/outputs``.
+
+    Returns:
+        The parsed files (sorted by path) and the number that failed to parse.
+
+    Raises:
+        FileNotFoundError: If the directory does not exist.
+    """
+    if not outputs_dir.is_dir():
+        raise FileNotFoundError(
+            f"No emic-judge outputs at {outputs_dir}. Run `arandu emic-judge --id <id>` first."
+        )
+    sources: list[EmicSourceScores] = []
+    unreadable = 0
+    for path in sorted(outputs_dir.glob("*.json")):
+        try:
+            sources.append(EmicSourceScores.load(path))
+        except (OSError, ValidationError):
+            unreadable += 1
+    return sources, unreadable
+
+
+def resolve_scope(run_dir: Path, sources: list[EmicSourceScores]) -> str:
+    """Determine which pairs the run was allowed to score.
+
+    Prefers the ``run_metadata.json`` snapshot, which is written once per run.
+    Falls back to the ``scope`` persisted on the outputs themselves, and only
+    accepts it when every file agrees: files written before the field existed
+    carry ``None``, and mixing them with a later run's outputs makes the scope
+    unknowable.
+
+    Args:
+        run_dir: ``results/<id>/emic_judge``.
+        sources: The parsed per-source score files.
+
+    Returns:
+        ``"all"``, ``"approved"`` or ``"unknown"``.
+    """
+    metadata_path = run_dir / "run_metadata.json"
+    try:
+        metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+        scope = metadata["config"]["config_values"]["scope"]
+    except (OSError, ValueError, KeyError, TypeError):
+        scope = None
+    if scope in ("all", "approved"):
+        return str(scope)
+    scopes = {source.scope for source in sources}
+    if len(scopes) == 1 and (only := scopes.pop()) is not None:
+        return only
+    return UNKNOWN_SCOPE
+
+
+def _pct(value: float | None) -> str:
+    return "n/a" if value is None else f"{value * 100:.1f}%"
+
+
+def _num(value: float | None) -> str:
+    return "n/a" if value is None else f"{value:.2f}"
+
+
+def _iqr(dist: Distribution) -> str:
+    if dist.p25 is None or dist.p75 is None:
+        return "n/a"
+    return f"{dist.p25:.1f}-{dist.p75:.1f}"
+
+
+def _share(count: int, total: int) -> str:
+    return "n/a" if total == 0 else f"{count / total * 100:.1f}%"
+
+
+def _health_table(health: Health) -> list[str]:
+    return [
+        "## Run health",
+        "",
+        "| Metric | Value |",
+        "|--------|-------|",
+        f"| Scope | {health.scope} |",
+        f"| Sources read | {health.sources_read} |",
+        f"| Sources unreadable | {health.sources_unreadable} |",
+        f"| Pairs found | {health.pairs_total} |",
+        f"| Pairs scored | {health.pairs_scored} |",
+        f"| Pairs failed (LLM error) | {health.pairs_failed} "
+        f"({_share(health.pairs_failed, health.pairs_total)}) |",
+        "",
+    ]
+
+
+def _overall_table(dist: Distribution) -> list[str]:
+    lines = [
+        "## Score distribution",
+        "",
+        "| Score | n | % |",
+        "|-------|---|---|",
+    ]
+    lines += [
+        f"| {anchor} | {dist.counts[anchor]} | {_share(dist.counts[anchor], dist.n)} |"
+        for anchor in ANCHORS
+    ]
+    lines += [
+        f"| **total** | **{dist.n}** | |",
+        "",
+        f"mean {_num(dist.mean)} | median {_num(dist.median)} | IQR {_iqr(dist)} "
+        f"| >=4 {_pct(dist.pct_ge_4)}",
+        "",
+    ]
+    return lines
+
+
+def _breakdown_table(title: str, label: str, rows: list[tuple[str, Distribution]]) -> list[str]:
+    anchors_header = " | ".join(str(anchor) for anchor in ANCHORS)
+    lines = [
+        title,
+        "",
+        f"| {label} | n | mean | median | IQR | >=4 | {anchors_header} |",
+        f"|{'---|' * (6 + len(ANCHORS))}",
+    ]
+    for name, dist in rows:
+        counts = " | ".join(str(dist.counts[anchor]) for anchor in ANCHORS)
+        lines.append(
+            f"| {name} | {dist.n} | {_num(dist.mean)} | {_num(dist.median)} | {_iqr(dist)} "
+            f"| {_pct(dist.pct_ge_4)} | {counts} |"
+        )
+    lines.append("")
+    return lines
+
+
+def _verdict_rows(analysis: EmicAnalysis) -> list[tuple[str, Distribution]]:
+    """Pick the cross-tab rows the run's scope can actually support."""
+    if analysis.health.scope == "approved":
+        return [(VERDICT_LABELS["approved"], analysis.by_verdict["approved"])]
+    return [(label, analysis.by_verdict[bucket]) for bucket, label in VERDICT_LABELS.items()]
+
+
+def _source_table(rows: list[SourceRow]) -> list[str]:
+    lines = [
+        "## By source",
+        "",
+        "| Source | n | mean | median | IQR | >=4 |",
+        "|--------|---|------|--------|-----|-----|",
+    ]
+    lines += [
+        f"| {row.filename} | {row.dist.n} | {_num(row.dist.mean)} | {_num(row.dist.median)} "
+        f"| {_iqr(row.dist)} | {_pct(row.dist.pct_ge_4)} |"
+        for row in rows
+    ]
+    lines.append("")
+    return lines
+
+
+def render_markdown(analysis: EmicAnalysis, pipeline_id: str) -> str:
+    """Render every table as Markdown.
+
+    Args:
+        analysis: The aggregated analysis.
+        pipeline_id: Run identifier, for the heading.
+
+    Returns:
+        The Markdown document, also used verbatim as the console output.
+    """
+    lines = [
+        f"# Emic-validity scores - {pipeline_id}",
+        "",
+        "Automatic judge only; no human-agreement coefficients. Pairs whose LLM call "
+        "errored are counted under run health and excluded from every statistic below.",
+        "",
+    ]
+    lines += _health_table(analysis.health)
+    lines += _overall_table(analysis.overall)
+    lines += _breakdown_table("## By Bloom level", "Bloom level", list(analysis.by_bloom.items()))
+    lines += _breakdown_table(
+        "## Emic score x judge-qa verdict", "Verdict", _verdict_rows(analysis)
+    )
+    if analysis.health.scope == "approved":
+        lines += [
+            "Scope is `approved`: pairs the judge-qa step rejected or never judged were "
+            "never scored, so they are omitted here rather than reported as zero.",
+            "",
+        ]
+    elif analysis.health.scope == UNKNOWN_SCOPE:
+        lines += [
+            "Scope is unknown (no `run_metadata.json` and the outputs disagree), so the "
+            "verdict rows may be empty because those pairs were out of scope rather than "
+            "absent from the corpus.",
+            "",
+        ]
+    lines += _source_table(analysis.by_source)
+    return "\n".join(lines)
+
+
+def main() -> None:
+    """Parse arguments, aggregate the run and emit the tables."""
+    parser = argparse.ArgumentParser(
+        description="Descriptive analysis of the emic-validity judge's scores."
+    )
+    parser.add_argument("--id", required=True, help="Pipeline run id (e.g. thesis-run-01).")
+    parser.add_argument("--results-root", default="results", help="Results root dir.")
+    parser.add_argument("--out", default=None, help="Optional path to write the Markdown to.")
+    args = parser.parse_args()
+
+    run_dir = Path(args.results_root) / args.id / STAGE
+    try:
+        sources, unreadable = load_source_scores(run_dir / "outputs")
+    except FileNotFoundError as exc:
+        print_error(str(exc))
+        raise SystemExit(1) from exc
+
+    analysis = build_analysis(sources, unreadable, resolve_scope(run_dir, sources))
+    rendered = render_markdown(analysis, args.id)
+    # soft_wrap: Rich word-wrap would fold wide table rows and corrupt the Markdown.
+    console.print(rendered, markup=False, highlight=False, soft_wrap=True)
+    if args.out:
+        out_path = Path(args.out)
+        out_path.write_text(rendered + "\n", encoding="utf-8")
+        print_success(f"Wrote {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/analyze_emic_scores.py
+++ b/scripts/analyze_emic_scores.py
@@ -2,10 +2,11 @@
 
 Aggregates ``results/<id>/emic_judge/outputs/*.json`` into the tables the
 results chapter needs: the ordinal distribution over the whole corpus, the same
-distribution split by Bloom level, by ``judge-qa`` verdict and by source
-interview, plus a run-health block. This is the automatic measurement only; the
-human-annotation agreement (Krippendorff alpha, weighted Cohen kappa, AC2) is
-the separate ``emic-analysis`` work and is deliberately absent here.
+distribution split by Bloom level, by ``judge-qa`` verdict, by the two of them
+jointly and by source interview, plus a run-health block. This is the automatic
+measurement only; the human-annotation agreement (Krippendorff alpha, weighted
+Cohen kappa, AC2) is the separate ``emic-analysis`` work and is deliberately
+absent here.
 
 Pairs whose LLM call errored carry ``emic_score=None``. They are counted under
 run health and excluded from every mean, median and percentage, so a dead
@@ -119,6 +120,9 @@ class EmicAnalysis:
         overall: Distribution over every scored pair.
         by_bloom: Distribution per Bloom level, in canonical ladder order.
         by_verdict: Distribution per ``judge-qa`` verdict bucket.
+        by_bloom_verdict: Distribution per (Bloom level, verdict) cell, in
+            canonical ladder order then verdict order. Only cells the corpus
+            actually populates are present.
         by_source: Per-source distributions, worst mean first.
     """
 
@@ -126,6 +130,7 @@ class EmicAnalysis:
     overall: Distribution
     by_bloom: dict[str, Distribution]
     by_verdict: dict[str, Distribution]
+    by_bloom_verdict: dict[tuple[str, str], Distribution]
     by_source: list[SourceRow]
 
 
@@ -175,6 +180,12 @@ def _bloom_sort_key(level: str) -> tuple[int, str]:
     return (len(CANONICAL_BLOOM_ORDER), level)
 
 
+def _cell_sort_key(cell: tuple[str, str]) -> tuple[tuple[int, str], int]:
+    """Order cross-tab cells by Bloom ladder, then by verdict bucket order."""
+    level, bucket = cell
+    return (_bloom_sort_key(level), list(VERDICT_LABELS).index(bucket))
+
+
 def build_analysis(sources: list[EmicSourceScores], unreadable: int, scope: str) -> EmicAnalysis:
     """Aggregate per-source scores into every table of the report.
 
@@ -191,6 +202,7 @@ def build_analysis(sources: list[EmicSourceScores], unreadable: int, scope: str)
     total = 0
     bloom_values: dict[str, list[int]] = {}
     verdict_values: dict[str, list[int]] = {bucket: [] for bucket in VERDICT_LABELS}
+    cell_values: dict[tuple[str, str], list[int]] = {}
     rows: list[SourceRow] = []
 
     for source in sources:
@@ -200,13 +212,16 @@ def build_analysis(sources: list[EmicSourceScores], unreadable: int, scope: str)
             # Register the level even for an errored pair: a Bloom level whose
             # every pair failed must show up as n=0, not vanish from the table.
             level_values = bloom_values.setdefault(score.bloom_level, [])
+            bucket = _verdict_bucket(score)
+            cell = cell_values.setdefault((score.bloom_level, bucket), [])
             if score.emic_score is None:
                 failed += 1
                 continue
             scored.append(score.emic_score)
             source_values.append(score.emic_score)
             level_values.append(score.emic_score)
-            verdict_values[_verdict_bucket(score)].append(score.emic_score)
+            verdict_values[bucket].append(score.emic_score)
+            cell.append(score.emic_score)
         rows.append(
             SourceRow(
                 file_id=source.source_file_id,
@@ -234,6 +249,9 @@ def build_analysis(sources: list[EmicSourceScores], unreadable: int, scope: str)
             for level in sorted(bloom_values, key=_bloom_sort_key)
         },
         by_verdict={bucket: distribution(values) for bucket, values in verdict_values.items()},
+        by_bloom_verdict={
+            key: distribution(cell_values[key]) for key in sorted(cell_values, key=_cell_sort_key)
+        },
         by_source=rows,
     )
 
@@ -375,6 +393,16 @@ def _verdict_rows(analysis: EmicAnalysis) -> list[tuple[str, Distribution]]:
     return [(label, analysis.by_verdict[bucket]) for bucket, label in VERDICT_LABELS.items()]
 
 
+def _bloom_verdict_rows(analysis: EmicAnalysis) -> list[tuple[str, Distribution]]:
+    """Flatten the (Bloom level, verdict) cells into renderable rows."""
+    approved_only = analysis.health.scope == "approved"
+    return [
+        (f"{level} / {VERDICT_LABELS[bucket]}", dist)
+        for (level, bucket), dist in analysis.by_bloom_verdict.items()
+        if not approved_only or bucket == "approved"
+    ]
+
+
 def _source_table(rows: list[SourceRow]) -> list[str]:
     lines = [
         "## By source",
@@ -413,6 +441,11 @@ def render_markdown(analysis: EmicAnalysis, pipeline_id: str) -> str:
     lines += _breakdown_table("## By Bloom level", "Bloom level", list(analysis.by_bloom.items()))
     lines += _breakdown_table(
         "## Emic score x judge-qa verdict", "Verdict", _verdict_rows(analysis)
+    )
+    lines += _breakdown_table(
+        "## Emic score x judge-qa verdict, by Bloom level",
+        "Bloom level / verdict",
+        _bloom_verdict_rows(analysis),
     )
     if analysis.health.scope == "approved":
         lines += [

--- a/tests/scripts/test_analyze_emic_scores.py
+++ b/tests/scripts/test_analyze_emic_scores.py
@@ -130,6 +130,29 @@ class TestBuildAnalysis:
         assert by_verdict["rejected"].counts == {1: 0, 2: 1, 3: 0, 4: 0, 5: 0}
         assert by_verdict["unjudged"].counts == {1: 0, 2: 0, 3: 1, 4: 0, 5: 0}
 
+    def test_bloom_verdict_crosstab_keys_only_populated_combinations(
+        self, sources: list[EmicSourceScores]
+    ) -> None:
+        cells = build_analysis(sources, unreadable=0, scope="all").by_bloom_verdict
+
+        assert list(cells) == [
+            ("remember", "approved"),
+            ("remember", "unjudged"),
+            ("understand", "approved"),
+            ("apply", "rejected"),
+            ("analyze", "approved"),
+        ]
+        assert cells[("remember", "approved")].counts == {1: 1, 2: 0, 3: 0, 4: 0, 5: 1}
+        assert cells[("remember", "approved")].mean == pytest.approx(3.0)
+
+    def test_bloom_verdict_cell_whose_only_pair_errored_is_kept_empty(
+        self, sources: list[EmicSourceScores]
+    ) -> None:
+        cells = build_analysis(sources, unreadable=0, scope="all").by_bloom_verdict
+
+        assert cells[("analyze", "approved")].n == 0
+        assert cells[("analyze", "approved")].mean is None
+
     def test_sources_are_ordered_worst_mean_first(self, sources: list[EmicSourceScores]) -> None:
         rows = build_analysis(sources, unreadable=0, scope="all").by_source
 
@@ -188,6 +211,8 @@ class TestRenderMarkdown:
         assert "## Score distribution" in rendered
         assert "## By Bloom level" in rendered
         assert "## Emic score x judge-qa verdict" in rendered
+        assert "## Emic score x judge-qa verdict, by Bloom level" in rendered
+        assert "| remember / approved |" in rendered
         assert "## By source" in rendered
         assert "entrevista-b.m4a" in rendered
 
@@ -209,3 +234,5 @@ class TestRenderMarkdown:
 
         assert "never scored" in rendered
         assert "| rejected |" not in rendered
+        assert "| remember / approved |" in rendered
+        assert "/ rejected |" not in rendered

--- a/tests/scripts/test_analyze_emic_scores.py
+++ b/tests/scripts/test_analyze_emic_scores.py
@@ -1,0 +1,211 @@
+"""Tests for the emic-judge descriptive analysis script.
+
+Guards the load-bearing arithmetic (a pair whose LLM call errored must never
+enter a mean) and the two reporting decisions that would otherwise mislead the
+results chapter: an ``approved``-scope run must not report zero rejected pairs,
+and an unreadable output file must be counted rather than silently dropped.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from arandu.shared.emic.schemas import EmicScore, EmicSourceScores
+from scripts.analyze_emic_scores import (
+    build_analysis,
+    distribution,
+    load_source_scores,
+    render_markdown,
+    resolve_scope,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _score(
+    index: int,
+    value: int | None,
+    bloom: str = "remember",
+    is_valid: bool | None = True,
+) -> EmicScore:
+    return EmicScore(
+        pair_index=index,
+        bloom_level=bloom,
+        emic_score=value,
+        rationale="",
+        error=None if value is not None else "sidecar down",
+        is_valid=is_valid,
+    )
+
+
+@pytest.fixture
+def sources() -> list[EmicSourceScores]:
+    """Two sources: five scored pairs (1..5) plus one errored pair."""
+    return [
+        EmicSourceScores(
+            source_file_id="a",
+            source_filename="entrevista-a.m4a",
+            scope="all",
+            scores=[
+                _score(0, 5, "remember", True),
+                _score(1, 4, "understand", True),
+                _score(2, 2, "apply", False),
+                _score(3, None, "analyze", True),
+            ],
+        ),
+        EmicSourceScores(
+            source_file_id="b",
+            source_filename="entrevista-b.m4a",
+            scope="all",
+            scores=[
+                _score(0, 3, "remember", None),
+                _score(1, 1, "remember", True),
+            ],
+        ),
+    ]
+
+
+class TestDistribution:
+    def test_reports_counts_mean_median_and_iqr(self) -> None:
+        dist = distribution([1, 2, 3, 4, 5])
+
+        assert dist.n == 5
+        assert dist.counts == {1: 1, 2: 1, 3: 1, 4: 1, 5: 1}
+        assert dist.mean == pytest.approx(3.0)
+        assert dist.median == pytest.approx(3.0)
+        assert (dist.p25, dist.p75) == (pytest.approx(2.0), pytest.approx(4.0))
+        assert dist.pct_ge_4 == pytest.approx(0.4)
+
+    def test_single_value_has_a_degenerate_iqr(self) -> None:
+        dist = distribution([4])
+
+        assert (dist.n, dist.mean, dist.median) == (1, 4.0, 4.0)
+        assert (dist.p25, dist.p75) == (4.0, 4.0)
+
+    def test_empty_reports_no_central_tendency(self) -> None:
+        dist = distribution([])
+
+        assert dist.n == 0
+        assert dist.counts == {1: 0, 2: 0, 3: 0, 4: 0, 5: 0}
+        assert (dist.mean, dist.median, dist.p25, dist.p75, dist.pct_ge_4) == (
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+
+
+class TestBuildAnalysis:
+    def test_errored_pairs_are_counted_but_never_averaged(
+        self, sources: list[EmicSourceScores]
+    ) -> None:
+        analysis = build_analysis(sources, unreadable=0, scope="all")
+
+        assert analysis.health.pairs_total == 6
+        assert analysis.health.pairs_scored == 5
+        assert analysis.health.pairs_failed == 1
+        assert analysis.overall.n == 5
+        assert analysis.overall.mean == pytest.approx(3.0)
+
+    def test_bloom_breakdown_keeps_a_level_whose_only_pair_errored(
+        self, sources: list[EmicSourceScores]
+    ) -> None:
+        by_bloom = build_analysis(sources, unreadable=0, scope="all").by_bloom
+
+        assert by_bloom["remember"].n == 3
+        assert by_bloom["remember"].mean == pytest.approx(3.0)
+        assert by_bloom["analyze"].n == 0
+        assert by_bloom["analyze"].mean is None
+
+    def test_verdict_crosstab_splits_approved_rejected_and_unjudged(
+        self, sources: list[EmicSourceScores]
+    ) -> None:
+        by_verdict = build_analysis(sources, unreadable=0, scope="all").by_verdict
+
+        assert by_verdict["approved"].counts == {1: 1, 2: 0, 3: 0, 4: 1, 5: 1}
+        assert by_verdict["rejected"].counts == {1: 0, 2: 1, 3: 0, 4: 0, 5: 0}
+        assert by_verdict["unjudged"].counts == {1: 0, 2: 0, 3: 1, 4: 0, 5: 0}
+
+    def test_sources_are_ordered_worst_mean_first(self, sources: list[EmicSourceScores]) -> None:
+        rows = build_analysis(sources, unreadable=0, scope="all").by_source
+
+        assert [row.filename for row in rows] == ["entrevista-b.m4a", "entrevista-a.m4a"]
+        assert rows[0].dist.mean == pytest.approx(2.0)
+
+
+class TestLoadSourceScores:
+    def test_missing_outputs_directory_names_the_stage(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError, match="emic_judge"):
+            load_source_scores(tmp_path / "emic_judge" / "outputs")
+
+    def test_unreadable_file_is_skipped_and_counted(
+        self, tmp_path: Path, sources: list[EmicSourceScores]
+    ) -> None:
+        outputs = tmp_path / "emic_judge" / "outputs"
+        outputs.mkdir(parents=True)
+        sources[0].save(outputs / "a.json")
+        (outputs / "b.json").write_text("{ not json", encoding="utf-8")
+
+        loaded, unreadable = load_source_scores(outputs)
+
+        assert [s.source_file_id for s in loaded] == ["a"]
+        assert unreadable == 1
+
+
+class TestResolveScope:
+    def test_prefers_the_run_metadata_snapshot(
+        self, tmp_path: Path, sources: list[EmicSourceScores]
+    ) -> None:
+        (tmp_path / "run_metadata.json").write_text(
+            '{"config": {"config_values": {"scope": "approved"}}}', encoding="utf-8"
+        )
+
+        assert resolve_scope(tmp_path, sources) == "approved"
+
+    def test_falls_back_to_the_unanimous_scope_on_the_outputs(
+        self, tmp_path: Path, sources: list[EmicSourceScores]
+    ) -> None:
+        assert resolve_scope(tmp_path, sources) == "all"
+
+    def test_reports_unknown_when_the_outputs_disagree(
+        self, tmp_path: Path, sources: list[EmicSourceScores]
+    ) -> None:
+        sources[1].scope = None
+
+        assert resolve_scope(tmp_path, sources) == "unknown"
+
+
+class TestRenderMarkdown:
+    def test_renders_every_section(self, sources: list[EmicSourceScores]) -> None:
+        rendered = render_markdown(build_analysis(sources, unreadable=0, scope="all"), "run-01")
+
+        assert "# Emic-validity scores - run-01" in rendered
+        assert "## Run health" in rendered
+        assert "## Score distribution" in rendered
+        assert "## By Bloom level" in rendered
+        assert "## Emic score x judge-qa verdict" in rendered
+        assert "## By source" in rendered
+        assert "entrevista-b.m4a" in rendered
+
+    def test_approved_scope_says_unscored_instead_of_zero(
+        self, sources: list[EmicSourceScores]
+    ) -> None:
+        approved_only = [
+            EmicSourceScores(
+                source_file_id="a",
+                source_filename="entrevista-a.m4a",
+                scope="approved",
+                scores=[_score(0, 5), _score(1, 4)],
+            )
+        ]
+
+        rendered = render_markdown(
+            build_analysis(approved_only, unreadable=0, scope="approved"), "run-01"
+        )
+
+        assert "never scored" in rendered
+        assert "| rejected |" not in rendered


### PR DESCRIPTION
## Summary

- Adds `scripts/analyze_emic_scores.py`, a read-only aggregation of
  `results/<id>/emic_judge/outputs/*.json` into the tables the results chapter
  needs: run health, the ordinal distribution over the corpus, and that same
  distribution split by Bloom level, by `judge-qa` verdict, by the two of them
  jointly, and by source interview. Prints Markdown to the console; `--out`
  writes the same document to a file.
- Automatic measurement only. The human-agreement coefficients (Krippendorff
  alpha, weighted Cohen kappa, AC2) stay out: they belong to the deferred
  `emic-analysis` command, whose statistical core already lives in
  `arandu.shared.agreement`.
- A pair whose LLM call errored is counted under run health and excluded from
  every mean, so a dead sidecar reads as a failure rather than as low emic
  validity. A Bloom level whose every pair failed still shows up, at `n=0`.
- The joint `Bloom level / verdict` cross-tab answers what neither marginal
  can: whether the approval gate behaves the same way up the ladder. One row
  per populated cell, in ladder order; a cell with no pair at all is omitted,
  a cell whose every pair errored is kept at `n=0`.
- Under `scope="approved"` the verdict cross-tab drops the rejected and
  unjudged rows and states they were never scored, instead of reporting zeros
  that read as "no rejected pairs in the corpus". Same treatment when the scope
  cannot be resolved.

## Test plan

- [x] `uv run pytest tests/scripts/test_analyze_emic_scores.py` (16 tests, TDD:
      each one watched failing first)
- [x] `uv run pytest` full suite: 1960 passed
- [x] `uv run ruff check` and `uv run ruff format --check` clean
- [x] End-to-end smoke run over a synthetic run (3 sources, 72 pairs, 1
      corrupted output file): all six tables rendered, `--out` file written
- [x] Second smoke run under `scope="approved"`: the verdict tables collapse to
      the approved rows and carry the "never scored" note
- [ ] Reviewer: run it against a real `emic_judge` run and sanity-check the
      per-source ordering and the failure counts
